### PR TITLE
tests: Do not call both include(CTest) and enable_testing()

### DIFF
--- a/tests/samples/hello-cython/CMakeLists.txt
+++ b/tests/samples/hello-cython/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.5.0)
 
 project(hello_cython)
 
-include(CTest)
 enable_testing()
 
 find_package(PythonInterp REQUIRED)

--- a/tests/samples/hello/CMakeLists.txt
+++ b/tests/samples/hello/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.5.0)
 
 project(hello)
 
-include(CTest)
 enable_testing()
 
 find_package(PythonInterp REQUIRED)

--- a/tests/samples/pen2-cython/CMakeLists.txt
+++ b/tests/samples/pen2-cython/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.5.0)
 
 project(pen2_cython)
 
-include(CTest)
 enable_testing()
 
 find_package(PythonInterp REQUIRED)

--- a/tests/samples/tower-of-babel/CMakeLists.txt
+++ b/tests/samples/tower-of-babel/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.5.0)
 
 project(tower_of_babel)
 
-include(CTest)
 enable_testing()
 
 find_package(PythonInterp REQUIRED)


### PR DESCRIPTION
They are redundant and only one or the other should be called per best
practices.