### PR TITLE
tests: Fix test_hello_*_wheel tests adding support for wheel 0.31.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ matrix:
       python: "3.4"
 
     - os: linux
-      python: "3.3.5"
-
-    - os: linux
       python: "2.7"
 
     - os: osx
@@ -25,17 +22,11 @@ matrix:
     - os: osx
       language: generic
       env:
-        - PYTHON_VERSION=3.3.7
-
-    - os: osx
-      language: generic
-      env:
         - PYTHON_VERSION=2.7.14
 
 cache:
   directories:
     - $HOME/.pyenv/versions/3.4.7
-    - $HOME/.pyenv/versions/3.3.7
     - $HOME/.pyenv/versions/2.7.14
     - $HOME/downloads
 

--- a/tests/test_hello_cpp.py
+++ b/tests/test_hello_cpp.py
@@ -13,11 +13,13 @@ import pytest
 import six
 import sysconfig
 import tarfile
+import wheel
 
 from skbuild import __version__ as skbuild_version
 from skbuild.constants import CMAKE_BUILD_DIR, CMAKE_INSTALL_DIR, SKBUILD_DIR
 from skbuild.utils import push_dir
 
+from pkg_resources import parse_version
 from zipfile import ZipFile
 
 from . import project_setup_py_test
@@ -88,10 +90,8 @@ def test_hello_sdist():
 def test_hello_wheel():
     expected_content = [
         'hello-1.2.3.dist-info/top_level.txt',
-        'hello-1.2.3.dist-info/DESCRIPTION.rst',
         'hello-1.2.3.dist-info/WHEEL',
         'hello-1.2.3.dist-info/RECORD',
-        'hello-1.2.3.dist-info/metadata.json',
         'hello-1.2.3.dist-info/METADATA',
         'hello/_hello%s' % (sysconfig.get_config_var('SO')),
         'hello/__init__.py',
@@ -104,6 +104,12 @@ def test_hello_wheel():
         'bonjour/data/terre.txt',
         'bonjourModule.py'
     ]
+
+    if parse_version(wheel.__version__) < parse_version('0.31.0'):
+        expected_content += [
+            'hello-1.2.3.dist-info/DESCRIPTION.rst',
+            'hello-1.2.3.dist-info/metadata.json'
+        ]
 
     def check_whls(whls):
         assert len(whls) == 1

--- a/tests/test_hello_cython.py
+++ b/tests/test_hello_cython.py
@@ -10,7 +10,9 @@ Tries to build and test the `hello-cython` sample project.
 import glob
 import sysconfig
 import tarfile
+import wheel
 
+from pkg_resources import parse_version
 from zipfile import ZipFile
 
 from . import project_setup_py_test
@@ -65,15 +67,19 @@ def test_hello_cython_wheel():
 
     expected_content = [
         'hello_cython-1.2.3.dist-info/top_level.txt',
-        'hello_cython-1.2.3.dist-info/DESCRIPTION.rst',
         'hello_cython-1.2.3.dist-info/WHEEL',
         'hello_cython-1.2.3.dist-info/RECORD',
-        'hello_cython-1.2.3.dist-info/metadata.json',
         'hello_cython-1.2.3.dist-info/METADATA',
         'hello_cython/_hello%s' % (sysconfig.get_config_var('SO')),
         'hello_cython/__init__.py',
         'hello_cython/__main__.py'
     ]
+
+    if parse_version(wheel.__version__) < parse_version('0.31.0'):
+        expected_content += [
+            'hello_cython-1.2.3.dist-info/DESCRIPTION.rst',
+            'hello_cython-1.2.3.dist-info/metadata.json'
+        ]
 
     member_list = ZipFile(whls[0]).namelist()
     assert sorted(expected_content) == sorted(member_list)

--- a/tests/test_hello_pure.py
+++ b/tests/test_hello_pure.py
@@ -9,10 +9,13 @@ Tries to build and test the `hello-pure` sample project.
 
 import glob
 import tarfile
-from zipfile import ZipFile
+import wheel
 
 from skbuild.constants import SKBUILD_DIR
 from skbuild.utils import push_dir
+
+from pkg_resources import parse_version
+from zipfile import ZipFile
 
 from . import project_setup_py_test
 
@@ -66,13 +69,17 @@ def test_hello_pure_wheel():
 
     expected_content = [
         'hello_pure-1.2.3.dist-info/top_level.txt',
-        'hello_pure-1.2.3.dist-info/DESCRIPTION.rst',
         'hello_pure-1.2.3.dist-info/WHEEL',
         'hello_pure-1.2.3.dist-info/RECORD',
-        'hello_pure-1.2.3.dist-info/metadata.json',
         'hello_pure-1.2.3.dist-info/METADATA',
         'hello/__init__.py'
     ]
+
+    if parse_version(wheel.__version__) < parse_version('0.31.0'):
+        expected_content += [
+            'hello_pure-1.2.3.dist-info/DESCRIPTION.rst',
+            'hello_pure-1.2.3.dist-info/metadata.json'
+        ]
 
     member_list = ZipFile(whls[0]).namelist()
     assert sorted(expected_content) == sorted(member_list)


### PR DESCRIPTION
This commit updates the tests to account for these two changes available
in wheel 0.31.0:
* pypa/wheel@4fcc31d (Updated metadata version to 2.1 and dropped
  DESCRIPTION.rst from the list of created files.)
* pypa/wheel@595e4a8 (Don't create metadata.json anymore)