### PR TITLE
docs: Add "Hacking/Internal API" section generated using sphinx-apidoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ docs/_build
 # build output (testing)
 skbuild/_cmake_test_compile/*
 
+# generated docs
+docs/modules.rst
+docs/skbuild.*
+

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,10 @@ Documentation
  * Add "Why should I use scikit-build ?"
  * Add "Setup options" section
 
+* hacking:
+
+ * Add :ref:`internal_api` section generated using `sphinx-apidoc`.
+
 Requirements
 ------------
 

--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,9 @@ coverage: test
 	open htmlcov/index.html || xdg-open htmlcov/index.html
 
 docs-only:
-	rm -f docs/skbuild rst
+	rm -f docs/skbuild.rst
 	rm -f docs/modules.rst
+	sphinx-apidoc -o docs/ -M  skbuild
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 

--- a/docs/hacking.rst
+++ b/docs/hacking.rst
@@ -26,5 +26,11 @@ You can drive CMake directly using scikit-build::
 
     maker.make()
 
-.. autoclass:: skbuild.cmaker.CMaker
-   :members: configure, make
+See :obj:`skbuild.cmaker.CMaker` for more details.
+
+.. _internal_api:
+
+Internal API
+------------
+
+.. include:: modules.rst


### PR DESCRIPTION
[ci skip]