### PR TITLE
travis/install_pyenv: Improve MacOSX build time updating scikit-ci-addons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,17 +20,17 @@ matrix:
     - os: osx
       language: generic
       env:
-        - PYTHONVERSION=3.4.5
+        - PYTHON_VERSION=3.4.5
 
     - os: osx
       language: generic
       env:
-        - PYTHONVERSION=3.3.6
+        - PYTHON_VERSION=3.3.6
 
     - os: osx
       language: generic
       env:
-        - PYTHONVERSION=2.7.12
+        - PYTHON_VERSION=2.7.12
 
 cache:
   directories:
@@ -47,7 +47,7 @@ addons:
       - python-vtk
 
 before_install:
-  - pip install scikit-ci==0.12.0 scikit-ci-addons==0.10.0
+  - pip install scikit-ci==0.12.0 scikit-ci-addons==0.11.0
   - ci_addons --install ../addons
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,7 +73,7 @@ cache:
   - C:\\cmake-3.6.2
 
 init:
-  - python -m pip install scikit-ci==0.12.0 scikit-ci-addons==0.10.0
+  - python -m pip install scikit-ci==0.12.0 scikit-ci-addons==0.11.0
   - python -m ci_addons --install ../addons
 
   - ps: ../addons/appveyor/rolling-build.ps1

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
   override:
-    - pip install scikit-ci==0.12.0 scikit-ci-addons==0.10.0
+    - pip install scikit-ci==0.12.0 scikit-ci-addons==0.11.0
     - ci_addons --install ../addons
     - ci install
 

--- a/scikit-ci.yml
+++ b/scikit-ci.yml
@@ -14,7 +14,7 @@ before_install:
     osx:
       environment:
         PYTEST_ADDOPTS: "-m \"not fortran\""
-        PATH: $<HOME>/.pyenv/versions/$<PYTHONVERSION>/bin:$<PATH>
+        PATH: $<HOME>/.pyenv/versions/$<PYTHON_VERSION>/bin:$<PATH>
       commands:
         - python ../addons/travis/install_pyenv.py
 


### PR DESCRIPTION
$ git shortlog 0.10.0..0.11.0 --no-merges
Jean-Christophe Fillion-Robin (6):
      docs/make_a_release: Re-order steps to account for use of versioneer
      docs/make_a_release: Ensure uploaded distributions are signed
      docs/make_a_release: Update reference to external documentation
      docs/addons: Fix typo in enable-worker-remote-access section
      addon/install_pyenv: Use PYTHON_VERSION instead of PYTHONVERSION
      addon/install_pyenv: Skip brew update/upgrade if python if found in the cache