### PR TITLE
escape detected entries in FindPythonExtensions.cmake

### DIFF
--- a/skbuild/resources/cmake/FindPythonExtensions.cmake
+++ b/skbuild/resources/cmake/FindPythonExtensions.cmake
@@ -278,14 +278,17 @@ for candidate in candidates:
         rel_result = rel_candidate
         break
 
-sys.stdout.write(\";\".join((
-    os.sep,
-    os.pathsep,
-    sys.prefix,
-    result,
-    rel_result,
-    sysconfig.get_config_var('SO')
-)))
+sys.stdout.write(\";\".join(
+    entry.replace(\";\", 4*\"\\\\\" + \";\")
+    for entry in (
+        os.sep,
+        os.pathsep,
+        sys.prefix,
+        result,
+        rel_result,
+        sysconfig.get_config_var('SO')
+    )
+))
 ")
 
 execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c "${_command}"


### PR DESCRIPTION
Handles the case where the entries detected in the Python script may contain semicolons.  The script now correctly escapes these entries for proper consumption by CMake.

Thanks to @xoviat for originally pointing out the bug!