### PR TITLE
ci: Update scikit-ci[-addons] and simplify "scikit-ci.yml"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ addons:
       - python-vtk
 
 before_install:
-  - pip install scikit-ci==0.7.0 scikit-ci-addons==0.3.0
+  - pip install scikit-ci==0.12.0 scikit-ci-addons==0.10.0
   - ci_addons --install ../addons
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,7 +73,7 @@ cache:
   - C:\\cmake-3.6.2
 
 init:
-  - python -m pip install scikit-ci==0.7.0 scikit-ci-addons==0.3.0
+  - python -m pip install scikit-ci==0.12.0 scikit-ci-addons==0.10.0
   - python -m ci_addons --install ../addons
 
   - ps: ../addons/appveyor/rolling-build.ps1

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
   override:
-    - pip install scikit-ci==0.7.0 scikit-ci-addons==0.3.0
+    - pip install scikit-ci==0.12.0 scikit-ci-addons==0.10.0
     - ci_addons --install ../addons
     - ci install
 

--- a/scikit-ci.yml
+++ b/scikit-ci.yml
@@ -2,14 +2,10 @@ schema_version: "0.5.0"
 
 before_install:
 
-  environment:
-    PYTHON: python
-    RUN_ENV: ""
-
   appveyor:
     environment:
       PYTEST_ADDOPTS: "-m \"not fortran\""
-      PYTHON: $<PYTHON_DIR>\\python.exe
+      PATH: $<PYTHON_DIR>;$<PYTHON_DIR>\\Scripts;$<PATH>
       RUN_ENV: .\\..\\addons\\appveyor\\run-with-visual-studio.cmd
     commands:
       - python ../addons/appveyor/patch_vs2008.py
@@ -18,7 +14,7 @@ before_install:
     osx:
       environment:
         PYTEST_ADDOPTS: "-m \"not fortran\""
-        RUN_ENV: ../addons/travis/run-with-pyenv.sh
+        PATH: $<HOME>/.pyenv/versions/$<PYTHONVERSION>/bin:$<PATH>
       commands:
         - python ../addons/travis/install_pyenv.py
 
@@ -26,9 +22,9 @@ install:
 
   commands:
     - python ../addons/$<CI_NAME>/install_cmake.py 3.6.2
-    - $<RUN_ENV> $<PYTHON> -m pip install --disable-pip-version-check --upgrade pip
-    - $<RUN_ENV> $<PYTHON> -m pip install -r requirements.txt
-    - $<RUN_ENV> $<PYTHON> -m pip install -r requirements-dev.txt
+    - python -m pip install --disable-pip-version-check --upgrade pip
+    - $<RUN_ENV> pip install -r requirements.txt
+    - $<RUN_ENV> pip install -r requirements-dev.txt
 
   circle:
     commands:
@@ -37,23 +33,17 @@ install:
 
 before_build:
   commands:
-    - $<RUN_ENV> $<PYTHON> -m flake8 -v
+    - flake8
 
 build:
   commands:
-    - $<RUN_ENV> $<PYTHON> setup.py build
+    - python setup.py sdist
+    - $<RUN_ENV> python setup.py bdist_wheel
 
 test:
-
-  appveyor:
-    environment:
-      PATH: $<PYTHON_DIR>\\Scripts;$<PATH>
-
   commands:
-    - $<RUN_ENV> $<PYTHON> setup.py test
+    - $<RUN_ENV> python setup.py test
 
 after_test:
-
   commands:
-    - $<RUN_ENV> codecov -X gcov --required --file ./tests/coverage.xml
-    - $<RUN_ENV> $<PYTHON> setup.py bdist_wheel
+    - codecov -X gcov --required --file ./tests/coverage.xml


### PR DESCRIPTION
* Update PATH and remove use of $<PYTHON>

* Remove explicit setting of RUN_ENV to an empty var (not needed following
  scikit-build/scikit-ci@e48e300)

* upgrade of pip still requires to be invoked using "python -m pip",
  otherwise, windows complains that it can't remove "pip.exe"

scikit-ci:

