### PR TITLE
Use utf-8 to open cmake files

### DIFF
--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -5,6 +5,7 @@ This module provides an interface for invoking CMake executable.
 import argparse
 import distutils.sysconfig as du_sysconfig
 import glob
+import io
 import itertools
 import os
 import os.path
@@ -414,7 +415,7 @@ class CMaker(object):
                 if os.path.splitext(filename)[1] != ".cmake":
                     continue
 
-                for line in open(os.path.join(root, filename), encoding="utf-8"):
+                for line in io.open(os.path.join(root, filename), encoding="utf-8"):
                     match = RE_FILE_INSTALL.match(line)
                     if match is None:
                         continue

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -414,7 +414,7 @@ class CMaker(object):
                 if os.path.splitext(filename)[1] != ".cmake":
                     continue
 
-                for line in open(os.path.join(root, filename)):
+                for line in open(os.path.join(root, filename), encoding="utf-8"):
                     match = RE_FILE_INSTALL.match(line)
                     if match is None:
                         continue


### PR DESCRIPTION
On Windows the default encoding for opening files is not utf-8.
This changes the scanning of .cmake files to open with utf-8.
If there is any character in a file that is not available in
CP-1252 the build fails.