### PR TITLE
requirements: Unpin wheel package version requiring >= 0.29.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,13 @@ details, see the commit logs at http://github.com/scikit-build/scikit-build
 Next Release
 ============
 
+Requirements
+------------
+
+* wheel:  As suggested by :user:`thewtex`, unpinning version of the package
+  by requiring ``>=0.29.0`` instead of ``==0.29.0`` will avoid uninstalling a newer
+  version of wheel package on up-to-date system.
+
 Documentation
 -------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-wheel==0.29.0
+wheel>=0.29.0
 setuptools>=28.0.0


### PR DESCRIPTION
This will avoid uninstalling a newer version of wheel package
on up-to-date system.

Suggested-by: Matt McCormick <matt.mccormick@kitware.com>