### PR TITLE
factor out custom command logic to mixins

### DIFF
--- a/skbuild/command/__init__.py
+++ b/skbuild/command/__init__.py
@@ -1,0 +1,23 @@
+
+from .. import cmaker
+
+
+class set_build_base_mixin(object):
+    def finalize_options(self, *args, **kwargs):
+        try:
+            if not self.build_base or self.build_base == 'build':
+                self.build_base = cmaker.SETUPTOOLS_INSTALL_DIR
+        except AttributeError:
+            pass
+
+        super(set_build_base_mixin, self).finalize_options(*args, **kwargs)
+
+
+# distutils/setuptools command classes are old-style classes, which won't work
+# with mixins.  To work around this limitation, we dynamically convert them to
+# new style classes by creating a new class that inherits from them and also
+# <object>.  This ensures that <object> is always at the end of the MRO, even
+# after being mixed in with other classes.
+
+def new_style(klass):
+    return type("NewStyleClass<{}>".format(klass.__name__), (klass, object), {})

--- a/skbuild/command/bdist.py
+++ b/skbuild/command/bdist.py
@@ -4,14 +4,8 @@ try:
 except ImportError:
     from distutils.command.bdist import bdist as _bdist
 
-from .. import cmaker
+from . import new_style, set_build_base_mixin
 
 
-class bdist(_bdist):
-    def finalize_options(self):
-        try:
-            if not self.build_base or self.build_base == 'build':
-                self.build_base = cmaker.SETUPTOOLS_INSTALL_DIR
-        except AttributeError:
-            pass
-        _bdist.finalize_options(self)
+class bdist(set_build_base_mixin, new_style(_bdist)):
+    pass

--- a/skbuild/command/bdist_wheel.py
+++ b/skbuild/command/bdist_wheel.py
@@ -1,14 +1,8 @@
 
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
-from .. import cmaker
+from . import new_style, set_build_base_mixin
 
 
-class bdist_wheel(_bdist_wheel):
-    def finalize_options(self):
-        try:
-            if not self.build_base or self.build_base == 'build':
-                self.build_base = cmaker.SETUPTOOLS_INSTALL_DIR
-        except AttributeError:
-            pass
-        _bdist_wheel.finalize_options(self)
+class bdist_wheel(set_build_base_mixin, new_style(_bdist_wheel)):
+    pass

--- a/skbuild/command/build.py
+++ b/skbuild/command/build.py
@@ -4,14 +4,8 @@ try:
 except ImportError:
     from distutils.command.build import build as _build
 
-from .. import cmaker
+from . import new_style, set_build_base_mixin
 
 
-class build(_build):
-    def finalize_options(self):
-        try:
-            if not self.build_base or self.build_base == 'build':
-                self.build_base = cmaker.SETUPTOOLS_INSTALL_DIR
-        except AttributeError:
-            pass
-        _build.finalize_options(self)
+class build(set_build_base_mixin, new_style(_build)):
+    pass

--- a/skbuild/command/clean.py
+++ b/skbuild/command/clean.py
@@ -8,21 +8,13 @@ from shutil import rmtree
 
 from distutils import log
 
+from . import new_style, set_build_base_mixin
 from .. import cmaker
 
 
-class clean(_clean):
-    def finalize_options(self):
-        try:
-            if not self.build_base or self.build_base == 'build':
-                self.build_base = cmaker.SETUPTOOLS_INSTALL_DIR
-        except AttributeError:
-            pass
-
-        _clean.finalize_options(self)
-
+class clean(set_build_base_mixin, new_style(_clean)):
     def run(self):
-        _clean.run(self)
+        super(clean, self).run()
         for dir_ in (cmaker.CMAKE_INSTALL_DIR,
                      cmaker.CMAKE_BUILD_DIR,
                      cmaker.SKBUILD_DIR):

--- a/skbuild/command/egg_info.py
+++ b/skbuild/command/egg_info.py
@@ -3,12 +3,14 @@ import os
 
 from setuptools.command.egg_info import egg_info as _egg_info
 
+from . import new_style, set_build_base_mixin
 
-class egg_info(_egg_info):
+
+class egg_info(set_build_base_mixin, new_style(_egg_info)):
     def finalize_options(self):
         if self.egg_base is not None:
             script_path = os.path.abspath(self.distribution.script_name)
             script_dir = os.path.dirname(script_path)
             self.egg_base = os.path.join(script_dir, self.egg_base)
 
-        _egg_info.finalize_options(self)
+        super(egg_info, self).finalize_options()

--- a/skbuild/command/install.py
+++ b/skbuild/command/install.py
@@ -4,14 +4,8 @@ try:
 except ImportError:
     from distutils.command.install import install as _install
 
-from .. import cmaker
+from . import new_style, set_build_base_mixin
 
 
-class install(_install):
-    def finalize_options(self):
-        try:
-            if not self.build_base or self.build_base == 'build':
-                self.build_base = cmaker.SETUPTOOLS_INSTALL_DIR
-        except AttributeError:
-            pass
-        _install.finalize_options(self)
+class install(set_build_base_mixin, new_style(_install)):
+    pass


### PR DESCRIPTION
Removes code that was duplicated across multiple custom command classes and replaces it with a mixin solution.  Eliminates duplication and should also help with coverage numbers.

One technical challenge is that distutils/setuptools command classes are old-style classes, which don't work with mixins.  This PR addresses the challenge by introducing a small wrapper function that takes an old-style class and produces an equivalent new-style class.

Also, replaces superclass calls with proper uses of `super`.