### PR TITLE
Find f2py rebased

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,14 @@ details, see the commit logs at http://github.com/scikit-build/scikit-build
 Next Release
 ============
 
+New Features
+------------
+
+* Add CMake module :doc:`\cmake-modules/F2PY` useful to find the ``f2py`` executable for building Python
+  extensions with Fortran. Thanks to :user:`xoviat` for moving forward with the integration. Concept for the
+  module comes from the work of :user:`scopatz` done in `PyNE <https://github.com/pyne/pyne>`_ project.
+  See :issue:`273`.
+
 Bug fixes
 ---------
 

--- a/docs/cmake-modules.rst
+++ b/docs/cmake-modules.rst
@@ -12,6 +12,7 @@ CMake modules:
    cmake-modules/Cython
    cmake-modules/NumPy
    cmake-modules/PythonExtensions
+   cmake-modules/F2PY
 
 
 They can be included using ``find_package``:
@@ -21,6 +22,7 @@ They can be included using ``find_package``:
     find_package(Cython REQUIRED)
     find_package(NumPy REQUIRED)
     find_package(PythonExtensions REQUIRED)
+    find_package(F2PY REQUIRED)
 
 
 For more details, see the respective documentation of each modules.

--- a/docs/cmake-modules/F2PY.rst
+++ b/docs/cmake-modules/F2PY.rst
@@ -1,0 +1,4 @@
+F2PY
+----
+
+.. cmake-module:: ../../skbuild/resources/cmake/FindF2PY.cmake

--- a/skbuild/resources/cmake/FindF2PY.cmake
+++ b/skbuild/resources/cmake/FindF2PY.cmake
@@ -1,0 +1,91 @@
+#.rst:
+#
+# The purpose of the F2PY –Fortran to Python interface generator– project is to provide a
+# connection between Python and Fortran languages.
+#
+# F2PY is a Python package (with a command line tool f2py and a module f2py2e) that facilitates
+# creating/building Python C/API extension modules that make it possible to call Fortran 77/90/95
+# external subroutines and Fortran 90/95 module subroutines as well as C functions; to access Fortran
+# 77 COMMON blocks and Fortran 90/95 module data, including allocatable arrays from Python.
+#
+# For more information on the F2PY project, see http://www.f2py.com/.
+#
+# The following variables are defined:
+#
+# ::
+#
+#   F2PY_EXECUTABLE      - absolute path to the F2PY executable
+#
+# ::
+#
+#   F2PY_VERSION_STRING  - the version of F2PY found
+#   F2PY_VERSION_MAJOR   - the F2PY major version
+#   F2PY_VERSION_MINOR   - the F2PY minor version
+#   F2PY_VERSION_PATCH   - the F2PY patch version
+#
+#
+# .. note::
+#
+#   By default, the module finds the F2PY program associated with the installed NumPy package.
+#
+# Example usage
+# ^^^^^^^^^^^^^
+#
+# Assuming that a package named ``method`` is declared in ``setup.py`` and that the corresponding directory
+# containing ``__init__.py`` also exists, the following CMake code can be added to ``method/CMakeLists.txt``
+# to ensure the C sources associated with ``cylinder_methods.f90`` are generated and the corresponding module
+# is compiled:
+#
+# .. code-block:: cmake
+#
+#   find_package(F2PY REQUIRED)
+#
+#   set(f2py_module_name "_cylinder_methods")
+#   set(fortran_src_file "${CMAKE_CURRENT_SOURCE_DIR}/cylinder_methods.f90")
+#
+#   set(generated_module_file ${CMAKE_CURRENT_BINARY_DIR}/${f2py_module_name}${PYTHON_EXTENSION_MODULE_SUFFIX})
+#
+#   add_custom_target(${f2py_module_name} ALL
+#     DEPENDS ${generated_module_file}
+#     )
+#
+#   add_custom_command(
+#     OUTPUT ${generated_module_file}
+#     COMMAND ${F2PY_EXECUTABLE}
+#       -m ${f2py_module_name}
+#       -c
+#       ${fortran_src_file}
+#     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+#     )
+#
+#   install(FILES ${generated_module_file} DESTINATION methods)
+#
+# .. warning::
+#
+#   Using ``f2py`` with ``-c`` argument means that f2py is also responsible to build the module. In that
+#   case, CMake is not used to find the compiler and configure the associated build system.
+#
+
+find_program(F2PY_EXECUTABLE NAMES f2py f2py${PYTHON_VERSION_MAJOR})
+
+if(F2PY_EXECUTABLE)
+  # extract the version string
+  execute_process(COMMAND "${F2PY_EXECUTABLE}" -v
+                  OUTPUT_VARIABLE F2PY_VERSION_STRING
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if("${F2PY_VERSION_STRING}" MATCHES "^([0-9]+)(.([0-9+]))?(.([0-9+]))?$")
+    set(F2PY_VERSION_MAJOR ${CMAKE_MATCH_1})
+    set(F2PY_VERSION_MINOR "${CMAKE_MATCH_3}")
+    set(F2PY_VERSION_PATCH "${CMAKE_MATCH_5}")
+  endif()
+endif()
+
+# handle the QUIETLY and REQUIRED arguments and set F2PY_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(F2PY
+  REQUIRED_VARS F2PY_EXECUTABLE
+  VERSION_VAR F2PY_VERSION_STRING
+  )
+
+mark_as_advanced(F2PY_EXECUTABLE)

--- a/skbuild/resources/cmake/FindPythonExtensions.cmake
+++ b/skbuild/resources/cmake/FindPythonExtensions.cmake
@@ -19,6 +19,9 @@
 #   PYTHON_PATH_SEPARATOR             - separator string for PATH-style
 #                                       environment variables.  Equivalent to
 #                                       ``os.pathsep`` in Python.
+#   PYTHON_EXTENSION_MODULE_SUFFIX    - suffix of the compiled module. For example, on
+#                                       Linux, based on environment, it could be ``.cpython-35m-x86_64-linux-gnu.so``.
+#
 #
 #
 # The following functions are defined:


### PR DESCRIPTION
From https://github.com/scikit-build/scikit-build/pull/273#issuecomment-362862052:

So the idea here is actually to eliminate `numpy.distutils` entirely over time and replace it with scikit-build. We can't do that if we write `f2py -c` because `numpy.distutils` is still used. Instead we want to use `f2py` to generate the C files and then link them to the Python extension.

I'm also not happy with the way that Cython support was implemented in scikit-build. Ideally, you would be able to write the following and have scikit-build autogenerate the cython and f2py targets:

```
add_library(LIBRARY_NAME
    input.pyf.src
    input.pyx
) 
```

If you look at [what we're replacing](https://github.com/scipy/scipy/blob/5531da38cec429f3cf2f9aca0f698e2130562592/scipy/fftpack/setup.py), we essentially need to translate the `add_library` and `add_extension` function calls on a one-to-one basis.