### PR TITLE
Address CMP0054 warning with "unused" string/variable

### DIFF
--- a/skbuild/resources/cmake/targetLinkLibrariesWithDynamicLookup.cmake
+++ b/skbuild/resources/cmake/targetLinkLibrariesWithDynamicLookup.cmake
@@ -463,7 +463,7 @@ function(check_dynamic_lookup)
     ${link_flags_var}
     )
   set(${has_dynamic_lookup_var} ${${has_dynamic_lookup_var}} PARENT_SCOPE)
-  if(NOT link_flags_var STREQUAL "unused")
+  if(NOT "x${link_flags_var}x" STREQUAL "xunusedx")
     set(${link_flags_var} ${${link_flags_var}} PARENT_SCOPE)
   endif()
 endfunction()


### PR DESCRIPTION
Use standard regex MATCH approach to avoid a string being confused
with a variable. This patch addressed the following CMake warning:

```
CMake Warning (dev) at
CMake/sitkTargetLinkLibrariesWithDynamicLookup.cmake:466 (if):
  Policy CMP0054 is not set: Only interpret if() arguments as
  variables or
  keywords when unquoted.  Run "cmake --help-policy CMP0054" for
  policy
  details.  Use the cmake_policy command to set the policy and
  suppress this
  warning.

  Quoted variables like "unused" will no longer be dereferenced when
  the
  policy is set to NEW.  Since the policy is not set the OLD behavior
  will be
  used.
```