### PR TITLE
Switch to py.test testing tool

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,6 @@
 branch = True
 source = skbuild
 include = */skbuild/*
+
+[xml]
+output = tests/coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,38 +11,38 @@ matrix:
     - os: linux
       python: "3.4"
       env:
-        - EXTRA_TEST_ARGS="--exclude pen2 --exclude tbabel"
+        - EXTRA_TEST_ARGS="--ignore=tests/test_pen2.py --ignore=tests/test_tower_of_babel.py"
 
     - os: linux
       python: "3.3"
       env:
-        - EXTRA_TEST_ARGS="--exclude pen2 --exclude tbabel"
+        - EXTRA_TEST_ARGS="--ignore=tests/test_pen2.py --ignore=tests/test_tower_of_babel.py"
 
     - os: linux
       python: "2.7"
       env:
-        - EXTRA_TEST_ARGS="--exclude pen2 --exclude tbabel"
+        - EXTRA_TEST_ARGS="--ignore=tests/test_pen2.py --ignore=tests/test_tower_of_babel.py"
 
     - os: osx
       language: generic
       python: "3.4"
       env:
         - PYTHONVERSION=3.4.5
-        - EXTRA_TEST_ARGS="--exclude pen2 --exclude tbabel"
+        - EXTRA_TEST_ARGS="--ignore=tests/test_pen2.py --ignore=tests/test_tower_of_babel.py"
 
     - os: osx
       language: generic
       python: "3.3"
       env:
         - PYTHONVERSION=3.3.6
-        - EXTRA_TEST_ARGS="--exclude pen2 --exclude tbabel"
+        - EXTRA_TEST_ARGS="--ignore=tests/test_pen2.py --ignore=tests/test_tower_of_babel.py"
 
     - os: osx
       language: generic
       python: "2.7"
       env:
         - PYTHONVERSION=2.7.12
-        - EXTRA_TEST_ARGS="--exclude pen2 --exclude tbabel"
+        - EXTRA_TEST_ARGS="--ignore=tests/test_pen2.py --ignore=tests/test_tower_of_babel.py"
 
 
 before_script:
@@ -71,7 +71,7 @@ install:
 script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then eval "$(pyenv init -)"; fi
   - flake8 -v
-  - python setup.py test --args="$EXTRA_TEST_ARGS"
+  - python setup.py test --addopts "$EXTRA_TEST_ARGS"
 
 after_success:
   - codecov -X gcov --required --file tests/coverage.xml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,9 +20,9 @@ environment:
       PYTHON_ARCH: "32"
       CMAKE_GENERATOR: Visual Studio 9 2008
       RUN: "cmd /E:ON /V:ON /C .\\ci\\appveyor\\run.cmd"
-      EXTRA_TEST_ARGS: "--exclude fortran_compiler \
-                        --exclude pen2 \
-                        --exclude tbabel"
+      EXTRA_TEST_ARGS: "-m \"not fortran\" \
+                        --ignore=tests/test_pen2.py \
+                        --ignore=tests/test_tower_of_babel.py"
       SKIP: "0"
       BLOCK: "0"
 
@@ -31,9 +31,9 @@ environment:
       PYTHON_ARCH: "64"
       CMAKE_GENERATOR: Visual Studio 9 2008 Win64
       RUN: "cmd /E:ON /V:ON /C .\\ci\\appveyor\\run.cmd"
-      EXTRA_TEST_ARGS: "--exclude fortran_compiler \
-                        --exclude pen2 \
-                        --exclude tbabel"
+      EXTRA_TEST_ARGS: "-m \"not fortran\" \
+                        --ignore=tests/test_pen2.py \
+                        --ignore=tests/test_tower_of_babel.py"
       SKIP: "0"
       BLOCK: "0"
 
@@ -42,9 +42,9 @@ environment:
       PYTHON_ARCH: "32"
       CMAKE_GENERATOR: Visual Studio 14 2015
       RUN: "cmd /E:ON /V:ON /C .\\ci\\appveyor\\run.cmd"
-      EXTRA_TEST_ARGS: "--exclude fortran_compiler \
-                        --exclude pen2 \
-                        --exclude tbabel"
+      EXTRA_TEST_ARGS: "-m \"not fortran\" \
+                        --ignore=tests/test_pen2.py \
+                        --ignore=tests/test_tower_of_babel.py"
       SKIP: "0"
       BLOCK: "0"
 
@@ -53,9 +53,9 @@ environment:
       PYTHON_ARCH: "64"
       CMAKE_GENERATOR: Visual Studio 14 2015 Win64
       RUN: "cmd /E:ON /V:ON /C .\\ci\\appveyor\\run.cmd"
-      EXTRA_TEST_ARGS: "--exclude fortran_compiler \
-                        --exclude pen2 \
-                        --exclude tbabel"
+      EXTRA_TEST_ARGS: "-m \"not fortran\" \
+                        --ignore=tests/test_pen2.py \
+                        --ignore=tests/test_tower_of_babel.py"
       SKIP: "0"
       BLOCK: "0"
 
@@ -65,9 +65,9 @@ environment:
       PYTHON_ARCH: "64"
       CMAKE_GENERATOR: "MinGW Makefiles"
       RUN: "cmd /E:ON /V:ON /C .\\ci\\appveyor\\run.cmd"
-      EXTRA_TEST_ARGS: "--exclude fortran_compiler \
-                        --exclude pen2 \
-                        --exclude tbabel"
+      EXTRA_TEST_ARGS: "-m \"not fortran\" \
+                        --ignore=tests/test_pen2.py \
+                        --ignore=tests/test_tower_of_babel.py"
       SKIP: "1"
       BLOCK: "0"
 
@@ -76,9 +76,9 @@ environment:
       PYTHON_ARCH: "32"
       CMAKE_GENERATOR: "MinGW Makefiles"
       RUN: "cmd /E:ON /V:ON /C .\\ci\\appveyor\\run.cmd"
-      EXTRA_TEST_ARGS: "--exclude fortran_compiler \
-                        --exclude pen2 \
-                        --exclude tbabel"
+      EXTRA_TEST_ARGS: "-m \"not fortran\" \
+                        --ignore=tests/test_pen2.py \
+                        --ignore=tests/test_tower_of_babel.py"
       SKIP: "1"
       BLOCK: "0"
 
@@ -88,9 +88,9 @@ environment:
       PYTHON_VERSION: "2.7.x"
       PYTHON_ARCH: "64"
       RUN: "cmd /E:ON /V:ON /C .\\ci\\appveyor\\run.cmd"
-      EXTRA_TEST_ARGS: "--exclude fortran_compiler \
-                        --exclude pen2 \
-                        --exclude tbabel"
+      EXTRA_TEST_ARGS: "-m \"not fortran\" \
+                        --ignore=tests/test_pen2.py \
+                        --ignore=tests/test_tower_of_babel.py"
       SKIP: "1"
       BLOCK: "0"
 
@@ -98,9 +98,9 @@ environment:
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
       RUN: "cmd /E:ON /V:ON /C .\\ci\\appveyor\\run.cmd"
-      EXTRA_TEST_ARGS: "--exclude fortran_compiler \
-                        --exclude pen2 \
-                        --exclude tbabel"
+      EXTRA_TEST_ARGS: "-m \"not fortran\" \
+                        --ignore=tests/test_pen2.py \
+                        --ignore=tests/test_tower_of_babel.py"
       SKIP: "1"
       BLOCK: "0"
 

--- a/ci/appveyor/driver.py
+++ b/ci/appveyor/driver.py
@@ -183,7 +183,7 @@ class Driver(object):
     def drive_test(self):
         extra_test_args = self.env.get("EXTRA_TEST_ARGS", "")
         self.check_call(
-            ["python", "setup.py", "test", "--args", "%s" % extra_test_args])
+            ["python", "setup.py", "test", "--addopts", "%s" % extra_test_args])
 
     def drive_after_test(self):
 

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ dependencies:
 
 test:
   override:
-    - python setup.py test --args="--exclude pen2"
+    - python setup.py test --addopts "--ignore=tests/test_pen2.py"
 
   post:
     - codecov -X gcov --required --file tests/coverage.xml

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -v --cov --cov-report xml

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,7 @@ codecov==2.0.5
 coverage==4.1
 cython==0.24.1
 flake8==3.0.1
-nose==1.3.7
+pytest==2.9.2
+pytest-cov==2.3.0
+pytest-runner==2.9
 six==1.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,5 @@
 [wheel]
 universal = 1
 
-[nosetests]
-exclude=project_setup_py_test
-verbosity=2
-where=tests
-with-coverage=1
-cover-xml=1
+[aliases]
+test = pytest

--- a/setup.py
+++ b/setup.py
@@ -1,36 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-commands = {}
+import sys
 
 try:
     from setuptools import setup
-    from setuptools.command.test import test as TestCommand
-
-    class NoseTestCommand(TestCommand):
-        """Command to run unit tests using nose driver after in-place build"""
-
-        user_options = TestCommand.user_options + [
-            ("args=", None, "Arguments to pass to nose"),
-        ]
-
-        def initialize_options(self):
-            self.args = []
-            TestCommand.initialize_options(self)
-
-        def finalize_options(self):
-            TestCommand.finalize_options(self)
-            if self.args:
-                self.args = __import__('shlex').split(self.args)
-
-        def run_tests(self):
-            # Run nose ensuring that argv simulates running nosetests directly
-            nose_args = ['nosetests']
-            nose_args.extend(self.args)
-            __import__('nose').run_exit(argv=nose_args)
-
-    commands["test"] = NoseTestCommand
-
 except ImportError:
     from distutils.core import setup
 
@@ -45,6 +19,13 @@ with open('requirements.txt', 'r') as fp:
 
 with open('requirements-dev.txt', 'r') as fp:
     dev_requirements = list(filter(bool, (line.strip() for line in fp)))
+
+# Require pytest-runner only when running tests
+pytest_runner = (['pytest-runner>=2.0,<3dev']
+                 if any(arg in sys.argv for arg in ('pytest', 'test'))
+                 else [])
+
+setup_requires = pytest_runner
 
 setup(
     name='scikit-build',
@@ -80,7 +61,6 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
     ],
-    test_suite='nose.collector',
     tests_require=dev_requirements,
-    cmdclass=commands
+    setup_requires=setup_requires
 )

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -8,6 +8,7 @@ Tests for platforms, to verify that CMake correctly does a test compilation.
 """
 
 import os
+import pytest
 
 from skbuild.platform_specifics import get_platform
 
@@ -50,6 +51,7 @@ def test_cxx_compiler():
         platform.cleanup_test()
 
 
+@pytest.mark.fortran
 def test_fortran_compiler():
     generator = platform.get_best_generator(languages=["Fortran"])
     # TODO: this isn't a true unit test.  It depends on the test

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist = py27, py33, py34, py35
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/skbuild
-commands = nosetests
+commands = python setup.py test
 deps =
     -r{toxinidir}/requirements.txt
-    nose


### PR DESCRIPTION
Because nose is not being maintained, switch from nose to py.test
(http://docs.pytest.org/).

From https://nose.readthedocs.io/en/latest/:

Nose has been in maintenance mode for the past several years and will likely
cease without a new person/team to take over maintainership. New projects should
consider using Nose2, py.test, or just plain unittest/unittest2.

Fixes #91 