### PR TITLE
Implement source distributions. fixes #84

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -164,4 +164,4 @@ notifications:
       [Build {{&projectName}} {{buildVersion}} {{status}}]({{buildUrl}})
       (commit {{commitUrl}} by @{{&commitAuthorUsername}})
 
-shallow_clone: true
+shallow_clone: false

--- a/ci/appveyor_driver.py
+++ b/ci/appveyor_driver.py
@@ -97,14 +97,6 @@ class AppveyorDriver(Driver):
 
         self.env_prepend("PATH", "C:\\cmake\bin")
 
-        # restore git repo information (needed for skbuild source dists)
-        repo_url = "git://github.com/{}".format(self.env["APPVEYOR_REPO_NAME"])
-        commit_hash = self.env["APPVEYOR_REPO_COMMIT"]
-        self.check_call(["git", "init"])
-        self.check_call(["git", "remote", "add", "origin", repo_url])
-        self.check_call(["git", "fetch", "--all", "--prune"])
-        self.check_call(["git", "reset", "--hard", commit_hash])
-
         Driver.drive_install(self)
 
     def drive_after_test(self):

--- a/ci/appveyor_driver.py
+++ b/ci/appveyor_driver.py
@@ -97,6 +97,14 @@ class AppveyorDriver(Driver):
 
         self.env_prepend("PATH", "C:\\cmake\bin")
 
+        # restore git repo information (needed for skbuild source dists)
+        repo_url = "git://github.com/{}".format(self.env["APPVEYOR_REPO_NAME"])
+        commit_hash = self.env["APPVEYOR_REPO_COMMIT"]
+        self.check_call(["git", "init"])
+        self.check_call(["git", "remote", "add", "origin", repo_url])
+        self.check_call(["git", "fetch", "--all", "--prune"])
+        self.check_call(["git", "reset", "--hard", commit_hash])
+
         Driver.drive_install(self)
 
     def drive_after_test(self):

--- a/skbuild/command/egg_info.py
+++ b/skbuild/command/egg_info.py
@@ -37,7 +37,7 @@ class egg_info(set_build_base_mixin, new_style(_egg_info)):
 
         if do_generate:
             try:
-                with open('MANIFEST', 'w') as file:
+                with open('MANIFEST', 'wb') as file:
                     file.write(
                         subprocess.check_output(
                             ['git', 'ls-tree', '--name-only', '-r', 'HEAD'])

--- a/skbuild/command/egg_info.py
+++ b/skbuild/command/egg_info.py
@@ -45,9 +45,10 @@ class egg_info(set_build_base_mixin, new_style(_egg_info)):
             except subprocess.CalledProcessError:
                 sys.stderr.write(
                     '\n\n'
-                    'scikit-build tried to generate a MANIFEST '
-                    'file, but could not because the files to include could '
-                    'not be inferred.\n\n'
+                    'Since scikit-build could not find MANIFEST.in or '
+                    'MANIFEST, it tried to generate a MANIFEST file '
+                    'automatically, but could not because it could not '
+                    'determine which source files to include.\n\n'
                     'The command used was "git ls-tree --name-only -r HEAD"\n'
                     '\n\n'
                 )

--- a/skbuild/command/egg_info.py
+++ b/skbuild/command/egg_info.py
@@ -1,12 +1,63 @@
 
 import os
+import os.path
+import subprocess
+import sys
 
 from setuptools.command.egg_info import egg_info as _egg_info
 
 from . import new_style, set_build_base_mixin
+from ..cmaker import SKBUILD_DIR
 
+SKBUILD_MARKER_FILE = os.path.join(SKBUILD_DIR, "_skbuild_MANIFEST")
 
 class egg_info(set_build_base_mixin, new_style(_egg_info)):
+    def run(self):
+        # If neither a MANIFEST, nor a a MANIFEST.in file is provided, and we
+        # are in a git repo, try to create a MANIFEST file from the output of
+        # `git ls-tree --name-only -r HEAD`.
+        #
+        # We need a reliable way to tell if an existing MANIFEST file is one
+        # we've generated.  distutils already uses a first-line comment to tell
+        # if the MANIFEST file was generated from MANIFEST.in, so we use a dummy
+        # file, "_skbuild_MANIFEST", to avoid confusing distutils.
+
+        do_generate = (
+            # If there's a MANIFEST.in file, we assume that we had nothing to do
+            # with the project's manifest.
+            not os.path.exists('MANIFEST.in')
+
+            # otherwise, we check to see that there is no MANIFEST, ...
+            or not os.path.exists('MANIFEST') # ... or ...
+
+            # ... (if there is one,) that we created it
+            or os.path.exists(SKBUILD_MARKER_FILE)
+        )
+
+        if do_generate:
+            try:
+                with open('MANIFEST', 'w') as file:
+                    file.write(
+                        subprocess.check_output(
+                            ['git', 'ls-tree', '--name-only', '-r', 'HEAD'])
+                    )
+            except subprocess.CalledProcessError:
+                sys.stderr.write(
+                    '\n\n'
+                    'scikit-build tried to generate a MANIFEST '
+                    'file, but could not because the files to include could '
+                    'not be inferred.\n\n'
+                    'The command used was "git ls-tree --name-only -r HEAD"\n'
+                    '\n\n'
+                )
+
+                raise
+
+            with open(SKBUILD_MARKER_FILE, 'w') as file: # touch
+                pass
+
+        super(egg_info, self).run()
+
     def finalize_options(self):
         if self.egg_base is not None:
             script_path = os.path.abspath(self.distribution.script_name)

--- a/skbuild/command/egg_info.py
+++ b/skbuild/command/egg_info.py
@@ -11,6 +11,7 @@ from ..cmaker import SKBUILD_DIR
 
 SKBUILD_MARKER_FILE = os.path.join(SKBUILD_DIR, "_skbuild_MANIFEST")
 
+
 class egg_info(set_build_base_mixin, new_style(_egg_info)):
     def run(self):
         # If neither a MANIFEST, nor a a MANIFEST.in file is provided, and we
@@ -28,7 +29,7 @@ class egg_info(set_build_base_mixin, new_style(_egg_info)):
             not os.path.exists('MANIFEST.in')
 
             # otherwise, we check to see that there is no MANIFEST, ...
-            or not os.path.exists('MANIFEST') # ... or ...
+            or not os.path.exists('MANIFEST')  # ... or ...
 
             # ... (if there is one,) that we created it
             or os.path.exists(SKBUILD_MARKER_FILE)
@@ -53,7 +54,7 @@ class egg_info(set_build_base_mixin, new_style(_egg_info)):
 
                 raise
 
-            with open(SKBUILD_MARKER_FILE, 'w') as file: # touch
+            with open(SKBUILD_MARKER_FILE, 'w') as file:  # touch
                 pass
 
         super(egg_info, self).run()

--- a/skbuild/command/sdist.py
+++ b/skbuild/command/sdist.py
@@ -1,0 +1,8 @@
+
+from distutils.command.sdist import sdist as _sdist
+
+from . import new_style, set_build_base_mixin
+
+class sdist(set_build_base_mixin, new_style(_sdist)):
+    pass
+

--- a/skbuild/command/sdist.py
+++ b/skbuild/command/sdist.py
@@ -3,6 +3,6 @@ from distutils.command.sdist import sdist as _sdist
 
 from . import new_style, set_build_base_mixin
 
+
 class sdist(set_build_base_mixin, new_style(_sdist)):
     pass
-

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -8,7 +8,7 @@ import sys
 import argparse
 
 from . import cmaker
-from .command import build, install, clean, bdist, bdist_wheel, egg_info
+from .command import build, install, clean, bdist, bdist_wheel, egg_info, sdist
 from .exceptions import SKBuildError
 
 try:
@@ -202,6 +202,7 @@ def setup(*args, **kw):
     cmdclass['build'] = cmdclass.get('build', build.build)
     cmdclass['install'] = cmdclass.get('install', install.install)
     cmdclass['clean'] = cmdclass.get('clean', clean.clean)
+    cmdclass['sdist'] = cmdclass.get('sdist', sdist.sdist)
     cmdclass['bdist'] = cmdclass.get('bdist', bdist.bdist)
     cmdclass['bdist_wheel'] = cmdclass.get(
         'bdist_wheel', bdist_wheel.bdist_wheel)

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -25,8 +25,9 @@ def test_hello_builds():
 
 @project_setup_py_test(("samples", "hello"), ["sdist"])
 def test_hello_sdist():
-    sdists = glob.glob('dist/*.tar.gz')
-    assert sdists
+    sdists_tar = glob.glob('dist/*.tar.gz')
+    sdists_zip = glob.glob('dist/*.zip')
+    assert sdists_tar or sdists_zip
 
 
 @project_setup_py_test(("samples", "hello"), ["bdist_wheel"])

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -23,6 +23,11 @@ def test_hello_builds():
 #     pass
 
 
+@project_setup_py_test(("samples", "hello"), ["sdist"])
+def test_hello_sdist():
+    sdists = glob.glob('dist/*.tar.gz')
+    assert sdists
+
 @project_setup_py_test(("samples", "hello"), ["bdist_wheel"])
 def test_hello_wheel():
     whls = glob.glob('dist/*.whl')

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -28,6 +28,7 @@ def test_hello_sdist():
     sdists = glob.glob('dist/*.tar.gz')
     assert sdists
 
+
 @project_setup_py_test(("samples", "hello"), ["bdist_wheel"])
 def test_hello_wheel():
     whls = glob.glob('dist/*.whl')

--- a/tests/test_hello_cython.py
+++ b/tests/test_hello_cython.py
@@ -21,6 +21,10 @@ def test_hello_cython_builds():
 # def test_hello_cython_works():
 #     pass
 
+@project_setup_py_test(("samples", "hello-cython"), ["sdist"])
+def test_hello_cython_sdist():
+    sdists = glob.glob('dist/*.tar.gz')
+    assert sdists
 
 @project_setup_py_test(("samples", "hello-cython"), ["bdist_wheel"])
 def test_hello_cython_wheel():

--- a/tests/test_hello_cython.py
+++ b/tests/test_hello_cython.py
@@ -24,8 +24,9 @@ def test_hello_cython_builds():
 
 @project_setup_py_test(("samples", "hello-cython"), ["sdist"])
 def test_hello_cython_sdist():
-    sdists = glob.glob('dist/*.tar.gz')
-    assert sdists
+    sdists_tar = glob.glob('dist/*.tar.gz')
+    sdists_zip = glob.glob('dist/*.zip')
+    assert sdists_tar or sdists_zip
 
 
 @project_setup_py_test(("samples", "hello-cython"), ["bdist_wheel"])

--- a/tests/test_hello_cython.py
+++ b/tests/test_hello_cython.py
@@ -21,10 +21,12 @@ def test_hello_cython_builds():
 # def test_hello_cython_works():
 #     pass
 
+
 @project_setup_py_test(("samples", "hello-cython"), ["sdist"])
 def test_hello_cython_sdist():
     sdists = glob.glob('dist/*.tar.gz')
     assert sdists
+
 
 @project_setup_py_test(("samples", "hello-cython"), ["bdist_wheel"])
 def test_hello_cython_wheel():

--- a/tests/test_skbuild_variable.py
+++ b/tests/test_skbuild_variable.py
@@ -26,6 +26,7 @@ def test_skbuild_variable_builds():
 def test_skbuild_variable_sdist():
     pass
 
+
 @project_setup_py_test(("samples", "fail-unless-skbuild-set"), ["bdist_wheel"])
 def test_skbuild_variable_wheel():
     pass

--- a/tests/test_skbuild_variable.py
+++ b/tests/test_skbuild_variable.py
@@ -22,6 +22,9 @@ def test_skbuild_variable_builds():
 # def test_skbuild_variable_works():
 #     pass
 
+@project_setup_py_test(("samples", "fail-unless-skbuild-set"), ["sdist"])
+def test_skbuild_variable_sdist():
+    pass
 
 @project_setup_py_test(("samples", "fail-unless-skbuild-set"), ["bdist_wheel"])
 def test_skbuild_variable_wheel():


### PR DESCRIPTION
Implements the `sdist` command for creating source distributions.
Uses the `sdist` command class from *distutils* (not setuptools).

Basically, it works by just jumping ahead of distutils' `sdist` logic and creating a MANIFEST file if the project does not provide its own.

This will only work within a git repo, since the implementation relies on the output of `git ls-files` to determine what files to include in the source distribution.

This implementation makes for some undesirable quirks, such as the output from `python setup.py sdist --help` being incorrect, but should suffice for the main source distribution needs for projects.