### PR TITLE
setup.py: Fix test command setting 'nose.collector' as test_suite See #58

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,6 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
-    test_suite='tests',
+    test_suite='nose.collector',
     tests_require=dev_requirements
 )


### PR DESCRIPTION
See http://nose.readthedocs.io/en/latest/setuptools_integration.html?highlight=python%20setup.py%20test

Suggested-by: Matt McCormick <matt.mccormick@kitware.com>