### PR TITLE
command: Split source MANIFEST generation into its own command

### DIFF
--- a/skbuild/command/egg_info.py
+++ b/skbuild/command/egg_info.py
@@ -3,71 +3,15 @@ command."""
 
 import os
 import os.path
-import subprocess
-import sys
 
 from setuptools.command.egg_info import egg_info as _egg_info
 
 from . import set_build_base_mixin
-from ..constants import SKBUILD_DIR
 from ..utils import new_style
-
-SKBUILD_MARKER_FILE = os.path.join(SKBUILD_DIR, "_skbuild_MANIFEST")
 
 
 class egg_info(set_build_base_mixin, new_style(_egg_info)):
-    """Custom implementation of ``egg_info`` setuptools command generating
-    a `MANIFEST` file if not already provided."""
-    def run(self):
-        """
-        If neither a `MANIFEST`, nor a `MANIFEST.in` file is provided, and
-        we are in a git repo, try to create a `MANIFEST` file from the output of
-        `git ls-tree --name-only -r HEAD`.
-
-        We need a reliable way to tell if an existing `MANIFEST` file is one
-        we've generated.  distutils already uses a first-line comment to tell
-        if the `MANIFEST` file was generated from `MANIFEST.in`, so we use a
-        dummy file, `_skbuild_MANIFEST`, to avoid confusing distutils.
-        """
-        do_generate = (
-            # If there's a MANIFEST.in file, we assume that we had nothing to do
-            # with the project's manifest.
-            not os.path.exists('MANIFEST.in')
-
-            # otherwise, we check to see that there is no MANIFEST, ...
-            or not os.path.exists('MANIFEST')  # ... or ...
-
-            # ... (if there is one,) that we created it
-            or os.path.exists(SKBUILD_MARKER_FILE)
-        )
-
-        if do_generate:
-            try:
-                with open('MANIFEST', 'wb') as manifest_file:
-                    manifest_file.write(
-                        subprocess.check_output(
-                            ['git', 'ls-tree', '--name-only', '-r', 'HEAD'])
-                    )
-            except subprocess.CalledProcessError:
-                sys.stderr.write(
-                    '\n\n'
-                    'Since scikit-build could not find MANIFEST.in or '
-                    'MANIFEST, it tried to generate a MANIFEST file '
-                    'automatically, but could not because it could not '
-                    'determine which source files to include.\n\n'
-                    'The command used was "git ls-tree --name-only -r HEAD"\n'
-                    '\n\n'
-                )
-
-                raise
-
-            if not os.path.exists(SKBUILD_DIR):
-                os.makedirs(SKBUILD_DIR)
-
-            with open(SKBUILD_MARKER_FILE, 'w'):  # touch
-                pass
-
-        super(egg_info, self).run()
+    """Custom implementation of ``egg_info`` setuptools command."""
 
     def finalize_options(self):
         if self.egg_base is not None:

--- a/skbuild/command/generate_source_manifest.py
+++ b/skbuild/command/generate_source_manifest.py
@@ -1,0 +1,75 @@
+import os
+import subprocess
+import sys
+
+from distutils.cmd import Command
+
+from . import set_build_base_mixin
+from ..constants import SKBUILD_DIR
+from ..utils import new_style
+
+SKBUILD_MARKER_FILE = os.path.join(SKBUILD_DIR, "_skbuild_MANIFEST")
+
+
+class generate_source_manifest(set_build_base_mixin, new_style(Command)):
+    """Custom implementation of ``egg_info`` setuptools command generating
+    a `MANIFEST` file if not already provided."""
+
+    description = "generate source MANIFEST"
+
+    def initialize_options(self):
+        """Set default values for all the options that this command supports."""
+        pass
+
+    def run(self):
+        """
+        If neither a `MANIFEST`, nor a `MANIFEST.in` file is provided, and
+        we are in a git repo, try to create a `MANIFEST` file from the output of
+        `git ls-tree --name-only -r HEAD`.
+
+        We need a reliable way to tell if an existing `MANIFEST` file is one
+        we've generated.  distutils already uses a first-line comment to tell
+        if the `MANIFEST` file was generated from `MANIFEST.in`, so we use a
+        dummy file, `_skbuild_MANIFEST`, to avoid confusing distutils.
+        """
+        do_generate = (
+            # If there's a MANIFEST.in file, we assume that we had nothing to do
+            # with the project's manifest.
+            not os.path.exists('MANIFEST.in')
+
+            # otherwise, we check to see that there is no MANIFEST, ...
+            or not os.path.exists('MANIFEST')  # ... or ...
+
+            # ... (if there is one,) that we created it
+            or os.path.exists(SKBUILD_MARKER_FILE)
+        )
+
+        if do_generate:
+            try:
+                with open('MANIFEST', 'wb') as manifest_file:
+                    manifest_file.write(
+                        subprocess.check_output(
+                            ['git', 'ls-tree', '--name-only', '-r', 'HEAD'])
+                    )
+            except subprocess.CalledProcessError:
+                sys.stderr.write(
+                    '\n\n'
+                    'Since scikit-build could not find MANIFEST.in or '
+                    'MANIFEST, it tried to generate a MANIFEST file '
+                    'automatically, but could not because it could not '
+                    'determine which source files to include.\n\n'
+                    'The command used was "git ls-tree --name-only -r HEAD"\n'
+                    '\n\n'
+                )
+
+                raise
+
+            if not os.path.exists(SKBUILD_DIR):
+                os.makedirs(SKBUILD_DIR)
+
+            with open(SKBUILD_MARKER_FILE, 'w'):  # touch
+                pass
+
+    def finalize_options(self):
+        """Set final values for all the options that this command supports."""
+        pass

--- a/skbuild/command/sdist.py
+++ b/skbuild/command/sdist.py
@@ -10,5 +10,5 @@ class sdist(set_build_base_mixin, new_style(_sdist)):
     """Custom implementation of ``sdist`` setuptools command."""
     def run(self, *args, **kwargs):
         """Force :class:`.egg_info.egg_info` command to run."""
-        self.run_command('egg_info')
+        self.run_command('generate_source_manifest')
         super(sdist, self).run(*args, **kwargs)

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -25,7 +25,8 @@ from setuptools import setup as upstream_setup
 from setuptools.dist import Distribution as upstream_Distribution
 
 from . import cmaker
-from .command import build, install, clean, bdist, bdist_wheel, egg_info, sdist
+from .command import (build, install, clean, bdist, bdist_wheel, egg_info,
+                      sdist, generate_source_manifest)
 from .constants import CMAKE_INSTALL_DIR
 from .exceptions import SKBuildError
 from .utils import (mkdir_p, PythonModuleFinder, to_platform_path, to_unix_path)
@@ -235,6 +236,9 @@ def setup(*args, **kw):  # noqa: C901
     cmdclass['bdist_wheel'] = cmdclass.get(
         'bdist_wheel', bdist_wheel.bdist_wheel)
     cmdclass['egg_info'] = cmdclass.get('egg_info', egg_info.egg_info)
+    cmdclass['generate_source_manifest'] = cmdclass.get(
+        'generate_source_manifest',
+        generate_source_manifest.generate_source_manifest)
     kw['cmdclass'] = cmdclass
 
     # Extract setup keywords specific to scikit-build and remove them from kw.


### PR DESCRIPTION
This will avoid the generation of MANIFEST when building a Wheel