### PR TITLE
CMaker: make configure and build errors more informative

### DIFF
--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -65,10 +65,10 @@ class CMaker(object):
 
     def __init__(self, **defines):
         # verify that CMake is installed
-        if platform.system() != 'Windows':
-            rtn = subprocess.call(['which', 'cmake'])
-            if rtn != 0:
-                raise SKBuildError('CMake is not installed, aborting build.')
+        try:
+            subprocess.check_call(['cmake', '--version'])
+        except (OSError, CalledProcessError):
+            raise SKBuildError('CMake is not installed, aborting build.')
 
         self.platform = get_platform()
 

--- a/skbuild/exceptions.py
+++ b/skbuild/exceptions.py
@@ -1,3 +1,6 @@
 
-class SKBuildError(Exception):
+class SKBuildError(RuntimeError):
+    """Exception raised when an error occurs while configuring or building a
+    project.
+    """
     pass

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -131,9 +131,16 @@ def setup(*args, **kw):
         reverse=True
     ))
 
-    cmkr = cmaker.CMaker()
-    cmkr.configure(cmake_args)
-    cmkr.make(make_args)
+    try:
+        cmkr = cmaker.CMaker()
+        cmkr.configure(cmake_args)
+        cmkr.make(make_args)
+    except SKBuildError as e:
+        import traceback
+        print("Traceback (most recent call last):")
+        traceback.print_tb(sys.exc_info()[2])
+        print()
+        sys.exit(e)
 
     install_root = os.path.join(os.getcwd(), cmaker.CMAKE_INSTALL_DIR)
     for path in cmkr.install():

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -142,8 +142,45 @@ def setup(*args, **kw):
         print()
         sys.exit(e)
 
+    _classify_files(cmkr.install(), package_data, package_prefixes, py_modules,
+                    scripts, new_scripts, data_files)
+
+    kw['package_data'] = package_data
+    kw['package_dir'] = {
+        package: os.path.join(cmaker.CMAKE_INSTALL_DIR, prefix)
+        for prefix, package in package_prefixes
+    }
+
+    kw['py_modules'] = py_modules
+
+    kw['scripts'] = [
+        os.path.join(cmaker.CMAKE_INSTALL_DIR, script) if mask else script
+        for script, mask in new_scripts.items()
+    ]
+
+    kw['data_files'] = [
+        (parent_dir, list(file_set))
+        for parent_dir, file_set in data_files.items()
+    ]
+
+    # work around https://bugs.python.org/issue1011113
+    # (patches provided, but no updates since 2014)
+    cmdclass = kw.get('cmdclass', {})
+    cmdclass['build'] = cmdclass.get('build', build.build)
+    cmdclass['install'] = cmdclass.get('install', install.install)
+    cmdclass['clean'] = cmdclass.get('clean', clean.clean)
+    cmdclass['bdist'] = cmdclass.get('bdist', bdist.bdist)
+    cmdclass['bdist_wheel'] = cmdclass.get(
+        'bdist_wheel', bdist_wheel.bdist_wheel)
+    kw['cmdclass'] = cmdclass
+
+    return upstream_setup(*args, **kw)
+
+
+def _classify_files(install_paths, package_data, package_prefixes, py_modules,
+                    scripts, new_scripts, data_files):
     install_root = os.path.join(os.getcwd(), cmaker.CMAKE_INSTALL_DIR)
-    for path in cmkr.install():
+    for path in install_paths:
         found_package = False
         found_module = False
         found_script = False
@@ -211,34 +248,3 @@ def setup(*args, **kw):
             data_files[parent_dir] = file_set
         file_set.add(os.path.join(cmaker.CMAKE_INSTALL_DIR, path))
         del parent_dir, file_set
