### PR TITLE
Setup add support cmake args keyword

### DIFF
--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -175,6 +175,7 @@ def setup(*args, **kw):
     # following call to _parse_setuptools_arguments would complain about
     # unknown setup options.
     parameters = {
+        'cmake_args': [],
         'cmake_source_dir': os.getcwd()
     }
     skbuild_kw = {param: kw.pop(param, parameters[param])
@@ -251,6 +252,11 @@ def setup(*args, **kw):
         (parent_dir or '.'): set(file_list)
         for parent_dir, file_list in kw.get('data_files', [])
     }
+
+    # Since CMake arguments provided through the command line have more
+    # weight and when CMake is given multiple times a argument, only the last
+    # one is considered, let's prepend the one provided in the setup call.
+    cmake_args = skbuild_kw['cmake_args'] + cmake_args
 
     try:
         cmkr = cmaker.CMaker()

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -138,19 +138,6 @@ def _parse_setuptools_arguments(setup_attrs):
     return display_only, dist.help_commands, dist.commands
 
 
-def _collect_skbuild_parameters(setup_kw):
-    skbuild_kw = {}
-    default_values = {'cmake_source_dir': os.getcwd()}
-    for param in ['cmake_source_dir']:
-        skbuild_kw[param] = None
-        if param in default_values:
-            skbuild_kw[param] = default_values[param]
-        if param in setup_kw:
-            skbuild_kw[param] = setup_kw[param]
-            del setup_kw[param]  # Update the dictionary passed by reference
-    return skbuild_kw
-
-
 def _check_skbuild_parameters(skbuild_kw):
     cmake_source_dir = skbuild_kw['cmake_source_dir']
     if not os.path.exists(cmake_source_dir):
@@ -186,8 +173,12 @@ def setup(*args, **kw):
     # Extract setup keywords specific to scikit-build and remove them from kw.
     # Removing the keyword from kw need to be done here otherwise, the
     # following call to _parse_setuptools_arguments would complain about
-    # unknown setup option.
-    skbuild_kw = _collect_skbuild_parameters(kw)
+    # unknown setup options.
+    parameters = {
+        'cmake_source_dir': os.getcwd()
+    }
+    skbuild_kw = {param: kw.pop(param, parameters[param])
+                  for param in parameters}
 
     # ... and validate them
     try:


### PR DESCRIPTION
This PR adds support for a `skbuild.setup` specific keyword `cmake_args`.

If specified the arguments will be passed to CMake when it is used to configure the project. Note that if the same CMake arguments are also passed from the command line, they will have priority.