### PR TITLE
setuptools_wrap: Add support for default package_dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ pip-log.txt
 
 # Unit test / coverage reports
 .cache
+.pytest_cache/
 .coverage
 .tox
 coverage.xml

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ New Features
   directory for each python version. Thanks :user:`isuruf` for the suggestion and :user:`xoviat` for contributing
   the feature. See :issue:`283`.
 
+* Run cmake and ``develop`` command when command ``test`` is executed.
+
 Bug fixes
 ---------
 
@@ -34,6 +36,10 @@ Bug fixes
 
 * Ensure package data files specified in the ``setup()`` function using ``package_data`` keyword are packaged
   and installed.
+
+* Support specifying a default directory for all packages not already associated with one using syntax like
+  ``package_dir={'':'src'}`` in ``setup.py``. Thanks :user:`benjaminjack` for reporting the issue.
+  See :issue:`274`.
 
 Tests
 -----
@@ -61,6 +67,11 @@ Tests
   * TravisCI: from **~21 to ~10** minutes.
 
 * Update maximum line length specified in flake8 settings from 80 to 120 characters.
+
+* Add ``prepend_sys_path`` utility function.
+
+* Ensure that the project directory is prepended to ``sys.path`` when executing test building sample project
+  with the help of ``execute_setup_py`` function.
 
 Documentation
 -------------

--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,37 @@
-.PHONY: clean-pyc clean-build clean-skbuild docs clean
+.PHONY: help clean clean-build clean-coverage clean-pyc clean-skbuild clear-test lint test test-all coverage docs-only docs release dist
 
 help:
 	@echo "$(MAKE) [target]"
 	@echo
 	@echo "  targets:"
-	@echo "    clean-build - remove build artifacts"
-	@echo "    clean-pyc   - remove Python file artifacts"
+	@echo "    clean       - remove build and testing artifacts"
 	@echo "    lint        - check style with flake8"
 	@echo "    test        - run tests quickly with the default Python"
 	@echo "    test-all    - run tests on every Python version with tox"
 	@echo "    coverage    - check code coverage quickly with the default Python"
-	@echo "    docs        - generate Sphinx HTML documentation, including API docs"
+	@echo "    docs-only   - generate Sphinx HTML documentation, including API docs"
+	@echo "    docs        - same as 'docs-only' and load HTML using default web browser"
 	@echo "    release     - package and upload a release"
 	@echo "    dist        - package"
 	@echo
 
-clean: clean-build clean-pyc clean-skbuild
-	rm -fr htmlcov/
-	find . -name '.coverage' -exec rm -f {} +
-	find . -name 'coverage.xml' -exec rm -f {} +
-	rm -rf .cache
+clean: clean-build clean-coverage clean-pyc clean-skbuild clear-test
 
 clean-build:
 	rm -fr build/
 	rm -fr dist/
+	find . -type d -name '*.eggs' -exec rm -rf {} +
 	find . -type d -name '*.egg-info' -exec rm -rf {} +
 	find . -type f -name 'MANIFEST' -exec rm -f {} +
 	find tests/samples/*/dist/ -type d -exec rm -rf {} + > /dev/null 2>&1 || true
 
+clean-coverage:
+	rm -fr htmlcov/
+	find . -name '.coverage' -exec rm -f {} +
+	find . -name 'coverage.xml' -exec rm -f {} +
+
 clean-pyc:
+	find . -name '__pycache__' -exec rm -rf {} +
 	find . -name '*.pyc' -exec rm -f {} +
 	find . -name '*.pyo' -exec rm -f {} +
 	find . -name '*~' -exec rm -f {} +
@@ -36,6 +39,10 @@ clean-pyc:
 clean-skbuild:
 	rm -rf _skbuild
 	find tests/samples/*/_skbuild/ -type d -exec rm -rf {} + > /dev/null 2>&1 || true
+
+clear-test:
+	rm -rf .cache
+	rm -rf .pytest_cache/
 
 lint:
 	flake8

--- a/skbuild/command/egg_info.py
+++ b/skbuild/command/egg_info.py
@@ -7,7 +7,8 @@ import os.path
 from setuptools.command.egg_info import egg_info as _egg_info
 
 from . import set_build_base_mixin
-from ..utils import new_style
+from ..constants import CMAKE_INSTALL_DIR
+from ..utils import new_style, to_unix_path
 
 
 class egg_info(set_build_base_mixin, new_style(_egg_info)):
@@ -15,7 +16,21 @@ class egg_info(set_build_base_mixin, new_style(_egg_info)):
 
     def finalize_options(self, *args, **kwargs):
         # pylint:disable=access-member-before-definition
-        if self.egg_base is not None:
+        if self.egg_base is None:
+            if self.distribution.package_dir is not None and len(self.distribution.package_dir) == 1:
+                # Recover directory specified in setup() function
+                # using `package_dir={'':<egg_base>}`
+                # This is required to successfully update the python path when
+                # running the test command.
+                package_name = list(self.distribution.package_dir.keys())[0]
+                egg_base = to_unix_path(list(self.distribution.package_dir.values())[0])
+                cmake_install_dir = to_unix_path(CMAKE_INSTALL_DIR)
+                if egg_base.startswith(cmake_install_dir):
+                    egg_base = egg_base[len(cmake_install_dir) + 1:]
+                if package_name and egg_base.endswith(package_name):
+                    egg_base = egg_base[:-len(package_name) - 1]
+                self.egg_base = egg_base
+        else:
             script_path = os.path.abspath(self.distribution.script_name)
             script_dir = os.path.dirname(script_path)
             # pylint:disable=attribute-defined-outside-init

