### PR TITLE
Correct DYNAMIC_LOOKUP_* cache type to STRING

### DIFF
--- a/skbuild/resources/cmake/targetLinkLibrariesWithDynamicLookup.cmake
+++ b/skbuild/resources/cmake/targetLinkLibrariesWithDynamicLookup.cmake
@@ -516,7 +516,7 @@ function(_check_dynamic_lookup
     mark_as_advanced(${cache_var})
 
     set(${result_var} "${link_flags}"
-        CACHE BOOL
+        CACHE STRING
         "linker flags for dynamic lookup${caveat}")
     mark_as_advanced(${result_var})
 


### PR DESCRIPTION
When CMake ran multiple time, the value would change from the correct
string to a boolean value. This caused failure of the expected dynamic
lookup behavior.

This patch addresses #240 