### PR TITLE
setuptool_wrap: Add support for 'cmake_source_dir' keyword

### DIFF
--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -66,7 +66,7 @@ class CMaker(object):
 
         self.platform = get_platform()
 
-    def configure(self, clargs=(), generator_id=None):
+    def configure(self, clargs=(), generator_id=None, cmake_src_dir=None):
         """Calls cmake to generate the Makefile/VS Solution/XCode project.
 
         Input:
@@ -108,7 +108,8 @@ class CMaker(object):
         python_library = CMaker.get_python_library(python_version)
 
         cwd = os.getcwd()
-        cmake_src_dir = cwd
+        if not cmake_src_dir:
+            cmake_src_dir = cwd
         cmd = [
             'cmake', cmake_src_dir, '-G', generator_id,
             ("-DCMAKE_INSTALL_PREFIX:PATH=" +

--- a/tests/samples/cmakelists-not-in-top-level-dir/hello/CMakeLists.txt
+++ b/tests/samples/cmakelists-not-in-top-level-dir/hello/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.5.0)
+
+project(hello)
+
+enable_testing()
+
+find_package(PythonInterp REQUIRED)
+find_package(PythonLibs REQUIRED)
+find_package(PythonExtensions REQUIRED)
+
+add_library(_hello MODULE _hello.cxx)
+python_extension_module(_hello)
+
+# for testing
+file(COPY __init__.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+file(COPY __main__.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+add_test(NAME hello
+         COMMAND ${PYTHON_EXECUTABLE} -m hello
+         WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX})
+
+install(TARGETS _hello LIBRARY DESTINATION hello)
+install(FILES __init__.py      DESTINATION hello)
+install(FILES __main__.py      DESTINATION hello)

--- a/tests/samples/cmakelists-not-in-top-level-dir/hello/__main__.py
+++ b/tests/samples/cmakelists-not-in-top-level-dir/hello/__main__.py
@@ -1,0 +1,4 @@
+
+if __name__ == "__main__":
+    from . import _hello as hello
+    hello.hello("World")

--- a/tests/samples/cmakelists-not-in-top-level-dir/hello/_hello.cxx
+++ b/tests/samples/cmakelists-not-in-top-level-dir/hello/_hello.cxx
@@ -1,0 +1,65 @@
+
+// Python includes
+#include <Python.h>
+
+// STD includes
+#include <stdio.h>
+
+//-----------------------------------------------------------------------------
+static PyObject *hello_example(PyObject *self, PyObject *args)
+{
+  // Unpack a string from the arguments
+  const char *strArg;
+  if (!PyArg_ParseTuple(args, "s", &strArg))
+    return NULL;
+
+  // Print message and return None
+  PySys_WriteStdout("Hello, %s! :)\n", strArg);
+  Py_RETURN_NONE;
+}
+
+//-----------------------------------------------------------------------------
+static PyObject *elevation_example(PyObject *self, PyObject *args)
+{
+  // Return an integer
+  return PyLong_FromLong(21463L);
+}
+
+//-----------------------------------------------------------------------------
+static PyMethodDef hello_methods[] = {
+  {
+    "hello",
+    hello_example,
+    METH_VARARGS,
+    "Prints back 'Hello <param>', for example example: hello.hello('you')"
+  },
+
+  {
+    "size",
+    elevation_example,
+    METH_VARARGS,
+    "Returns elevation of Nevado Sajama."
+  },
+  {NULL, NULL, 0, NULL}        /* Sentinel */
+};
+
+//-----------------------------------------------------------------------------
+#if PY_MAJOR_VERSION < 3
+PyMODINIT_FUNC init_hello(void)
+{
+  (void) Py_InitModule("_hello", hello_methods);
+}
+#else /* PY_MAJOR_VERSION >= 3 */
+static struct PyModuleDef hello_module_def = {
+  PyModuleDef_HEAD_INIT,
+  "_hello",
+  "Internal \"_hello\" module",
+  -1,
+  hello_methods
+};
+
+PyMODINIT_FUNC PyInit__hello(void)
+{
+  return PyModule_Create(&hello_module_def);
+}
+#endif /* PY_MAJOR_VERSION >= 3 */

--- a/tests/samples/cmakelists-not-in-top-level-dir/setup.py
+++ b/tests/samples/cmakelists-not-in-top-level-dir/setup.py
@@ -1,0 +1,12 @@
+from skbuild import setup
+
+setup(
+    name="hello",
+    version="1.2.3",
+    description="a minimal example package (CMakeLists not in top-level dir)",
+    author='The scikit-build team',
+    license="MIT",
+    packages=['hello'],
+    package_dir={'hello': 'hello'},
+    cmake_source_dir='hello'
+)

--- a/tests/test_cmakelists_not_in_top_level_dir.py
+++ b/tests/test_cmakelists_not_in_top_level_dir.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""test_cmakelists_not_in_top_level_dir
+----------------------------------
+
+Tries to build and test the `cmakelists_not_in_top_level_dir` sample
+project. It basically checks that using the `cmake_source_dir` setup
+keyword works.
+"""
+
+import glob
+import tarfile
+import textwrap
+
+from zipfile import ZipFile
+
+from skbuild.exceptions import SKBuildError
+
+from . import (_tmpdir, execute_setup_py, project_setup_py_test)
+
+
+@project_setup_py_test("cmakelists-not-in-top-level-dir", ["build"])
+def test_build(capsys):
+    out, err = capsys.readouterr()
+    dist_warning = "Unknown distribution option: 'cmake_source_dir'"
+    assert (dist_warning not in err and dist_warning not in out)
+
+
+def test_invalid_cmake_source_dir():
+    tmp_dir = _tmpdir('invalid_cmake_source_dir')
+
+    tmp_dir.join('setup.py').write(textwrap.dedent(
+        """
+        from skbuild import setup
+        setup(
+            name="hello",
+            version="1.2.3",
+            description="a minimal example package",
+            author='The scikit-build team',
+            license="MIT",
+            cmake_source_dir="invalid"
+        )
+        """
+    ))
+    failed = False
+    message = ""
+    try:
+        with execute_setup_py(tmp_dir, ['build']):
+            pass
+    except SystemExit as e:
+        failed = isinstance(e.code, SKBuildError)
+        message = str(e)
+
+    assert failed
+    assert "'cmake_source_dir' set to a nonexistent directory." in message
+
+
+@project_setup_py_test("cmakelists-not-in-top-level-dir", ["sdist"])
+def test_hello_sdist():
+    sdists_tar = glob.glob('dist/*.tar.gz')
+    sdists_zip = glob.glob('dist/*.zip')
+    assert sdists_tar or sdists_zip
+
+    expected_content = [
+        'hello-1.2.3/hello/_hello.cxx',
+        'hello-1.2.3/hello/CMakeLists.txt',
+        'hello-1.2.3/hello/__init__.py',
+        'hello-1.2.3/hello/__main__.py',
+        'hello-1.2.3/setup.py',
+        'hello-1.2.3/PKG-INFO'
+    ]
+
+    member_list = None
+    if sdists_tar:
+        expected_content.extend([
+            'hello-1.2.3',
+            'hello-1.2.3/hello'
+        ])
+        member_list = tarfile.open('dist/hello-1.2.3.tar.gz').getnames()
+
+    elif sdists_zip:
+        member_list = ZipFile('dist/hello-1.2.3.zip').namelist()
+
+    assert expected_content and member_list
+    assert sorted(expected_content) == sorted(member_list)


### PR DESCRIPTION
This PR adds support for a `skbuild.setup` specific keyword `cmake_source_dir`.

If not specified, `CMakeLists.txt` is expected in the current working directory. Alternatively, setting this new keyword to an existing sub-directory of your project will ensure CMake is using it to configure and build.

