### PR TITLE
ci/travis: allow failures on Linux/Python 3.3 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,10 @@ matrix:
         - PYTHONVERSION=2.7.12
         - EXTRA_TEST_ARGS="--ignore=tests/test_pen2.py --ignore=tests/test_tower_of_babel.py"
 
+  allow_failures:
+    - os: linux
+      python: "3.3"
+
 
 before_script:
   - "\


### PR DESCRIPTION
Allow failures on Linux/Python 3.3 builds until the following Travis CI issue is resolved:

https://github.com/travis-ci/travis-ci/issues/6437