### PR TITLE
Run setup test in dedicated tmpdir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,4 @@ docs/_build
 
 # build output (testing)
 skbuild/_cmake_test_compile/*
-tests/samples/*/_cmake_test_compile/*
-tests/samples/*/MANIFEST
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,15 +1,17 @@
 # -*- coding: utf-8 -*-
 
-import distutils.dir_util
+import _pytest.tmpdir
 import os
 import os.path
-import shutil
+import py.path
+import re
 import six
+import subprocess
 import sys
+
 
 from contextlib import contextmanager
 
-from skbuild.cmaker import SKBUILD_DIR
 from skbuild.utils import push_dir
 
 
@@ -43,27 +45,108 @@ def push_env(**kwargs):
         os.environ[saved_var] = saved_value
 
 
-def project_setup_py_test(project, setup_args, clear_cache=False):
+def _tmpdir(basename):
+    """This function returns a temporary directory similar to the one
+    returned by the ``tmpdir`` pytest fixture.
+    The difference is that the `basetemp` is not configurable using
+    the pytest settings."""
+
+    # Adapted from _pytest.tmpdir.tmpdir()
+    basename = re.sub("[\W]", "_", basename)
+    max_val = 30
+    if len(basename) > max_val:
+        basename = basename[:max_val]
+
+    # Adapted from _pytest.tmpdir.TempdirFactory.getbasetemp()
+    try:
+        basetemp = _tmpdir._basetemp
+    except AttributeError:
+        temproot = py.path.local.get_temproot()
+        user = _pytest.tmpdir.get_user()
+
+        if user:
+            # use a sub-directory in the temproot to speed-up
+            # make_numbered_dir() call
+            rootdir = temproot.join('pytest-of-%s' % user)
+        else:
+            rootdir = temproot
+
+        rootdir.ensure(dir=1)
+        basetemp = py.path.local.make_numbered_dir(prefix='pytest-',
+                                                   rootdir=rootdir)
+
+    # Adapted from _pytest.tmpdir.TempdirFactory.mktemp
+    return py.path.local.make_numbered_dir(prefix=basename,
+                                           keep=0, rootdir=basetemp,
+                                           lock_timeout=None)
+
+
+def _copy_dir(target_dir, entry, on_duplicate='exception', keep_top_dir=False):
+
+    if isinstance(entry, six.string_types):
+        entry = py.path.local(entry)
+
+    # Copied from pytest-datafiles/pytest_datafiles.py (MIT License)
+    basename = entry.basename
+    if keep_top_dir:
+        if on_duplicate == 'overwrite' or not (target_dir / basename).exists():
+            entry.copy(target_dir / basename)
+        elif on_duplicate == 'exception':
+            raise ValueError(
+                "'%s' already exists (entry %s)" % (basename, entry)
+                )
+        # else: on_duplicate == 'ignore': do nothing with entry
+    else:
+        # Regular directory (no keep_top_dir). Need to check every file
+        # for duplicates
+        if on_duplicate == 'overwrite':
+            entry.copy(target_dir)
+            return
+        for sub_entry in entry.listdir():
+            if not (target_dir / sub_entry.basename).exists():
+                sub_entry.copy(target_dir / sub_entry.basename)
+                continue
+            if on_duplicate == 'exception':
+                # target exists
+                raise ValueError(
+                    "'%s' already exists (entry %s)" % (
+                        (target_dir / sub_entry.basename),
+                        sub_entry,
+                        )
+                    )
+            # on_duplicate == 'ignore': do nothing with e2
+
+
+def project_setup_py_test(project, setup_args, tmp_dir=None):
 
     def dec(fun):
 
         @six.wraps(fun)
         def wrapped(*iargs, **ikwargs):
 
-            # Clear distutils.dir_util.mkpath() cache
-            # See issue scikit-build#120
-            distutils.dir_util._path_created = {}
+            # If requested, make temp directory
+            if wrapped.tmp_dir is None:
+                project_dir = os.path.join(SAMPLES_DIR, wrapped.project)
 
-            dir = os.path.join(SAMPLES_DIR, wrapped.project)
+                wrapped.tmp_dir = _tmpdir(fun.__name__)
 
-            with push_dir(dir), push_argv(["setup.py"] + wrapped.setup_args):
+                # Copy files only if temp directory  was not
+                # explicitly provided.
+                _copy_dir(wrapped.tmp_dir, project_dir)
 
