### PR TITLE
WIP: ci/travis: remove workaround to allow failures on Linux/Python 3.3 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
         - RUN=
 
     - os: linux
-      python: "3.3"
+      python: "3.3.5"
       env:
         - RUN=
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,6 @@ matrix:
       env:
         - PYTHONVERSION=2.7.12 RUN=./ci/travis/run.bash
 
-  allow_failures:
-    - os: linux
-      python: "3.3"
-
 addons:
   apt:
     packages:


### PR DESCRIPTION
Test the fix for https://github.com/travis-ci/travis-ci/issues/6437.