### PR TITLE
documentation: Fix formatting of requirements

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -32,10 +32,12 @@ The project has a few common Python package dependencies. The runtime
 dependencies are:
 
 .. include:: ../requirements.txt
+   :literal:
 
 the build time dependencies (also required for development) are:
 
 .. include:: ../requirements-dev.txt
+   :literal:
 
 Compiler Toolchain
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This commit fixes the formatting of the Python package dependencies in the
documentation by including the requirements*.txt files as literal blocks.

Reference:
http://docutils.sourceforge.net/docs/ref/rst/directives.html#including-an-external-document-fragment