### PR TITLE
Support pure python package and package built by cmake

### DIFF
--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -175,6 +175,7 @@ def setup(*args, **kw):
     # following call to _parse_setuptools_arguments would complain about
     # unknown setup options.
     parameters = {
+        'cmake_args': [],
         'cmake_source_dir': os.getcwd()
     }
     skbuild_kw = {param: kw.pop(param, parameters[param])
@@ -251,6 +252,11 @@ def setup(*args, **kw):
         (parent_dir or '.'): set(file_list)
         for parent_dir, file_list in kw.get('data_files', [])
     }
+
+    # Since CMake arguments provided through the command line have more
+    # weight and when CMake is given multiple times a argument, only the last
+    # one is considered, let's prepend the one provided in the setup call.
+    cmake_args = skbuild_kw['cmake_args'] + cmake_args
 
     try:
         cmkr = cmaker.CMaker()

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -138,19 +138,6 @@ def _parse_setuptools_arguments(setup_attrs):
     return display_only, dist.help_commands, dist.commands
 
 
-def _collect_skbuild_parameters(setup_kw):
-    skbuild_kw = {}
-    default_values = {'cmake_source_dir': os.getcwd()}
-    for param in ['cmake_source_dir']:
-        skbuild_kw[param] = None
-        if param in default_values:
-            skbuild_kw[param] = default_values[param]
-        if param in setup_kw:
-            skbuild_kw[param] = setup_kw[param]
-            del setup_kw[param]  # Update the dictionary passed by reference
-    return skbuild_kw
-
-
 def _check_skbuild_parameters(skbuild_kw):
     cmake_source_dir = skbuild_kw['cmake_source_dir']
     if not os.path.exists(cmake_source_dir):
@@ -186,8 +173,12 @@ def setup(*args, **kw):
     # Extract setup keywords specific to scikit-build and remove them from kw.
     # Removing the keyword from kw need to be done here otherwise, the
     # following call to _parse_setuptools_arguments would complain about
-    # unknown setup option.
-    skbuild_kw = _collect_skbuild_parameters(kw)
+    # unknown setup options.
+    parameters = {
+        'cmake_source_dir': os.getcwd()
+    }
+    skbuild_kw = {param: kw.pop(param, parameters[param])
+                  for param in parameters}
 
     # ... and validate them
     try:

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -277,7 +277,10 @@ def setup(*args, **kw):
 
     kw['package_data'] = package_data
     kw['package_dir'] = {
-        package: os.path.join(cmaker.CMAKE_INSTALL_DIR, prefix)
+        package: (
+            os.path.join(cmaker.CMAKE_INSTALL_DIR, prefix)
+            if os.path.exists(os.path.join(cmaker.CMAKE_INSTALL_DIR, prefix))
+            else prefix)
         for prefix, package in package_prefixes
     }
 

--- a/tests/samples/hello/setup.py
+++ b/tests/samples/hello/setup.py
@@ -6,6 +6,9 @@ setup(
     description="a minimal example package",
     author='The scikit-build team',
     license="MIT",
-    packages=['hello'],
-    package_dir={'hello': 'hello'},
+    packages=['bonjour', 'hello'],
+    package_dir={
+        'bonjour': 'bonjour',
+        'hello': 'hello'
+    },
 )

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -87,6 +87,7 @@ def test_hello_sdist():
 
     expected_content = [
         'hello-1.2.3/CMakeLists.txt',
+        'hello-1.2.3/bonjour/__init__.py',
         'hello-1.2.3/hello/_hello.cxx',
         'hello-1.2.3/hello/CMakeLists.txt',
         'hello-1.2.3/hello/__init__.py',
@@ -99,6 +100,7 @@ def test_hello_sdist():
     if sdists_tar:
         expected_content.extend([
             'hello-1.2.3',
+            'hello-1.2.3/bonjour',
             'hello-1.2.3/hello'
         ])
         member_list = tarfile.open('dist/hello-1.2.3.tar.gz').getnames()


### PR DESCRIPTION
 setuptools_wrap: Add support for pure python packages and packages built by CMake

Prior to this commit, install rules for all packages were required
to be added to the CMake project. This commit changes this by allowing
mixing of pure python package along with package built by CMake.

To illustrate this, the "hello" sample project has been updated to include
a pure python package named 'bonjour' that doesn't have any install
rules in any of the CMakeLists.txt