### PR TITLE
Adding start of a basic pure cpython module build with CMake.

### DIFF
--- a/tests/purecpython_test1/CMakeLists.txt
+++ b/tests/purecpython_test1/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required (VERSION 2.8.1 FATAL_ERROR)
+
+project(PyCMakePureCPythonTest)
+
+#
+# Use standard CMake package to find Python. This should be passed
+# from PyCMake.
+#
+find_package(PythonInterp REQUIRED)
+find_package(PythonLibs REQUIRED)
+
+
+add_library(test1 MODULE src/test1.c)
+
+include_directories(${PYTHON_INCLUDE_DIRS})
+target_link_libraries(test1 ${PYTHON_LIBRARIES})

--- a/tests/purecpython_test1/README.rst
+++ b/tests/purecpython_test1/README.rst
@@ -1,0 +1,4 @@
+This is a basic test for a pure CPython module name "test1".
+
+The test will include configuration, building, installation and
+testing of the test1 module.

--- a/tests/purecpython_test1/setup.py
+++ b/tests/purecpython_test1/setup.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+from __future__ import print_function
+from PyCMake import setup
+
+PKG = "test1"
+version = "test"
+
+
+
+setup(
+    name=PKG,
+    version=version,
+    description="The {0} package".format(PKG),
+    author='PyCMake team',
+    license="MIT",
+    zip_safe=False,
+    test_suite='tests',
+)

--- a/tests/purecpython_test1/src/test1.c
+++ b/tests/purecpython_test1/src/test1.c
@@ -1,0 +1,20 @@
+#include <Python.h>
+
+static PyObject *
+test123(PyObject *self, PyObject *args)
+{
+  const int value = 123;
+  return Py_BuildValue("i", value);
+}
+
+
+static PyMethodDef module_methods[] = {
+   { "test123", (PyCFunction)test123, METH_NOARGS, NULL },
+   { NULL }
+};
+
+
+void inittest1(void)
+{
+    Py_InitModule("test1", module_methods );
+}

--- a/tests/purecpython_test1/tests/test_test1.py
+++ b/tests/purecpython_test1/tests/test_test1.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+test_test123
+----------------------------------
+
+Test to verify the test1 packages for PyCMake's test1
+"""
+
+import unittest
+
+class TestTest1(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_import(self):
+        """Verify import of libtest1."""
+        import test1
+
+    def test_test123(self):
+        """Verify "test123" the method from the CPython extension."""
+        from test1 import test123
+        self.assertEqual(test123(), 123)
+        pass
+
+    def tearDown(self):
+        pass
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I have added a directory with a basic CPython module which can be build with CMake. There is still work to do to get it working with PyCMake.setup. Additionally, it's not currently being tested. It should provide a simple example to experiment with how things should be done.