-
-    kw['package_data'] = package_data
-    kw['package_dir'] = {
-        package: os.path.join(cmaker.CMAKE_INSTALL_DIR, prefix)
-        for prefix, package in package_prefixes
-    }
-
-    kw['py_modules'] = py_modules
-
-    kw['scripts'] = [
-        os.path.join(cmaker.CMAKE_INSTALL_DIR, script) if mask else script
-        for script, mask in new_scripts.items()
-    ]
-
-    kw['data_files'] = [
-        (parent_dir, list(file_set))
-        for parent_dir, file_set in data_files.items()
-    ]
-
-    # work around https://bugs.python.org/issue1011113
-    # (patches provided, but no updates since 2014)
-    cmdclass = kw.get('cmdclass', {})
-    cmdclass['build'] = cmdclass.get('build', build.build)
-    cmdclass['install'] = cmdclass.get('install', install.install)
-    cmdclass['clean'] = cmdclass.get('clean', clean.clean)
-    cmdclass['bdist'] = cmdclass.get('bdist', bdist.bdist)
-    cmdclass['bdist_wheel'] = cmdclass.get(
-        'bdist_wheel', bdist_wheel.bdist_wheel)
-    kw['cmdclass'] = cmdclass
-
-    return upstream_setup(*args, **kw)

--- a/tests/test_outside_project_root.py
+++ b/tests/test_outside_project_root.py
@@ -5,7 +5,8 @@
 ----------------------------------
 
 Tries to build the `fail-outside-project-root` sample project.  Ensures that the
-attempt fails with an SKBuildError exception.
+attempt fails with a SystemExit exception that has an SKBuildError exception as
+its value.
 """
 
 from skbuild.exceptions import SKBuildError
@@ -23,10 +24,10 @@ def test_outside_project_root_fails():
         def should_fail():
             pass
 
-        exception_thrown = False
+        failed = False
         try:
             should_fail()
-        except SKBuildError:
-            exception_thrown = True
+        except SystemExit as e:
+            failed = isinstance(e.code, SKBuildError)
 
-        assert exception_thrown
+        assert failed


### PR DESCRIPTION
Fixes #75.

Display the following information when a configure or build error occurs:

- The command line in a format that can be copied and pasted into a shell
- The source directory
- The working directory

Given that information, the user can get more details from CMakeCache.txt in the working directory.

Example output (following CMake output) from a configure error:

    -- Configuring incomplete, errors occurred!
    See also "/home/msmolens/dev/scikit-build/tests/samples/tower-of-babel/CMakeFiles/CMakeOutput.log".
    Traceback (most recent call last):
      File "/home/msmolens/dev/scikit-build/skbuild/setuptools_wrap.py", line 136, in setup
        cmkr.configure(cmake_args)
      File "/home/msmolens/dev/scikit-build/skbuild/cmaker.py", line 157, in configure
        os.path.abspath(CMAKE_BUILD_DIR)))

    An error occurred while configuring with CMake.
      Command:
        "cmake" "/home/msmolens/dev/scikit-build/tests/samples/tower-of-babel" "-G" "Unix Makefiles" "-DCMAKE_INSTALL_PREFIX:PATH=/home/msmolens/dev/scikit-build/tests/samples/tower-of-babel/_skbuild/cmake-install" "-DPYTHON_EXECUTABLE:FILEPATH=/home/msmolens/dev/python/scikit-build2/bin/python" "-DPYTHON_VERSION_STRING:STRING=3.5.2" "-DPYTHON_INCLUDE_DIR:PATH=/home/msmolens/tmp/Python-3.5.2-install/include/python3.5m" "-DPYTHON_LIBRARY:FILEPATH=/home/msmolens/tmp/Python-3.5.2-install/lib/libpython3.5m.a" "-DSKBUILD:BOOL=TRUE" "-DCMAKE_MODULE_PATH:PATH=/home/msmolens/dev/scikit-build/skbuild/resources/cmake" "-DCMAKE_BUILD_TYPE:STRING=Release"
      Source directory:
        /home/msmolens/dev/scikit-build/tests/samples/tower-of-babel
      Working directory:
        /home/msmolens/dev/scikit-build/tests/samples/tower-of-babel/_skbuild/cmake-build
    Please see CMake's output for more information.
