### PR TITLE
setuptools_wrap: Remove unneeded "is_pure" method, add test_setup

### DIFF
--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -276,9 +276,6 @@ def setup(*args, **kw):
 
     # Adapted from espdev/ITKPythonInstaller/setup.py.in
     class BinaryDistribution(upstream_Distribution):
-        def is_pure(self):
-            return False
-
         def has_ext_modules(self):
             return True
     kw['distclass'] = BinaryDistribution

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""test_setup
+----------------------------------
+
+Tests for `skbuild.setup` function.
+"""
+
+from distutils.core import Distribution as distutils_Distribution
+from setuptools import Distribution as setuptool_Distribution
+
+from skbuild import setup as skbuild_setup
+
+from . import push_argv
+
+
+def test_distribution_object():
+
+    with push_argv(["setup.py", "--name"]):
+        distribution = skbuild_setup(
+            name="test_distribution_type",
+            version="0.0.1",
+            description=(
+                "test object returned by setup function"),
+            author="The scikit-build team",
+            license="MIT",
+        )
+        assert issubclass(distribution.__class__,
+                          (distutils_Distribution, setuptool_Distribution))
+
+        assert not distribution.is_pure()


### PR DESCRIPTION
Since the implementation of is_pure() in both py2 and py3 is as reported
below, implementation has_ext_modules() is enough to ensure is_pure()
will always return False.

This commit also adds a test (1) checking the type of object returned
by the skbuild.setup and (2) ensuring is_pure() return False

```
def is_pure(self):
    return (self.has_pure_modules() and
            not self.has_ext_modules() and
            not self.has_c_libraries())
```