### PR TITLE
Weak linking CMake module

### DIFF
--- a/tests/samples/cmake-files/FindPythonExtensions.cmake
+++ b/tests/samples/cmake-files/FindPythonExtensions.cmake
@@ -219,8 +219,9 @@
 # limitations under the License.
 #=============================================================================
 
-find_package( PythonInterp REQUIRED )
-find_package( PythonLibs REQUIRED )
+find_package(PythonInterp REQUIRED)
+find_package(PythonLibs)
+include(targetLinkLibrariesWithDynamicLookup)
 
 set(_command "
 import distutils.sysconfig
@@ -291,7 +292,7 @@ mark_as_advanced(PYTHON_RELATIVE_SITE_PACKAGES_DIR)
 
 function(python_extension_module _target)
   set(one_ops LINKED_MODULES_VAR FORWARD_DECL_MODULES_VAR)
-  cmake_parse_arguments(_args "" "${one_ops}" "" "" ${ARGN})
+  cmake_parse_arguments(_args "" "${one_ops}" "" ${ARGN})
 
   set(_lib_type "NA")
   if(TARGET ${_target})
@@ -348,16 +349,11 @@ function(python_extension_module _target)
   endif()
 
   if(_is_module_lib OR _is_shared_lib)
-    if(APPLE)
-      set_target_properties(${_target} PROPERTIES
-                            LINK_FLAGS "-undefined dynamic_lookup")
-    else()
-      target_link_libraries(${_target} ${PYTHON_LIBRARIES})
-
-      if(_is_module_lib AND WIN32 AND NOT CYGWIN)
-        set_target_properties(${_target} PROPERTIES SUFFIX ".pyd")
-      endif()
+    if(_is_module_lib AND WIN32 AND NOT CYGWIN)
+      set_target_properties(${_target} PROPERTIES SUFFIX ".pyd")
     endif()
+
+    target_link_libraries_with_dynamic_lookup(${_target} ${PYTHON_LIBRARIES})
   endif()
 endfunction()
 
@@ -370,7 +366,7 @@ function(python_modules_header _name)
   set(one_ops FORWARD_DECL_MODULES_LIST
               HEADER_OUTPUT_VAR
               INCLUDE_DIR_OUTPUT_VAR)
-  cmake_parse_arguments(_args "" "${one_ops}" "" "" ${ARGN})
+  cmake_parse_arguments(_args "" "${one_ops}" "" ${ARGN})
 
   list(GET _args_UNPARSED_ARGUMENTS 0 _arg0)
   # if present, use arg0 as the input file path

--- a/tests/samples/cmake-files/targetLinkLibrariesWithDynamicLookup.cmake
+++ b/tests/samples/cmake-files/targetLinkLibrariesWithDynamicLookup.cmake
@@ -102,7 +102,10 @@
 # weak-linking, this function works just like ``target_link_libraries``.
 
 function(_get_target_type result_var target)
-  get_property(target_type TARGET ${target} PROPERTY TYPE)
+  set(target_type "SHARED_LIBRARY")
+  if(TARGET ${target})
+    get_property(target_type TARGET ${target} PROPERTY TYPE)
+  endif()
 
   set(result "STATIC")
 

--- a/tests/samples/cmake-files/targetLinkLibrariesWithDynamicLookup.cmake
+++ b/tests/samples/cmake-files/targetLinkLibrariesWithDynamicLookup.cmake
@@ -1,0 +1,278 @@
+#
+# - This module provides the function
+# target_link_libraries_with_dynamic_lookup which can be used to
+# "weakly" link loadable module.
+#
+# Link a library to a target such that the symbols are resolved at
+# run-time not link-time. This should be used when compiling a
+# loadable module when the symbols should be resolve from the run-time
+# environment where the module is loaded, and not a specific system
+# library.
+#
+# Specifically, for OSX it uses undefined dynamic_lookup. This is
+# similar to using "-shared" on Linux where undefined symbols are
+# ignored.
+#
+# Additionally, the linker is checked to see if it supports undefined
+# symbols when linking a shared library. If it does then the library
+# is not linked when specified with this function.
+#
+# http://blog.tim-smith.us/2015/09/python-extension-modules-os-x/
+#
+#
+# The following functions are defined:
+#
+#   has_dynamic_lookup(<ResultVar>)
+#
+# Check if the linker requires a command line flag to allow leaving symbols
+# unresolved until runtime.  A test project is built and ran and ``<ResultVar>``
+# is set based on whether the project was built and ran successfully.  The
+# result is cached between invocations and recomputed only when the value of
+# ``CMAKE_SHARED_LINKER_FLAGS`` changes.
+#
+# Defined variables:
+#
+# ``<ResultVar>``
+#   Whether the linker allows undefined symbols for shared libraries.
+#
+# ``HAS_DYNAMIC_LOOKUP``
+#   Cached alias.
+#
+#
+#   has_symbol_dedupe(<ResultVar>)
+#
+# Check if the linker/loader correctly coalesces symbols that have been
+# duplicated across link boundaries.  A test project is built and ran and
+# ``<ResultVar>`` is set based on whether the project was built and ran
+# successfully.  The result is cached between invocations and recomputed only
+# when the value of ``CMAKE_SHARED_LINKER_FLAGS`` changes.
+
+# Defined variables:
+#
+# ``<ResultVar>``
+#   Whether the linker/loader correctly coalesces duplicated symbols
+#
+# ``HAS_SYMBOL_DEDUPE``
+#   Cached alias.
+#
+
+function(_test_weak_link_project projectName testName)
+  set(options DYNAMIC_LOOKUP SYMBOL_DEDUPE)
+  cmake_parse_arguments(_args "${options}" "" "" ${ARGN})
+
+  set(test_project_src_dir
+      "${PROJECT_BINARY_DIR}/CMakeTmp/${projectName}/src")
+  set(test_project_bin_dir
+      "${PROJECT_BINARY_DIR}/CMakeTmp/${projectName}/build")
+
+  file(MAKE_DIRECTORY ${test_project_src_dir})
+  file(MAKE_DIRECTORY ${test_project_bin_dir})
+
+  file(WRITE "${test_project_src_dir}/CMakeLists.txt" "
+    cmake_minimum_required(VERSION ${CMAKE_VERSION})
+    project(${projectName} C)
+
+    include_directories(${test_project_src_dir})
+
+    add_library(number SHARED number.c)
+
+    add_library(counter MODULE counter.c)
+    set_target_properties(counter PROPERTIES PREFIX \"\")
+  ")
+
+  if(_args_DYNAMIC_LOOKUP)
+    file(APPEND "${test_project_src_dir}/CMakeLists.txt" "
+    set_target_properties(
+      counter
+      PROPERTIES LINK_FLAGS \"-undefined dynamic_lookup\")
+    ")
+  elseif(_args_SYMBOL_DEDUPE)
+    file(APPEND "${test_project_src_dir}/CMakeLists.txt" "
+    target_link_libraries(counter number)
+    ")
+  endif()
+
+  file(APPEND "${test_project_src_dir}/CMakeLists.txt" "
+    add_executable(main main.c)
+    target_link_libraries(main number)
+    target_link_libraries(main ${CMAKE_DL_LIBS})
+  ")
+
+  file(WRITE "${test_project_src_dir}/number.c" "
+    #include <number.h>
+
+    static int _number;
+    void set_number(int number) { _number = number; }
+    int get_number() { return _number; }
+  ")
+
+  file(WRITE "${test_project_src_dir}/number.h" "
+    #ifndef _NUMBER_H
+    #define _NUMBER_H
+    extern void set_number(int);
+    extern int get_number(void);
+    #endif
+  ")
+
+  file(WRITE "${test_project_src_dir}/counter.c" "
+    #include <number.h>
+    int count() {
+      int result = get_number();
+      set_number(result + 1);
+      return result;
+    }
+  ")
+
+  file(WRITE "${test_project_src_dir}/counter.h" "
+    #ifndef _COUNTER_H
+    #define _COUNTER_H
+    extern int count(void);
+    #endif
+  ")
+
+  file(WRITE "${test_project_src_dir}/main.c" "
+    #include <stdlib.h>
+    #include <stdio.h>
+    #include <dlfcn.h>
+
+    int my_count() {
+      int result = get_number();
+      set_number(result + 1);
+      return result;
+    }
+
+    int main(int argc, char **argv) {
+      void *counter_module;
+      int (*count)(void);
+      int result;
+
+      counter_module = dlopen(\"./counter.so\", RTLD_LAZY);
+      if(!counter_module) goto error;
+
+      count = dlsym(counter_module, \"count\");
+      if(!count) goto error;
+
+      result = count()    != 0 ? 1 :
+               my_count() != 1 ? 1 :
+               my_count() != 2 ? 1 :
+               count()    != 3 ? 1 :
+               count()    != 4 ? 1 :
+               count()    != 5 ? 1 :
+               my_count() != 6 ? 1 : 0;
+
+
+      goto done;
+      error:
+        fprintf(stderr, \"Error occured:\\n    %s\\n\", dlerror());
+        result = 1;
+
+      done:
+        if(counter_module) dlclose(counter_module);
+        return result;
+    }
+  ")
+
+  set(_rpath_arg)
+  if(APPLE AND ${CMAKE_VERSION} VERSION_GREATER 2.8.11)
+    set(_rpath_arg "-DCMAKE_MACOSX_RPATH='${CMAKE_MACOSX_RPATH}'")
+  endif()
+
+  try_compile(project_compiles
+              "${test_project_bin_dir}"
+              "${test_project_src_dir}"
+              "${projectName}"
+              CMAKE_FLAGS
+                "-DCMAKE_SHARED_LINKER_FLAGS='${CMAKE_SHARED_LINKER_FLAGS}'"
+                ${_rpath_arg}
+              OUTPUT_VARIABLE compile_output)
+
+  set(project_works 1)
+  set(run_output)
+
+  if(project_compiles)
+    execute_process(COMMAND "${test_project_bin_dir}/main"
+                    WORKING_DIRECTORY "${test_project_bin_dir}"
+                    RESULT_VARIABLE project_works
+                    OUTPUT_VARIABLE run_output
+                    ERROR_VARIABLE run_output)
+  endif()
+
+  if(project_works EQUAL 0)
+    set(project_works TRUE)
+    message(STATUS "Performing Test ${testName} - Success")
+  else()
+    set(project_works FALSE)
+    message(STATUS "Performing Test ${testName} - Failed")
+    file(APPEND ${CMAKE_BINARY_DIR}/${CMAKE_FILES_DIRECTORY}/CMakeError.log
+         "Performing Test ${testName} failed with the following output:\n"
+         "BUILD\n-----\n${compile_output}\nRUN\n---\n${run_output}\n")
+  endif()
+
+  set(${projectName} ${project_works} PARENT_SCOPE)
+endfunction()
+
+
+function(has_dynamic_lookup resultVar)
+  # hash the CMAKE_FLAGS passed and check cache to know if we need to rerun
+  string(MD5 cmake_flags_hash "${CMAKE_SHARED_LINKER_FLAGS}")
+
+  if(     NOT DEFINED HAS_DYNAMIC_LOOKUP_hash
+       OR NOT "${HAS_DYNAMIC_LOOKUP_hash}" STREQUAL "${cmake_flags_hash}")
+    unset(HAS_DYNAMIC_LOOKUP)
+  endif()
+
+  if(NOT DEFINED HAS_DYNAMIC_LOOKUP)
+    _test_weak_link_project(has_dynamic_lookup
+                            HAS_DYNAMIC_LOOKUP
+                            DYNAMIC_LOOKUP)
+
+    set(HAS_DYNAMIC_LOOKUP ${has_dynamic_lookup}
+        CACHE BOOL "linker requires \"dynamic_lookup\" for undefined symbols")
+
+    set(HAS_DYNAMIC_LOOKUP_hash "${cmake_flags_hash}"
+        CACHE INTERNAL "hashed flags for HAS_DYNAMIC_LOOKUP check")
+  endif()
+
+  set(${resultVar} "${HAS_DYNAMIC_LOOKUP}" PARENT_SCOPE)
+endfunction()
+
+
+function(has_symbol_dedupe resultVar)
+  # hash the CMAKE_FLAGS passed and check cache to know if we need to rerun
+  string(MD5 cmake_flags_hash "${CMAKE_SHARED_LINKER_FLAGS}")
+
+  if(     NOT DEFINED HAS_SYMBOL_DEDUPE_hash
+       OR NOT "${HAS_SYMBOL_DEDUPE_hash}" STREQUAL "${cmake_flags_hash}")
+    unset(HAS_SYMBOL_DEDUPE)
+  endif()
+
+  if(NOT DEFINED HAS_SYMBOL_DEDUPE)
+    _test_weak_link_project(has_symbol_dedupe
+                            HAS_SYMBOL_DEDUPE
+                            SYMBOL_DEDUPE)
+
+    set(HAS_SYMBOL_DEDUPE ${has_symbol_dedupe}
+        CACHE BOOL "linker/loader can coalesce duplicated symbols")
+
+    set(HAS_SYMBOL_DEDUPE_hash "${cmake_flags_hash}"
+        CACHE INTERNAL "hashed flags for HAS_SYMBOL_DEDUPE check")
+  endif()
+
+  set(${resultVar} "${HAS_SYMBOL_DEDUPE}" PARENT_SCOPE)
+endfunction()
+
+
+function(target_link_libraries_with_dynamic_lookup target)
+  has_dynamic_lookup(_dlookup)
+  if(_dlookup)
+    set_target_properties(${target}
+                          PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+  else()
+    has_symbol_dedupe(_dedupe)
+    if(_dedupe)
+      # loader coalesces duplicate symbols, so just link normally
+      target_link_libraries(${target} ${ARGN})
+    endif()
+  endif()
+endfunction()
+

--- a/tests/samples/cmake-files/targetLinkLibrariesWithDynamicLookup.cmake
+++ b/tests/samples/cmake-files/targetLinkLibrariesWithDynamicLookup.cmake
@@ -290,13 +290,13 @@ function(_test_weak_link_project
     endif()
 
     file(APPEND "${test_project_src_dir}/main.c" "
-        result = count()    != 0 ? 1 :
-                 my_count() != 1 ? 1 :
-                 my_count() != 2 ? 1 :
-                 count()    != 3 ? 1 :
-                 count()    != 4 ? 1 :
-                 count()    != 5 ? 1 :
-                 my_count() != 6 ? 1 : 0;
+        result = count()    != 0 ? EXIT_FAILURE :
+                 my_count() != 1 ? EXIT_FAILURE :
+                 my_count() != 2 ? EXIT_FAILURE :
+                 count()    != 3 ? EXIT_FAILURE :
+                 count()    != 4 ? EXIT_FAILURE :
+                 count()    != 5 ? EXIT_FAILURE :
+                 my_count() != 6 ? EXIT_FAILURE : EXIT_SUCCESS;
     ")
 
     if(NOT link_exe_mod)
@@ -389,14 +389,22 @@ function(check_dynamic_lookup
   endif()
 
   if(NOT DEFINED ${cache_var})
-    if(NOT CMAKE_CROSSCOMPILING OR CMAKE_CROSSCOMPILING_EMULATOR)
+    set(skip_test FALSE)
+
+    if(NOT CMAKE_CROSSCOMPILING)
+      set(skip_test TRUE)
+    elseif(CMAKE_CROSSCOMPILING AND CMAKE_CROSSCOMPILING_EMULATOR)
+      set(skip_test TRUE)
+    endif()
+
+    if(skip_test)
+      set(has_dynamic_lookup FALSE)
+      set(link_flags)
+    else()
       _test_weak_link_project(${target_type}
                               ${lib_type}
                               has_dynamic_lookup
                               link_flags)
-    else()
-      set(has_dynamic_lookup FALSE)
-      set(link_flags)
     endif()
 
     set(caveat " (when linking ${target_type} against ${lib_type})")

--- a/tests/samples/tower-of-babel/CMakeLists.txt
+++ b/tests/samples/tower-of-babel/CMakeLists.txt
@@ -73,5 +73,7 @@ install(FILES tbabel_boost_common.h DESTINATION include)
 
 install(FILES tbabel_python.py DESTINATION ${site_packages})
 
+file(COPY tbabel_python.py DESTINATION ${CMAKE_BINARY_DIR})
+
 add_subdirectory(scripts)
 

--- a/tests/samples/tower-of-babel/scripts/CMakeLists.txt
+++ b/tests/samples/tower-of-babel/scripts/CMakeLists.txt
@@ -10,8 +10,12 @@ get_property(MODS GLOBAL PROPERTY PY_LINKED_MODULES_LIST)
 add_executable(tbabel ${tbabel})
 target_link_libraries(tbabel ${MODS})
 python_standalone_executable(tbabel)
+
 add_test(NAME tbabel COMMAND tbabel
          WORKING_DIRECTORY ${CMAKE_BUILD_DIRECTORY})
 
-install(TARGETS tbabel DESTINATION scripts)
+set_property(TEST tbabel PROPERTIES
+             ENVIRONMENT
+             "LD_LIBRARY_PATH=${CMAKE_BUILD_DIRECTORY};DYLD_LIBRARY_PATH=${CMAKE_BUILD_DIRECTORY}")
 
+install(TARGETS tbabel DESTINATION scripts)

--- a/tests/samples/tower-of-babel/scripts/CMakeLists.txt
+++ b/tests/samples/tower-of-babel/scripts/CMakeLists.txt
@@ -10,14 +10,8 @@ get_property(MODS GLOBAL PROPERTY PY_LINKED_MODULES_LIST)
 add_executable(tbabel ${tbabel})
 target_link_libraries(tbabel ${MODS})
 python_standalone_executable(tbabel)
-add_test(NAME tbabel COMMAND tbabel)
-
-set(_pp "")
-set(_pp "${_pp}${CMAKE_SOURCE_DIR}")
-set(_pp "${_pp}${PYTHON_PATH_SEPARATOR}")
-set(_pp "${_pp}${CMAKE_BINARY_DIR}")
-
-set_property(TEST tbabel PROPERTY ENVIRONMENT "PYTHONPATH=${_pp}")
+add_test(NAME tbabel COMMAND tbabel
+         WORKING_DIRECTORY ${CMAKE_BUILD_DIRECTORY})
 
 install(TARGETS tbabel DESTINATION scripts)
 

--- a/tests/samples/tower-of-babel/scripts/CMakeLists.txt
+++ b/tests/samples/tower-of-babel/scripts/CMakeLists.txt
@@ -14,8 +14,7 @@ python_standalone_executable(tbabel)
 add_test(NAME tbabel COMMAND tbabel
          WORKING_DIRECTORY ${CMAKE_BUILD_DIRECTORY})
 
-set_property(TEST tbabel PROPERTIES
-             ENVIRONMENT
+set_property(TEST tbabel PROPERTY ENVIRONMENT
              "LD_LIBRARY_PATH=${CMAKE_BUILD_DIRECTORY};DYLD_LIBRARY_PATH=${CMAKE_BUILD_DIRECTORY}")
 
 install(TARGETS tbabel DESTINATION scripts)

--- a/tests/test_tower_of_babel.py
+++ b/tests/test_tower_of_babel.py
@@ -35,11 +35,17 @@ def test_tbabel_builds():
 def test_tbabel_works():
     old_cwd = os.getcwd()
     os.chdir(os.path.join("samples", "tower-of-babel", CMAKE_BUILD_DIR))
+
+    env = os.environ
+    if not env.get("PYTHONHOME") and env.get("CONDA_ENV_PATH"):
+        env["PYTHONHOME"] = env["CONDA_ENV_PATH"]
+
     try:
         subprocess.check_call(
             ["ctest", "--build-config",
                 os.environ.get("SKBUILD_CMAKE_CONFIG", "Debug"),
-                "--output-on-failure"])
+                "--output-on-failure"],
+            env=env)
     finally:
         os.chdir(old_cwd)
 

--- a/tests/test_tower_of_babel.py
+++ b/tests/test_tower_of_babel.py
@@ -37,8 +37,21 @@ def test_tbabel_works():
     os.chdir(os.path.join("samples", "tower-of-babel", CMAKE_BUILD_DIR))
 
     env = os.environ
-    if not env.get("PYTHONHOME") and env.get("CONDA_ENV_PATH"):
-        env["PYTHONHOME"] = env["CONDA_ENV_PATH"]
+    pp = env.get("PYTHONPATH", [])
+    if(pp):
+        pp = pp.split(os.pathsep)
+
+    pyversion = "python" + ".".join(str(x) for x in sys.version_info[:2])
+    pp.extend((
+        os.path.join(sys.prefix, "lib", pyversion),
+        os.path.join(sys.prefix, "lib", pyversion, "site-packages"),
+        os.path.join(sys.prefix, "lib", pyversion, "lib-dynload"),
+        os.getcwd()
+    ))
+
+    env["PYTHONPATH"] = os.pathsep.join(pp)
+
+    env["PYTHONHOME"] = env.get("PYTHONHOME", sys.prefix)
 
     try:
         subprocess.check_call(


### PR DESCRIPTION
Adapted from [vtk#1511](https://gitlab.kitware.com/vtk/vtk/merge_requests/1511).

Adds a new experimental CMake module: `targetLinkLibrariesWithDynamicLookup` that allows one to portably indicate that a target uses symbols from another library, but that the resolution of symbols should be delayed until runtime, i.e.: the linker should tolerate undefined symbols when linking.  "Weak linking" has been used to refer to this code sharing scheme as well as its many subtle variants.

Reviewers, please note the major differences in this PR when compared to [vtk#1511](https://gitlab.kitware.com/vtk/vtk/merge_requests/1511).
  - This version uses two instances of a sample project with `try_compile` to infer the level of support for dynamic symbol resolution.  The first determines if the linker responds to the dynamic lookup flag currently present in linker on OS X.  The second determines if the linker and run-time loader can properly coalesce symbols that have been duplicated across link boundaries, such as `ld`/Linux.  The original version only included the first check.
  - In addition, each sample project is tested after compiling to ensure that the test program produces the expected output as well as compile successfully.  The original used a much simpler test program that would only compile.
  - In the original version, no link is performed when the linker is found to not support the dynamic lookup flag.  In general, a proper linking is still necessary on platforms like Linux, whose loader can coalesce duplicate symbols at run-time.  In this version, the link is performed when such a loader has been detected.
  - The original version's system checks were performed immediately upon module load and then cached.  This version runs the system checks and caches on demand. 

Also, includes a fix for when testing the `tower-of-babel` sample project under anaconda.