-                if wrapped.clear_cache:
-                    # XXX We assume dist_dir is not customized
-                    dest_dir = 'dist'
-                    for dir_to_remove in [SKBUILD_DIR, dest_dir]:
-                        if os.path.exists(dir_to_remove):
-                            shutil.rmtree(dir_to_remove)
+                # Initialize git
+                with push_dir(str(wrapped.tmp_dir)):
+                    for cmd in [
+                        ['git', 'init'],
+                        ['git', 'config', 'user.name', 'scikit-build'],
+                        ['git', 'config', 'user.email', 'test@test'],
+                        ['git', 'add', '-A'],
+                        ['git', 'commit', '-m', 'Initial commit']
+                    ]:
+                        subprocess.check_call(cmd)
+
+            with push_dir(str(wrapped.tmp_dir)),\
+                    push_argv(["setup.py"] + wrapped.setup_args):
 
                 setup_code = None
                 with open("setup.py", "r") as fp:
@@ -74,11 +157,11 @@ def project_setup_py_test(project, setup_args, clear_cache=False):
 
                 result2 = fun(*iargs, **ikwargs)
 
-            return result2
+            return wrapped.tmp_dir, result2
 
         wrapped.project = project
         wrapped.setup_args = setup_args
-        wrapped.clear_cache = clear_cache
+        wrapped.tmp_dir = tmp_dir
 
         return wrapped
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,6 +13,12 @@ from skbuild.cmaker import SKBUILD_DIR
 from skbuild.utils import push_dir
 
 
+SAMPLES_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    'samples',
+    )
+
+
 @contextmanager
 def push_argv(argv):
     old_argv = sys.argv
@@ -48,9 +54,7 @@ def project_setup_py_test(project, setup_args, clear_cache=False):
             # See issue scikit-build#120
             distutils.dir_util._path_created = {}
 
-            dir = list(wrapped.project)
-            dir.insert(0, os.path.dirname(os.path.abspath(__file__)))
-            dir = os.path.join(*dir)
+            dir = os.path.join(SAMPLES_DIR, wrapped.project)
 
             with push_dir(dir), push_argv(["setup.py"] + wrapped.setup_args):
 

--- a/tests/test_broken_project.py
+++ b/tests/test_broken_project.py
@@ -11,7 +11,7 @@ its value.
 
 import pytest
 
-from subprocess import CalledProcessError
+from subprocess import (check_call, CalledProcessError)
 
 from skbuild.exceptions import SKBuildError
 from skbuild.platform_specifics import get_platform
@@ -25,9 +25,7 @@ def test_cmakelists_with_fatalerror_fails(capfd):
 
     with push_dir():
 
-        @project_setup_py_test("fail-with-fatal-error-cmakelists",
-                               ["build"],
-                               clear_cache=True)
+        @project_setup_py_test("fail-with-fatal-error-cmakelists", ["build"])
         def should_fail():
             pass
 
@@ -50,9 +48,7 @@ def test_cmakelists_with_syntaxerror_fails(capfd):
 
     with push_dir():
 
-        @project_setup_py_test("fail-with-syntax-error-cmakelists",
-                               ["build"],
-                               clear_cache=True)
+        @project_setup_py_test("fail-with-syntax-error-cmakelists", ["build"])
         def should_fail():
             pass
 
@@ -75,9 +71,7 @@ def test_hello_with_compileerror_fails(capfd):
 
     with push_dir():
 
-        @project_setup_py_test("fail-hello-with-compile-error",
-                               ["build"],
-                               clear_cache=True)
+        @project_setup_py_test("fail-hello-with-compile-error", ["build"])
         def should_fail():
             pass
 
@@ -116,8 +110,7 @@ def test_invalid_cmake(exception, mocker):
 
     with push_dir():
 
-        @project_setup_py_test("hello", ["build"],
-                               clear_cache=True)
+        @project_setup_py_test("hello", ["build"])
         def should_fail():
             pass
 
@@ -144,8 +137,7 @@ def test_first_invalid_generator(mocker, capfd):
     mocker.patch('skbuild.cmaker.get_platform', return_value=platform)
 
     with push_dir(), push_env(CMAKE_GENERATOR=None):
