### PR TITLE
requirements: unpin version of setuptools and require >= 28.0.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,15 @@ Documentation
  * Add "Why should I use scikit-build ?"
  * Add "Setup options" section
 
+Requirements
+------------
+
+* setuptools: As suggested by :user:`mivade` in :issue:`212`, remove the
+  hard requirement for ``==28.8.0`` and require version ``>= 28.0.0``. This allows
+  to "play" nicely with conda where it is problematic to update the version
+  of setuptools. See `pypa/pip#2751 <https://github.com/pypa/pip/issues/2751`_
+  and `ContinuumIO/anaconda-issues#542 <https://github.com/ContinuumIO/anaconda-issues/issues/542>`_.
+
 Tests
 -----
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 wheel==0.29.0
-setuptools==28.8.0
+setuptools>=28.0.0


### PR DESCRIPTION
As suggested by @mivade: "Considering the target audience is likely using
anaconda/miniconda, I would think the most sensible thing is to use the
version used there as the minimum version. A quick check indicates that
setuptools is at version 28.8 there, so I think requiring >=28.0.0 should
work."

See #212, pypa/pip#2751 and ContinuumIO/anaconda-issues#542

Suggested-by: "Michael V. DePalatis" <mike@depalatis.net>