### PR TITLE
collect functionality for manifest parsing from PR #16

### DIFF
--- a/pycmake/cmaker.py
+++ b/pycmake/cmaker.py
@@ -1,58 +1,111 @@
 import os
+import sys
 import platform
 import subprocess
+import argparse
 
 from pycmake import platform_specifics
 
 
+def pop_arg(arg, a, default=None):
+    """Pops an arg(ument) from an argument list a and returns the new list 
+    and the value of the argument if present and a default otherwise.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(arg)
+    ns, a = parser.parse_known_args(a)
+    ns = tuple(vars(ns).items())
+    if len(ns) > 0 and ns[0][1] is not None:
+        val = ns[0][1]
+    else:
+        val = default
+    return a, val
+
+
+def _remove_cwd_prefix(path):
+    base_path = os.getcwd()
+    if platform.system() == "Windows":
+        base_path = base_path.replace("\\\\", "/")
+    common_prefix = os.path.commonprefix([base_path, path])
+    # strip off the base path - keep only the relative path
+    relpath = path.replace(common_prefix, "")
+    # get rid of a leading slash
+    path = relpath[1:]
+    # trim newline characters (sometimes at end of filename)
+    path = path.replace("\n", "")
+    return path
+
+
+def _touch_init(folder):
+    init = os.path.join(folder, "__init__.py")
+    if not os.path.exists(init):
+        with open(init, "w") as f:
+            f.write("\n")
+    return _remove_cwd_prefix(init)
+
+
 class CMaker(object):
 
-    def __init__(self, generator=None, **defines):
-        self.generator = generator or platform_specifics.get_platform()
+    def __init__(self, **defines):
         if platform.system() != 'Windows':
             rtn = subprocess.call(['which', 'cmake'])
             if rtn != 0:
                 sys.exit('CMake is not installed, aborting build.')
 
-    def configure(self, clargs=(), generator=None):
+    def configure(self, clargs=(), generator_id=None):
+        """Calls cmake to generate the makefile (or VS solution, or XCode project).
         """
-        Calls cmake to generate the makefile (or VS solution, or XCode project)
-
-        Input:
-        ------
-        generator: string
-            The string representing the CMake generator to use.  If None, uses defaults for your platform.
-        """
-        generator_id = self.generator.get_best_generator(generator)
+        # TODO: needs to parse languages somehow? or does it matter? it would
+        #    be an additional arg to the get_best_generator function.
+        clargs, generator_id = pop_arg('-G', clargs)
+        generator_id = platform_specifics.get_platform().get_best_generator(
+            generator_id)
+        if generator_id is None:
+            sys.exit("Could not get working generator for your system."
+                     "  Aborting build.")
         if not os.path.exists("cmake_build"):
             os.makedirs("cmake_build")
-        os.chdir("cmake_build")
-        return_status = subprocess.check_call(['cmake', '../', '-G', generator_id, "-DCMAKE_PREFIX_INSTALL=."])
-        os.chdir("..")
-        if return_status != 0:
-            raise RuntimeError(
-                "Could not successfully configure your project.  Please see CMake's output for more information.")
+        cmd = ['cmake', '..',  '-G', generator_id,
+               '-DCMAKE_INSTALL_PREFIX={0}'.format(os.getcwd()),
+               '-DPYTHON_EXECUTABLE=' + sys.executable, 
+               '-DPYTHON_VERSION_STRING=' + sys.version.split(' ')[0], ]
+        cmd.extend(clargs)
+        # changes dir to cmake_build and calls cmake's configure step
+        # to generate makefile
+        rtn = subprocess.check_call(cmd, cwd="cmake_build")
+        if rtn != 0:
+            raise RuntimeError("Could not successfully configure your project. "
+                               "Please see CMake's output for more information.")
 
-    def make(self, clargs=(), config="Release", source_dir="./"):
+    def make(self, clargs=(), config="Release", source_dir="."):
+        """Calls the system-specific make program to compile code.
         """
-        Calls the system-specific make program to compile code
-        """
+        clargs, config = pop_arg('--config', clargs, config)
         if not os.path.exists("cmake_build"):
-            raise RuntimeError(
-                "CMake build folder (cmake_build) does not exist.  Did you forget to run configure before make?")
-        os.chdir("cmake_build")
-        return_status = subprocess.check_call(["cmake", "--build", source_dir, "--target", "install", "--config", config])
-        os.chdir("..")
-        return return_status
+            raise RuntimeError("CMake build folder (cmake_build) does not exist. "
+                               "Did you forget to run configure before make?")
+        cmd = ["cmake", "--build", source_dir,
+               "--target", "install", "--config", config]
+        cmd.extend(clargs)
+        rtn = subprocess.check_call(cmd, cwd="cmake_build")
+        return rtn
 
     def install(self):
         """Returns a list of tuples of (install location, file list) to install
         via distutils that is compatible with the data_files keyword argument.
         """
-        return []
+        return self._parse_manifest()
 
-
-if __name__ == "__main__":
-    maker = CMaker()
-    #os.chdir("tests")
-    maker.configure("Visual Studio 11")
+    def _parse_manifest(self):
+        installed_files = list()
+        with open("cmake_build/install_manifest.txt", "r") as manifest:
+            for path in manifest.readlines():
+                # do we have an __init__.py file in the folder?
+                # if not, we should create one so that distutils can find files
+                # there.
+                init_path = _touch_init(os.path.split(path)[0])
+                cleaned_relative_path = _remove_cwd_prefix(path)
+                # distutils likes only the filename - gets confused by relative
+                # path???
+                installed_files.append(os.path.split(cleaned_relative_path)[1])
+        return installed_files

--- a/pycmake/distutils_wrap.py
+++ b/pycmake/distutils_wrap.py
@@ -8,7 +8,8 @@ import distutils.core
 
 from pycmake import cmaker
 
-def move_arg(arg, a, b, newarg=None, f=lambda x: x):
+
+def move_arg(arg, a, b, newarg=None, f=lambda x: x, concatenate_value=False):
     """Moves an argument from a list to b list, possibly giving it a new name
     and/or performing a transformation on the value. Returns a and b. The arg need 
     not be present in a.