-        @project_setup_py_test("hello", ["build"],
-                               clear_cache=True)
+        @project_setup_py_test("hello", ["build"])
         def run_build():
             pass
 
@@ -163,8 +155,7 @@ def test_invalid_generator(mocker, capfd):
     mocker.patch('skbuild.cmaker.get_platform', return_value=platform)
 
     with push_dir(), push_env(CMAKE_GENERATOR=None):
-        @project_setup_py_test("hello", ["build"],
-                               clear_cache=True)
+        @project_setup_py_test("hello", ["build"])
         def should_fail():
             pass
 

--- a/tests/test_broken_project.py
+++ b/tests/test_broken_project.py
@@ -25,7 +25,7 @@ def test_cmakelists_with_fatalerror_fails(capfd):
 
     with push_dir():
 
-        @project_setup_py_test(("samples", "fail-with-fatal-error-cmakelists"),
+        @project_setup_py_test("fail-with-fatal-error-cmakelists",
                                ["build"],
                                clear_cache=True)
         def should_fail():
@@ -50,7 +50,7 @@ def test_cmakelists_with_syntaxerror_fails(capfd):
 
     with push_dir():
 
-        @project_setup_py_test(("samples", "fail-with-syntax-error-cmakelists"),
+        @project_setup_py_test("fail-with-syntax-error-cmakelists",
                                ["build"],
                                clear_cache=True)
         def should_fail():
@@ -75,7 +75,7 @@ def test_hello_with_compileerror_fails(capfd):
 
     with push_dir():
 
-        @project_setup_py_test(("samples", "fail-hello-with-compile-error"),
+        @project_setup_py_test("fail-hello-with-compile-error",
                                ["build"],
                                clear_cache=True)
         def should_fail():
@@ -109,7 +109,7 @@ def test_invalid_cmake(exception, mocker):
 
     with push_dir():
 
-        @project_setup_py_test(("samples", "hello"), ["build"],
+        @project_setup_py_test("hello", ["build"],
                                clear_cache=True)
         def should_fail():
             pass
@@ -137,7 +137,7 @@ def test_first_invalid_generator(mocker, capfd):
     mocker.patch('skbuild.cmaker.get_platform', return_value=platform)
 
     with push_dir(), push_env(CMAKE_GENERATOR=None):
-        @project_setup_py_test(("samples", "hello"), ["build"],
+        @project_setup_py_test("hello", ["build"],
                                clear_cache=True)
         def run_build():
             pass
@@ -156,7 +156,7 @@ def test_invalid_generator(mocker, capfd):
     mocker.patch('skbuild.cmaker.get_platform', return_value=platform)
 
     with push_dir(), push_env(CMAKE_GENERATOR=None):
-        @project_setup_py_test(("samples", "hello"), ["build"],
+        @project_setup_py_test("hello", ["build"],
                                clear_cache=True)
         def should_fail():
             pass

--- a/tests/test_broken_project.py
+++ b/tests/test_broken_project.py
@@ -104,8 +104,15 @@ def test_invalid_cmake(exception, mocker):
         CalledProcessError: CalledProcessError(['cmake', '--version'], 1)
     }
 
-    mocker.patch('subprocess.check_call',
-                 side_effect=exceptions[exception])
+    check_call_original = check_call
+
+    def check_call_mock(*args, **kwargs):
+        if args[0] == ['cmake', '--version']:
+            raise exceptions[exception]
+        check_call_original(*args, **kwargs)
+
+    mocker.patch('skbuild.cmaker.subprocess.check_call',
+                 new=check_call_mock)
 
     with push_dir():
 

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -14,7 +14,7 @@ from skbuild.utils import push_dir
 from . import project_setup_py_test
 
 
-@project_setup_py_test(("samples", "hello"), ["--help"])
+@project_setup_py_test("hello", ["--help"])
 def test_help(capsys):
     out, err = capsys.readouterr()
     assert "scikit-build options" not in out
@@ -22,7 +22,7 @@ def test_help(capsys):
     assert "usage:" in out
 
 
-@project_setup_py_test(("samples", "hello"), ["--help-commands"])
+@project_setup_py_test("hello", ["--help-commands"])
 def test_help_commands(capsys):
     out, err = capsys.readouterr()
     assert "scikit-build options" in out
@@ -31,7 +31,7 @@ def test_help_commands(capsys):
     assert "usage:" in out
 
 
-@project_setup_py_test(("samples", "hello"), ["--author", "--name"])
+@project_setup_py_test("hello", ["--author", "--name"])
 def test_metadata_display(capsys):
     out, err = capsys.readouterr()
     assert "scikit-build options" not in out
@@ -44,7 +44,7 @@ def test_metadata_display(capsys):
 def test_no_command():
     with push_dir():
 
-        @project_setup_py_test(("samples", "hello"), [],
+        @project_setup_py_test("hello", [],
                                clear_cache=True)
         def run():
             pass
@@ -63,7 +63,7 @@ def test_invalid_command():
 
     with push_dir():
 
-        @project_setup_py_test(("samples", "hello"), ["unknown"],
+        @project_setup_py_test("hello", ["unknown"],
                                clear_cache=True)
         def run():
             pass
@@ -81,7 +81,7 @@ def test_invalid_command():
 def test_too_many_separators():
     with push_dir():
 
-        @project_setup_py_test(("samples", "hello"), ["--"] * 3)
+        @project_setup_py_test("hello", ["--"] * 3)
         def run():
             pass
 
@@ -94,7 +94,7 @@ def test_too_many_separators():
         assert failed
 
 
-@project_setup_py_test(("samples", "hello"),
+@project_setup_py_test("hello",
                        ["build", "--", "-DMY_CMAKE_VARIABLE:BOOL=1"],
                        clear_cache=True)
 def test_cmake_args(capfd):

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -44,8 +44,7 @@ def test_metadata_display(capsys):
 def test_no_command():
     with push_dir():
 
-        @project_setup_py_test("hello", [],
-                               clear_cache=True)
+        @project_setup_py_test("hello", [])
         def run():
             pass
 
@@ -63,8 +62,7 @@ def test_invalid_command():
 
     with push_dir():
 
-        @project_setup_py_test("hello", ["unknown"],
-                               clear_cache=True)
+        @project_setup_py_test("hello", ["unknown"])
         def run():
             pass
 
@@ -95,8 +93,7 @@ def test_too_many_separators():
 
 
 @project_setup_py_test("hello",
-                       ["build", "--", "-DMY_CMAKE_VARIABLE:BOOL=1"],
-                       clear_cache=True)
+                       ["build", "--", "-DMY_CMAKE_VARIABLE:BOOL=1"])
 def test_cmake_args(capfd):
     out, err = capfd.readouterr()
     assert "Manually-specified variables were not used by the project" in err

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+"""test_hello
+----------------------------------
+
+Tries to build and test the `hello` sample project.
+"""
+
 import glob
 import os
 import pytest
@@ -13,20 +19,14 @@ from skbuild.utils import push_dir
 
 from zipfile import ZipFile
 
-"""test_hello
-----------------------------------
-
-Tries to build and test the `hello` sample project.
-"""
-
 from . import project_setup_py_test
+from . import (_copy_dir, _tmpdir, SAMPLES_DIR)
 
 
 def test_hello_builds():
     with push_dir():
 
-        @project_setup_py_test("hello", ["build"],
-                               clear_cache=True)
+        @project_setup_py_test("hello", ["build"])
         def run():
             pass
 
@@ -49,8 +49,7 @@ def test_hello_builds_with_generator(generator_args):
         build_args = ["build"]
         build_args.extend(generator_args)
 
-        @project_setup_py_test("hello", build_args,
-                               clear_cache=True)
+        @project_setup_py_test("hello", build_args)
         def run():
             pass
 
@@ -126,16 +125,13 @@ def test_hello_clean(dry_run, capfd):
 
         dry_run = dry_run == 'with-dry-run'
 
-        skbuild_dir = os.path.join("tests", "samples", "hello", SKBUILD_DIR)
-
-        @project_setup_py_test("hello", ["build"],
-                               clear_cache=True)
+        @project_setup_py_test("hello", ["build"])
         def run_build():
             pass
 
-        run_build()
+        tmp_dir = run_build()[0]
 
-        assert os.path.exists(skbuild_dir)
+        assert tmp_dir.join(SKBUILD_DIR).exists()
 
         # XXX Since using capfd.disabled() context manager prevents
         # the output from being captured atfer it exits, we display
@@ -146,16 +142,16 @@ def test_hello_clean(dry_run, capfd):
         if dry_run:
             clean_args.append("--dry-run")
 
-        @project_setup_py_test("hello", clean_args)
+        @project_setup_py_test("hello", clean_args, tmp_dir=tmp_dir)
         def run_clean():
             pass
 
         run_clean()
 
         if not dry_run:
-            assert not os.path.exists(skbuild_dir)
+            assert not tmp_dir.join(SKBUILD_DIR).exists()
         else:
-            assert os.path.exists(skbuild_dir)
+            assert tmp_dir.join(SKBUILD_DIR).exists()
 
         build_out, clean_out = capfd.readouterr()[0].split('<<-->>')
         assert 'Build files have been written to' in build_out
@@ -165,12 +161,15 @@ def test_hello_clean(dry_run, capfd):
 def test_hello_cleans(capfd):
     with push_dir():
 
-        @project_setup_py_test("hello", ["build"],
-                               clear_cache=True)
+        tmp_dir = _tmpdir("test_hello_cleans")
+
+        _copy_dir(tmp_dir, os.path.join(SAMPLES_DIR, "hello"))
+
+        @project_setup_py_test("hello", ["build"], tmp_dir=tmp_dir)
         def run_build():
             pass
 
-        @project_setup_py_test("hello", ["clean"])
+        @project_setup_py_test("hello", ["clean"], tmp_dir=tmp_dir)
         def run_clean():
             pass
 

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -25,7 +25,7 @@ from . import project_setup_py_test
 def test_hello_builds():
     with push_dir():
 
-        @project_setup_py_test(("samples", "hello"), ["build"],
+        @project_setup_py_test("hello", ["build"],
                                clear_cache=True)
         def run():
             pass
@@ -49,7 +49,7 @@ def test_hello_builds_with_generator(generator_args):
         build_args = ["build"]
         build_args.extend(generator_args)
 
-        @project_setup_py_test(("samples", "hello"), build_args,
+        @project_setup_py_test("hello", build_args,
                                clear_cache=True)
         def run():
             pass
@@ -70,12 +70,12 @@ def test_hello_builds_with_generator(generator_args):
             assert not failed
 
 
-# @project_setup_py_test(("samples", "hello"), ["test"])
+# @project_setup_py_test("hello", ["test"])
 # def test_hello_works():
 #     pass
 
 
-@project_setup_py_test(("samples", "hello"), ["sdist"], clear_cache=True)
+@project_setup_py_test("hello", ["sdist"])
 def test_hello_sdist():
     sdists_tar = glob.glob('dist/*.tar.gz')
     sdists_zip = glob.glob('dist/*.zip')
@@ -113,7 +113,7 @@ def test_hello_sdist():
     assert sorted(expected_content) == sorted(member_list)
 
 
-@project_setup_py_test(("samples", "hello"), ["bdist_wheel"])
+@project_setup_py_test("hello", ["bdist_wheel"])
 def test_hello_wheel():
     whls = glob.glob('dist/*.whl')
     assert len(whls) == 1
@@ -128,7 +128,7 @@ def test_hello_clean(dry_run, capfd):
 
         skbuild_dir = os.path.join("tests", "samples", "hello", SKBUILD_DIR)
 
-        @project_setup_py_test(("samples", "hello"), ["build"],
+        @project_setup_py_test("hello", ["build"],
                                clear_cache=True)
         def run_build():
             pass
@@ -146,7 +146,7 @@ def test_hello_clean(dry_run, capfd):
         if dry_run:
             clean_args.append("--dry-run")
 
-        @project_setup_py_test(("samples", "hello"), clean_args)
+        @project_setup_py_test("hello", clean_args)
         def run_clean():
             pass
 
@@ -165,12 +165,12 @@ def test_hello_clean(dry_run, capfd):
 def test_hello_cleans(capfd):
     with push_dir():
 
-        @project_setup_py_test(("samples", "hello"), ["build"],
+        @project_setup_py_test("hello", ["build"],
                                clear_cache=True)
         def run_build():
             pass
 
-        @project_setup_py_test(("samples", "hello"), ["clean"])
+        @project_setup_py_test("hello", ["clean"])
         def run_clean():
             pass
 

--- a/tests/test_hello_cython.py
+++ b/tests/test_hello_cython.py
@@ -15,17 +15,17 @@ from zipfile import ZipFile
 from . import project_setup_py_test
 
 
-@project_setup_py_test(("samples", "hello-cython"), ["build"], clear_cache=True)
+@project_setup_py_test("hello-cython", ["build"], clear_cache=True)
 def test_hello_cython_builds():
     pass
 
 
-# @project_setup_py_test(("samples", "hello-cython"), ["test"])
+# @project_setup_py_test("hello-cython", ["test"])
 # def test_hello_cython_works():
 #     pass
 
 
-@project_setup_py_test(("samples", "hello-cython"), ["sdist"], clear_cache=True)
+@project_setup_py_test("hello-cython", ["sdist"])
 def test_hello_cython_sdist():
     sdists_tar = glob.glob('dist/*.tar.gz')
     sdists_zip = glob.glob('dist/*.zip')
@@ -63,7 +63,7 @@ def test_hello_cython_sdist():
     assert sorted(expected_content) == sorted(member_list)
 
 
-@project_setup_py_test(("samples", "hello-cython"), ["bdist_wheel"])
+@project_setup_py_test("hello-cython", ["bdist_wheel"])
 def test_hello_cython_wheel():
     whls = glob.glob('dist/*.whl')
     assert len(whls) == 1

--- a/tests/test_hello_cython.py
+++ b/tests/test_hello_cython.py
@@ -15,7 +15,7 @@ from zipfile import ZipFile
 from . import project_setup_py_test
 
 
-@project_setup_py_test("hello-cython", ["build"], clear_cache=True)
+@project_setup_py_test("hello-cython", ["build"])
 def test_hello_cython_builds():
     pass
 

--- a/tests/test_hello_pure.py
+++ b/tests/test_hello_pure.py
@@ -18,18 +18,18 @@ from skbuild.utils import push_dir
 from . import project_setup_py_test
 
 
-@project_setup_py_test(("samples", "hello-pure"), ["build"], clear_cache=True)
+@project_setup_py_test("hello-pure", ["build"], clear_cache=True)
 def test_hello_pure_builds(capsys):
     out, _ = capsys.readouterr()
     assert "skipping skbuild (no CMakeLists.txt found)" in out
 
 
-# @project_setup_py_test(("samples", "hello-pure"), ["test"])
+# @project_setup_py_test("hello-pure", ["test"])
 # def test_hello_cython_works():
 #     pass
 
 
-@project_setup_py_test(("samples", "hello-pure"), ["sdist"], clear_cache=True)
+@project_setup_py_test("hello-pure", ["sdist"])
 def test_hello_pure_sdist():
     sdists_tar = glob.glob('dist/*.tar.gz')
     sdists_zip = glob.glob('dist/*.zip')
@@ -59,7 +59,7 @@ def test_hello_pure_sdist():
     assert sorted(expected_content) == sorted(member_list)
 
 
-@project_setup_py_test(("samples", "hello-pure"), ["bdist_wheel"])
+@project_setup_py_test("hello-pure", ["bdist_wheel"])
 def test_hello_pure_wheel():
     whls = glob.glob('dist/*.whl')
     assert len(whls) == 1
@@ -72,7 +72,7 @@ def test_hello_clean(capfd):
         skbuild_dir = os.path.join(
             "tests", "samples", "hello-pure", SKBUILD_DIR)
 
-        @project_setup_py_test(("samples", "hello-pure"), ["build"],
+        @project_setup_py_test("hello-pure", ["build"],
                                clear_cache=True)
         def run_build():
             pass
@@ -81,7 +81,7 @@ def test_hello_clean(capfd):
 
         assert os.path.exists(skbuild_dir)
 
-        @project_setup_py_test(("samples", "hello-pure"), ["clean"])
+        @project_setup_py_test("hello-pure", ["clean"])
         def run_clean():
             pass
 

--- a/tests/test_hello_pure.py
+++ b/tests/test_hello_pure.py
@@ -8,7 +8,6 @@ Tries to build and test the `hello-pure` sample project.
 """
 
 import glob
-import os
 import tarfile
 from zipfile import ZipFile
 
@@ -18,7 +17,7 @@ from skbuild.utils import push_dir
 from . import project_setup_py_test
 
 
-@project_setup_py_test("hello-pure", ["build"], clear_cache=True)
+@project_setup_py_test("hello-pure", ["build"])
 def test_hello_pure_builds(capsys):
     out, _ = capsys.readouterr()
     assert "skipping skbuild (no CMakeLists.txt found)" in out
@@ -69,25 +68,21 @@ def test_hello_pure_wheel():
 def test_hello_clean(capfd):
     with push_dir():
 
-        skbuild_dir = os.path.join(
-            "tests", "samples", "hello-pure", SKBUILD_DIR)
-
-        @project_setup_py_test("hello-pure", ["build"],
-                               clear_cache=True)
+        @project_setup_py_test("hello-pure", ["build"])
         def run_build():
             pass
 
-        run_build()
+        tmp_dir = run_build()[0]
 
-        assert os.path.exists(skbuild_dir)
+        assert tmp_dir.join(SKBUILD_DIR).exists()
 
-        @project_setup_py_test("hello-pure", ["clean"])
+        @project_setup_py_test("hello-pure", ["clean"], tmp_dir=tmp_dir)
         def run_clean():
             pass
 
         run_clean()
 
-        assert not os.path.exists(skbuild_dir)
+        assert not tmp_dir.join(SKBUILD_DIR).exists()
 
         out = capfd.readouterr()[0]
         assert 'Build files have been written to' not in out

--- a/tests/test_outside_project_root.py
+++ b/tests/test_outside_project_root.py
@@ -33,9 +33,7 @@ def test_outside_project_root_fails(option):
             expected_failure = True
             cmd.extend(["--", option])
 
-        @project_setup_py_test("fail-outside-project-root",
-                               cmd,
-                               clear_cache=True)
+        @project_setup_py_test("fail-outside-project-root", cmd)
         def should_fail():
             pass
 

--- a/tests/test_outside_project_root.py
+++ b/tests/test_outside_project_root.py
@@ -33,7 +33,7 @@ def test_outside_project_root_fails(option):
             expected_failure = True
             cmd.extend(["--", option])
 
-        @project_setup_py_test(("samples", "fail-outside-project-root"),
+        @project_setup_py_test("fail-outside-project-root",
                                cmd,
                                clear_cache=True)
         def should_fail():

--- a/tests/test_skbuild_variable.py
+++ b/tests/test_skbuild_variable.py
@@ -11,9 +11,7 @@ Tries to build the `fail-unless-skbuild-set` sample project.  The CMake variable
 from . import project_setup_py_test
 
 
-@project_setup_py_test("fail-unless-skbuild-set",
-                       ["build"],
-                       clear_cache=True)
+@project_setup_py_test("fail-unless-skbuild-set", ["build"])
 def test_skbuild_variable_builds():
     pass
 

--- a/tests/test_skbuild_variable.py
+++ b/tests/test_skbuild_variable.py
@@ -11,22 +11,22 @@ Tries to build the `fail-unless-skbuild-set` sample project.  The CMake variable
 from . import project_setup_py_test
 
 
-@project_setup_py_test(("samples", "fail-unless-skbuild-set"),
+@project_setup_py_test("fail-unless-skbuild-set",
                        ["build"],
                        clear_cache=True)
 def test_skbuild_variable_builds():
     pass
 
 
-# @project_setup_py_test(("samples", "fail-unless-skbuild-set"), ["test"])
+# @project_setup_py_test("fail-unless-skbuild-set", ["test"])
 # def test_skbuild_variable_works():
 #     pass
 
-@project_setup_py_test(("samples", "fail-unless-skbuild-set"), ["sdist"])
+@project_setup_py_test("fail-unless-skbuild-set", ["sdist"])
 def test_skbuild_variable_sdist():
     pass
 
 
-@project_setup_py_test(("samples", "fail-unless-skbuild-set"), ["bdist_wheel"])
+@project_setup_py_test("fail-unless-skbuild-set", ["bdist_wheel"])
 def test_skbuild_variable_wheel():
     pass


### PR DESCRIPTION
 tests: Run each setup tests in a dedicated temp directory

This commit updates `project_setup_py_test` so that it automatically:
* creates a temporary directory
* copies the test project into it
* initializes associated git repository with one commit

It also remove the need for specifying `clear_cache` parameter. If the
project directory needs to be shared, the function decorated using
`project_setup_py_test` will return the tuple `(tmp_dir, decorated_func_result)`.

Then `tmp_dir` can be passed as a parameter to an other call to `project_setup_py_test`