### PR TITLE
test_cmaker: Add test for get_python_library in virtualenv

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,6 @@ pytest-cov==2.3.1
 pytest-mock==1.2
 pytest-runner==2.9
 six==1.10.0
+git+https://github.com/jcfr/pytest-plugins.git@pytest-fixture-config#egg=pytest-fixture-config
+git+https://github.com/jcfr/pytest-plugins.git@pytest-shutil#egg=pytest-shutil
+git+https://github.com/jcfr/pytest-plugins.git@pytest-virtualenv#egg=pytest-virtualenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-wheel==0.29.0
+pip==8.1.2
 setuptools==26.1.1
+wheel==0.29.0

--- a/setup.py
+++ b/setup.py
@@ -8,17 +8,20 @@ try:
 except ImportError:
     from distutils.core import setup
 
+from pip.req import parse_requirements
 
 with open('README.rst', 'r') as fp:
     readme = fp.read()
 with open('HISTORY.rst', 'r') as fp:
     history = fp.read().replace('.. :changelog:', '')
 
-with open('requirements.txt', 'r') as fp:
-    requirements = list(filter(bool, (line.strip() for line in fp)))
 
-with open('requirements-dev.txt', 'r') as fp:
-    dev_requirements = list(filter(bool, (line.strip() for line in fp)))
+def _parse_requirements(filename):
+    return [str(ir.req) for ir in parse_requirements(filename, session=False)]
+
+
+requirements = _parse_requirements('requirements.txt')
+dev_requirements = _parse_requirements('requirements-dev.txt')
 
 # Require pytest-runner only when running tests
 pytest_runner = (['pytest-runner>=2.0,<3dev']

--- a/tests/test_cmaker.py
+++ b/tests/test_cmaker.py
@@ -21,3 +21,7 @@ def test_get_python_library():
     python_library = CMaker.get_python_library(CMaker.get_python_version())
     assert python_library
     assert os.path.exists(python_library)
+
+
+def test_get_python_library_with_virtualenv(virtualenv):
+    test_get_python_library()


### PR DESCRIPTION
Since `pytest-plugins` maintainers have not yet create a new release
including the latest fixes for windows and python 3, the pytest
plugins related to `pytest-virtualenv` are installed from source.

For more details: https://gist.github.com/jcfr/19a360f541b5caae5f31ac31c83e4f65

See #119
