### PR TITLE
ci: Add codecov config file for better defaults

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        # Don't allow overall project coverage to be dropped more than 2%
+        threshold: 2
+    patch:
+      default:
+        # 75% of the changed code must be covered by tests
+        threshold: 25
+        only_pulls: true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -92,6 +92,9 @@ Tests
 * Ensure that the project directory is prepended to ``sys.path`` when executing test building sample project
   with the help of ``execute_setup_py`` function.
 
+* Add codecov config file for better defaults and prevent associated Pull Request checks from reporting failure
+  when coverage only slightly changes.
+
 Documentation
 -------------
 


### PR DESCRIPTION
This commit will prevent PR check from reporting failure when coverage
only slightly change.

Adapted from https://github.com/NeurodataWithoutBorders/pynwb/pull/496

Thanks: Doruk Ozturk <doruk.ozturk@kitware.com>