### PR TITLE
ci/appveyor: Fix typo in codecov command line

### DIFF
--- a/ci/appveyor/driver.py
+++ b/ci/appveyor/driver.py
@@ -189,7 +189,7 @@ class Driver(object):
 
         script_dir = os.path.join(self.env["PYTHON"], "Scripts")
         self.check_call([
-            os.path.join(script_dir, "codecov.exe"), "-X", "gcov", "-required",
+            os.path.join(script_dir, "codecov.exe"), "-X", "gcov", "--required",
             "--file", ".\\tests\\coverage.xml"])
 
         self.check_call(["python", "setup.py", "bdist_wheel"])


### PR DESCRIPTION
Submitting to codecov fails on AppVeyor because of a typo in the command line. Instead of passing `--required`, we are passing `-required`, which is interpreted as the `-r` argument (`--slug SLUG, -r SLUG  Specify repository slug for Enterprise ex. owner/repo`).

See https://ci.appveyor.com/project/scikit-build/scikit-build/build/0.0.1.61/job/kf2norwb3pe5l2by#L221 as an example failure.