### PR TITLE
tests/samples: Simplify project removing unneeded install rules and file copy

### DIFF
--- a/tests/samples/cmakelists-not-in-top-level-dir/hello/CMakeLists.txt
+++ b/tests/samples/cmakelists-not-in-top-level-dir/hello/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.5.0)
 
 project(hello)
 
-enable_testing()
-
 find_package(PythonInterp REQUIRED)
 find_package(PythonLibs REQUIRED)
 find_package(PythonExtensions REQUIRED)
@@ -11,14 +9,4 @@ find_package(PythonExtensions REQUIRED)
 add_library(_hello MODULE _hello.cxx)
 python_extension_module(_hello)
 
-# for testing
-file(COPY __init__.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-file(COPY __main__.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-
-add_test(NAME hello
-         COMMAND ${PYTHON_EXECUTABLE} -m hello
-         WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX})
-
 install(TARGETS _hello LIBRARY DESTINATION hello)
-install(FILES __init__.py      DESTINATION hello)
-install(FILES __main__.py      DESTINATION hello)

--- a/tests/samples/fail-hello-with-compile-error/CMakeLists.txt
+++ b/tests/samples/fail-hello-with-compile-error/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.5.0)
 
 project(hello)
 
-enable_testing()
-
 find_package(PythonInterp REQUIRED)
 find_package(PythonLibs REQUIRED)
 find_package(PythonExtensions REQUIRED)

--- a/tests/samples/fail-hello-with-compile-error/hello/CMakeLists.txt
+++ b/tests/samples/fail-hello-with-compile-error/hello/CMakeLists.txt
@@ -1,14 +1,4 @@
 add_library(_hello MODULE _hello.cxx)
 python_extension_module(_hello)
 
-# for testing
-file(COPY __init__.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-file(COPY __main__.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-
-add_test(NAME hello
-         COMMAND ${PYTHON_EXECUTABLE} -m hello
-         WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX})
-
 install(TARGETS _hello LIBRARY DESTINATION hello)
-install(FILES __init__.py      DESTINATION hello)
-install(FILES __main__.py      DESTINATION hello)

--- a/tests/samples/hello-cython/CMakeLists.txt
+++ b/tests/samples/hello-cython/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.5.0)
 
 project(hello_cython)
 
-enable_testing()
-
 find_package(PythonInterp REQUIRED)
 find_package(PythonLibs REQUIRED)
 find_package(PythonExtensions REQUIRED)

--- a/tests/samples/hello-cython/hello/CMakeLists.txt
+++ b/tests/samples/hello-cython/hello/CMakeLists.txt
@@ -3,14 +3,4 @@ add_cython_target(_hello CXX)
 add_library(_hello MODULE ${_hello})
 python_extension_module(_hello)
 
-# for testing
-file(COPY __init__.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-file(COPY __main__.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-
-add_test(NAME hello
-         COMMAND ${PYTHON_EXECUTABLE} -m hello
-         WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX})
-
 install(TARGETS _hello LIBRARY DESTINATION hello)
-install(FILES __init__.py      DESTINATION hello)
-install(FILES __main__.py      DESTINATION hello)

--- a/tests/samples/hello/CMakeLists.txt
+++ b/tests/samples/hello/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.5.0)
 
 project(hello)
 
-enable_testing()
-
 find_package(PythonInterp REQUIRED)
 find_package(PythonLibs REQUIRED)
 find_package(PythonExtensions REQUIRED)

--- a/tests/samples/hello/hello/CMakeLists.txt
+++ b/tests/samples/hello/hello/CMakeLists.txt
@@ -1,14 +1,4 @@
 add_library(_hello MODULE _hello.cxx)
 python_extension_module(_hello)
 
-# for testing
-file(COPY __init__.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-file(COPY __main__.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-
-add_test(NAME hello
-         COMMAND ${PYTHON_EXECUTABLE} -m hello
-         WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX})
-
 install(TARGETS _hello LIBRARY DESTINATION hello)
-install(FILES __init__.py      DESTINATION hello)
-install(FILES __main__.py      DESTINATION hello)


### PR DESCRIPTION
Extra install rules became obsolete after integration the support for
"hybrid project" (See 0d0ddbf)

File copy are removed because testing within the samples project should
be done using a pythonic testing framework (e.g pytest)