### PR TITLE
skbuild.plaform_specifics: pass CMake args to the generator check

### DIFF
--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -101,7 +101,7 @@ class CMaker(object):
 
         # use the generator returned from the platform, with the current
         # generator_name as a suggestion
-        generator = self.platform.get_best_generator(generator_name)
+        generator = self.platform.get_best_generator(generator_name, clargs)
 
         if not os.path.exists(CMAKE_BUILD_DIR):
             os.makedirs(CMAKE_BUILD_DIR)


### PR DESCRIPTION
The CMake command line arguments should be passed generator check cmake runs.
This ensures that builds can be successful if they require compiler flags that
were passed or if they require CMake variables to be set like
CMAKE_MAKE_PROGRAM.