```bash
$ git shortlog 0.7.0..0.12.0 --no-merges
Jean-Christophe Fillion-Robin (22):
      Bump version to 0.8.0
      ci: Install scikit-ci-addons into addons directory
      tests/test_current_service: Test for invalid service
      coverage: ci/__main__: Fix report removing exclusion from coveragerc
      tests/test_current_service: Fix test when running on CI service
      setup: Add "Environment :: Console" classifier
      setup: Simplify release process using "versioneer"
      ci: Display normal error message when command fails while executing a step
      ci: Ensure latest version of scikit-ci boostrap package is installed
      ci: Display step name using text to ascii art generator
      ci: Update from scikit-ci-addons 0.3.0 to 0.6.0
      setup: Update "Development Status" from "2 - Pre-Alpha" to "3 - Alpha"
      ci: Add support for '--clear-cached-env' option
      docs: Improve "Executing scikit-ci steps"
      ci: Add "true" support for multi-line command on unix
      ci: Add support for python command. See #22
      ci: Fix python command support working around ruamel.yaml issue.
      travis/appveyor: Fix typo "BOOTSRAP_BRANCH" -> "BOOTSTRAP_BRANCH"
      travis.yml: Fix setting of BOOTSTRAP_BRANCH for release
      ci: Expand unset scikit-ci env variable used in command to an empty string
      scikit-ci: Update PATH, remove use of $<PYTHON> and directly use executables
      ci: Execute python command with "shell=True"
```

scikit-ci-addons:

```bash
$ git shortlog 0.3.0..0.10.0 --no-merges
Jean-Christophe Fillion-Robin (48):
      Bump version to 0.4.0
      scikit-ci: Simpler config relying on automatic execution of dependent steps
      anyci/noop: Fix name of service user in _log function
      docs/addons: Fix power shell examples
      addon: Add add-on facilitating docker use on CI services.
      Bump version to 0.5.0
      lint: Find line too long error
      anyci/docker: Improve filename conversion
      anyci/docker: Fix caching of docker image and add tests
      ci_addons: Fix spelling of add-on(s) in docstrings
      tests/test_install: Simplify code and add comments
      coverage: ci_addons/__main__: Exclude cases already covered by tests
      ci_addons/install: Do not call "exit()", instead raises exception
      coverage: ci_addons/__main__: Fix report removing exclusion from coveragerc
      tests/test_path: Extend test to consider python/shell scripts and nonexistent ones
      tests: Check that --list command line argument works as expected
      tests: Fix tests on p3k converting result of check_output to string
      Bump version to 0.6.0
      ci: Simplify scikit-ci configuration
      addons/install_cmake: Skip download if cmake found in PATH
      anyci/docker: Display usage if no argument is provided
      anyci/docker: Save image into cache only if needed
      tests/test_addon_anyci_docker: Attempt to delete image only if not on CircleCI
      anyci/docker: Improve output and introduce "--verbose" parameter
      addons/install_cmake: Reduce verbosity using check_output instead of check_call
      setup: Simplify release process managing "versioning" with versioneer
      ci_addons: Simplify error display when reporting user error
      ci_addons: Fix more spelling of add-on(s)
      ci_addons: Do not list *.pyc files if any. Fixes #8
      tests: Simplify CMake version checking.
      travis/install_pyenv: Simplify and improve progress display
      travis/run-with-pyenv: Do not display content of init and local scripts
      setup: Update "Development Status" from "2 - Pre-Alpha" to "3 - Alpha"
      anyci/docker: Consistently display result after loading cached images
      anyci/docker: Use "Config.Image" to identify the images between re-load
      docs: Improve "usage" section
      docs: improve formatting of "add-ons" section
      ci_addons/usage: Fix metavar associated with --install" option
      ci_addons: Improve path/execute cmd to support script_name with/without extension
      scikit-ci: Add python to PATH and remove use of $<PYTHON>
      ci: Update from scikit-ci 0.7.0 to 0.11.0
      scikit-ci: Display "sys.version_info" using a python command
      scikit-ci: Display "PATH" environment variable
      scikit-ci: Test version associated with python code directly executed
      scikit-ci: Remove unneeded setting of "PYTHON" env var
      scikit-ci/travis/osx: Set PATH containins python executable
      travis/install_pyenv: Refactor code introducing "_execute_script" function
      travis/install_pyenv: Check if pyenv python executable exists
```