### PR TITLE
skbuild: Do not raise error if running clean command twice

### DIFF
--- a/skbuild/command/clean.py
+++ b/skbuild/command/clean.py
@@ -1,4 +1,6 @@
 
+import os
+
 try:
     from setuptools.command.clean import clean as _clean
 except ImportError:
@@ -18,6 +20,7 @@ class clean(set_build_base_mixin, new_style(_clean)):
         for dir_ in (cmaker.CMAKE_INSTALL_DIR,
                      cmaker.CMAKE_BUILD_DIR,
                      cmaker.SKBUILD_DIR):
-            log.info("removing '%s'", dir_)
-            if not self.dry_run:
+            if os.path.exists(dir_):
+                log.info("removing '%s'", dir_)
+            if not self.dry_run and os.path.exists(dir_):
                 rmtree(dir_)

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -126,3 +126,38 @@ def test_hello_clean(dry_run, capfd):
         build_out, clean_out = capfd.readouterr()[0].split('<<-->>')
         assert 'Build files have been written to' in build_out
         assert 'Build files have been written to' not in clean_out
+
+
+def test_hello_cleans(capfd):
+    with push_dir():
+
+        @project_setup_py_test(("samples", "hello"), ["build"],
+                               clear_cache=True)
+        def run_build():
+            pass
+
+        @project_setup_py_test(("samples", "hello"), ["clean"])
+        def run_clean():
+            pass
+
+        # Check that a project can be cleaned twice in a row
+        run_build()
+        print("<<-->>")
+        run_clean()
+        print("<<-->>")
+        run_clean()
+
+    _, clean1_out, clean2_out = \
+        capfd.readouterr()[0].split('<<-->>')
+
+    clean1_out = clean1_out.strip()
+    clean2_out = clean2_out.strip()
+
+    assert "running clean" == clean1_out.splitlines()[0]
+    assert "removing '_skbuild{}cmake-install'".format(os.path.sep) \
+           == clean1_out.splitlines()[1]
+    assert "removing '_skbuild{}cmake-build'".format(os.path.sep) \
+           == clean1_out.splitlines()[2]
+    assert "removing '_skbuild'" == clean1_out.splitlines()[3]
+
+    assert "running clean" == clean2_out


### PR DESCRIPTION
This commit prevents this error from being reported if clean command
is executed twice:

```
running clean
removing '_skbuild/cmake-install'
error: [Errno 2] No such file or directory: '_skbuild/cmake-install'
```