--- a/skbuild/command/test.py
+++ b/skbuild/command/test.py
@@ -1,0 +1,15 @@
+"""This module defines custom implementation of ``test`` setuptools command."""
+
+from setuptools.command.test import test as _test
+
+from . import set_build_base_mixin
+from ..utils import new_style
+
+
+class test(set_build_base_mixin, new_style(_test)):
+    """Custom implementation of ``test`` setuptools command."""
+
+    def run(self, *args, **kwargs):
+        """Force ``develop`` command to run."""
+        self.run_command('develop')
+        super(test, self).run(*args, **kwargs)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -47,6 +47,17 @@ def push_env(**kwargs):
         os.environ[saved_var] = saved_value
 
 
+@contextmanager
+def prepend_sys_path(paths):
+    """This context manager allows to prepend paths to ``sys.path`` and restore the
+    original list.
+    """
+    saved_paths = list(sys.path)
+    sys.path = paths + saved_paths
+    yield
+    sys.path = saved_paths
+
+
 def _tmpdir(basename):
     """This function returns a temporary directory similar to the one
     returned by the ``tmpdir`` pytest fixture.
@@ -179,8 +190,7 @@ def execute_setup_py(project_dir, setup_args, disable_languages_test=False):
     to ``project_dir``.
     """
 
-    with push_dir(str(project_dir)), \
-            push_argv(["setup.py"] + setup_args):
+    with push_dir(str(project_dir)), push_argv(["setup.py"] + setup_args), prepend_sys_path([str(project_dir)]):
 
         with open("setup.py", "r") as fp:
             setup_code = compile(fp.read(), "setup.py", mode="exec")

--- a/tests/samples/issue-274-support-default-package-dir/CMakeLists.txt
+++ b/tests/samples/issue-274-support-default-package-dir/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.5.0)
+
+project(hello NONE)
+
+
+set(module "${CMAKE_CURRENT_BINARY_DIR}/cmake_generated_module.py")
+file(WRITE ${module} "# Generated from ${CMAKE_CURRENT_LIST_FILE}
+
+def what():
+    return \"cmake_generated_module\"
+
+")
+install(FILES ${module} DESTINATION src/hello/)

--- a/tests/samples/issue-274-support-default-package-dir/hello_tests/__init__.py
+++ b/tests/samples/issue-274-support-default-package-dir/hello_tests/__init__.py
@@ -1,0 +1,18 @@
+import unittest
+import hello
+from hello import cmake_generated_module
+
+
+class HelloTest(unittest.TestCase):
+    def test_hello(self):
+        self.assertEqual(hello.who(), "world")
+
+        with open("test_hello.completed.txt", "w") as marker:
+            marker.write("")
+
+    def test_cmake_generated_module(self):
+        self.assertEqual(cmake_generated_module.what(), "cmake_generated_module")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/samples/issue-274-support-default-package-dir/setup.py
+++ b/tests/samples/issue-274-support-default-package-dir/setup.py
@@ -1,0 +1,12 @@
+from skbuild import setup
+
+setup(
+    name="hello",
+    version="1.2.3",
+    description="a minimal example package",
+    author='The scikit-build team',
+    license="MIT",
+    packages=['hello'],
+    package_dir={'': 'src'},
+    test_suite='hello_tests'
+)

--- a/tests/samples/issue-274-support-default-package-dir/src/hello/__init__.py
+++ b/tests/samples/issue-274-support-default-package-dir/src/hello/__init__.py
@@ -1,0 +1,3 @@
+
+def who():
+    return "world"

--- a/tests/test_issue274_support_default_package_dir.py
+++ b/tests/test_issue274_support_default_package_dir.py
@@ -1,0 +1,27 @@
+
+from . import (
+    _tmpdir, execute_setup_py, initialize_git_repo_and_commit,
+    prepare_project, project_setup_py_test, push_dir
+)
+
+
+@project_setup_py_test("issue-274-support-default-package-dir", ["install"], disable_languages_test=True)
+def test_install_command():
+    pass
+
+
+def test_test_command():
+    with push_dir():
+
+        tmp_dir = _tmpdir('test_test_command')
+        project = "issue-274-support-default-package-dir"
+        prepare_project(project, tmp_dir)
+        initialize_git_repo_and_commit(tmp_dir, verbose=True)
+
+        try:
+            with execute_setup_py(tmp_dir, ["test"], disable_languages_test=True):
+                pass
+        except SystemExit as exc:
+            assert exc.code == 0
+
+        assert tmp_dir.join("test_hello.completed.txt").exists()


### PR DESCRIPTION
This commit supports specifying a default directory for all packages
that do not have one already explicitly associated with them.

See #274