@@ -18,12 +19,15 @@ def move_arg(arg, a, b, newarg=None, f=lambda x: x):
     parser.add_argument(arg)
     ns, a = parser.parse_known_args(a)
     ns = tuple(vars(ns).items())
-    if len(ns) > 0:
+    if len(ns) > 0 and ns[0][1] is not None:
         key, value = ns[0]
+        if concatenate_value:
+            newarg += "=" + str(f(value))
         b.append(newarg)
         if value is not None:
             b.append(f(value))
     return a, b
+
 
 def parse_args():
     dutils = []
@@ -38,14 +42,17 @@ def parse_args():
             argsets[i].append(arg)
 
     # handle argument transformations
-    dutils, cmake = move_arg('--build-type', dutils, cmake, 
-                             newarg='-DCMAKE_BUILD_TYPE')
+    dutils, cmake = move_arg('--build-type', dutils, cmake,
+                             newarg='-DCMAKE_BUILD_TYPE',
+                             concatenate_value=True)
+    dutils, cmake = move_arg('-G', dutils, cmake)
     dutils, make = move_arg('-j', dutils, make)
     op = os.path
     absappend = lambda x: op.join(op.dirname(op.abspath(sys.argv[0])), x)
     dutils, dutils = move_arg('--egg-base', dutils, dutils, f=absappend)
 
     return dutils, cmake, make
+
 
 def setup(*args, **kw):
     """This function wraps distutils.core.setup() so that we can run cmake, make, 
@@ -57,7 +64,9 @@ def setup(*args, **kw):
     cmkr.configure(cmake_args)
     cmkr.make(make_args)
     extra_data_files = cmkr.install()
-    data_files = kw.get('data_files', [])
-    data_files.extend(extra_data_files)
-    kw['data_files'] = data_files
+    data_files = kw.get('package_data', {})
+    base_path_files = data_files.get("", [])
+    base_path_files.extend(extra_data_files)
+    data_files[""] = base_path_files
+    kw['package_data'] = data_files
     return distutils.core.setup(*args, **kw)

--- a/pycmake/platform_specifics/__init__.py
+++ b/pycmake/platform_specifics/__init__.py
@@ -1,2 +1,1 @@
 from .platform_factory import get_platform
-

--- a/pycmake/platform_specifics/abstract.py
+++ b/pycmake/platform_specifics/abstract.py
@@ -34,10 +34,17 @@ class CMakePlatform(object):
 
     # TODO: this method name is not great.  Does anyone have a better idea for
     # renaming it?
-    def get_best_generator(self, generator=None, languages=("CXX", "C")):
+    def get_best_generator(self, generator=None, languages=("CXX", "C"), cleanup=True):
         """Loop over generators to find one that works.
 
-        Languages is a list of all the languages you'll need for your project.
+        Parameters:
+        generator: string or None
+            If provided, uses only provided generator, instead of trying system defaults.
+        languages: tuple
+            the languages you'll need for your project, in terms that CMake recognizes.
+        cleanup: bool
+            If True, cleans up temporary folder used to test generators.  Set to False
+            for debugging to see CMake's output files.
         """
         if generator is not None:
             generators = [generator, ]
@@ -86,4 +93,6 @@ class CMakePlatform(object):
                 break
 
         os.chdir(backup_folder)
+        if cleanup:
+            CMakePlatform.cleanup_test()
         return working_generator

--- a/pycmake/platform_specifics/platform_factory.py
+++ b/pycmake/platform_specifics/platform_factory.py
@@ -11,7 +11,7 @@ def get_platform():
         return linux.LinuxPlatform()
     elif this_platform == "Windows":
         return windows.WindowsPlatform()
-    elif this_platform == "Darwin" :
+    elif this_platform == "Darwin":
         return osx.OSXPlatform()
     else:
         raise RuntimeError("Unsupported platform: {:s}. Please contact "


### PR DESCRIPTION
These changes implement a parser for CMake-generated install manifests, and appends those files accordingly to the package_data content for the package's setup.

This is a split-up of code from
https://github.com/PyCMake/PyCMake/pull/16

(Please review that PR for details and history)
