### PR TITLE
avoid escaping spaces

### DIFF
--- a/skbuild/resources/cmake/UseCython.cmake
+++ b/skbuild/resources/cmake/UseCython.cmake
@@ -26,7 +26,7 @@
 #
 # The Cython include search path is amended with any entries found in the
 # ``INCLUDE_DIRECTORIES`` property of the directory containing the
-# ``<CythonInput>`` file.  Use ``iunclude_directories`` to add to the Cython
+# ``<CythonInput>`` file.  Use ``include_directories`` to add to the Cython
 # include search path.
 #
 # Options:
@@ -101,6 +101,7 @@ set(CYTHON_ANNOTATE OFF
 set(CYTHON_FLAGS "" CACHE STRING
     "Extra flags to the cython compiler.")
 mark_as_advanced(CYTHON_ANNOTATE CYTHON_FLAGS)
+string(REGEX REPLACE " " ";" CYTHON_FLAGS_LIST "${CYTHON_FLAGS}")
 
 find_package(PythonLibs REQUIRED)
 
@@ -363,7 +364,7 @@ function(add_cython_target _name)
                      ARGS ${cxx_arg} ${include_directory_arg} ${py_version_arg}
                           ${embed_arg} ${annotate_arg} ${no_docstrings_arg}
                           ${cython_debug_arg} ${embed_pos_arg}
-                          ${line_directives_arg} ${CYTHON_FLAGS} ${pyx_location}
+                          ${line_directives_arg} ${CYTHON_FLAGS_LIST} ${pyx_location}
                           --output-file ${generated_file}
                      DEPENDS ${_source_file}
                              ${pxd_dependencies}


### PR DESCRIPTION
spaces in CYTHON_FLAGS are incorrectly escaped (at least on linux) when provided as command line arguments to the cython executable through CMake cache entries.

Here is a simple mwe (run `$ bash build.sh` in a terminal)
**build.sh**
```bash
#!/usr/bin/env bash
rm -r build; mkdir -p build; cd build

cmake \
-DCYTHON_FLAGS='-X boundscheck=False -X wraparound=False' \
-DCMAKE_MODULE_PATH="$SKBUILD_PREFIX/skbuild/resources/cmake" \
-DCMAKE_VERBOSE_MAKEFILE=ON ..

make || exit 1

python3 -c 'import fib; fib.fib(2000)'
```
**CMakeLists.txt**
```CMake
cmake_minimum_required(VERSION 3.8)

project(fib)

find_package(Cython REQUIRED)
include(UseCython)

include_directories(${PYTHON_INCLUDE_DIRS})

add_cython_target(fib fib.pyx C PY3)
add_library(fib MODULE fib.c)
set_target_properties(fib PROPERTIES PREFIX "")
```

**fib.pyx**
```python
def fib(n):
    """Print the Fibonacci series up to n."""
    a, b = 0, 1
    while b < n:
        print(b)
        a, b = b, a + b
```

without this patch, build.sh fails with the following output
```bash
<...>
cython --include-dir <...>/include/python3.6m -3 -X\ boundscheck=False\ -X\ wraparound=False <...>/fib.pyx --output-file <...>/build/fib.c
Error in compiler directive: boundscheck directive must be set to True or False, got 'False -X wraparound=False'
<...>
make[2]: *** [CMakeFiles/fib.dir/build.make:65: fib.c] Error 1
make[2]: Leaving directory <...>/build'
```