### PR TITLE
Fix cmaker parse

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@ Bug fixes
   `CP-1252 <https://en.wikipedia.org/wiki/Windows-1252>`_ (the default code page on
   windows). See :issue:`334` fixed by :user:`bgermann`.
 
+* Fix parsing of cmake arguments not overriding with later arguments. See
+  followup to :issue:`342` fixed by :user:`yonip`.
+
 Documentation
 -------------
 

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -61,7 +61,7 @@ def has_cmake_cache_arg(cmake_args, arg_name, arg_value=None):
     """Return True if ``-D<arg_name>:TYPE=<arg_value>`` is found
     in ``cmake_args``. If ``arg_value`` is None, return True only if
     ``-D<arg_name>:`` is found in the list."""
-    for arg in reverse(cmake_args):
+    for arg in reversed(cmake_args):
         if arg.startswith("-D%s:" % arg_name):
             if arg_value is None:
                 return True

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -61,7 +61,7 @@ def has_cmake_cache_arg(cmake_args, arg_name, arg_value=None):
     """Return True if ``-D<arg_name>:TYPE=<arg_value>`` is found
     in ``cmake_args``. If ``arg_value`` is None, return True only if
     ``-D<arg_name>:`` is found in the list."""
-    for arg in cmake_args:
+    for arg in reverse(cmake_args):
         if arg.startswith("-D%s:" % arg_name):
             if arg_value is None:
                 return True

--- a/tests/test_cmaker.py
+++ b/tests/test_cmaker.py
@@ -47,11 +47,11 @@ def test_has_cmake_cache_arg():
     assert has_cmake_cache_arg(cmake_args, "CLIMBING", None)
     assert has_cmake_cache_arg(cmake_args, "CLIMBING", "ON")
 
-    override = ['-DOTHER:STRING=C','-DOVERRIDE:STRING=A', '-DOVERRIDE:STRING=B']
+    override = ['-DOTHER:STRING=C', '-DOVERRIDE:STRING=A', '-DOVERRIDE:STRING=B']
     assert has_cmake_cache_arg(override, 'OVERRIDE')
     assert has_cmake_cache_arg(override, 'OVERRIDE', 'B')
     assert not has_cmake_cache_arg(override, 'OVERRIDE', 'A')
-    # ensure overriding doesn't magically have side effects. 
+    # ensure overriding doesn't magically have side effects.
     assert has_cmake_cache_arg(override, 'OTHER')
     assert has_cmake_cache_arg(override, 'OTHER', 'C')
     assert not has_cmake_cache_arg(override, 'OTHER', 'A')

--- a/tests/test_cmaker.py
+++ b/tests/test_cmaker.py
@@ -47,6 +47,16 @@ def test_has_cmake_cache_arg():
     assert has_cmake_cache_arg(cmake_args, "CLIMBING", None)
     assert has_cmake_cache_arg(cmake_args, "CLIMBING", "ON")
 
+    override = ['-DOTHER:STRING=C','-DOVERRIDE:STRING=A', '-DOVERRIDE:STRING=B']
+    assert has_cmake_cache_arg(override, 'OVERRIDE')
+    assert has_cmake_cache_arg(override, 'OVERRIDE', 'B')
+    assert not has_cmake_cache_arg(override, 'OVERRIDE', 'A')
+    # ensure overriding doesn't magically have side effects. 
+    assert has_cmake_cache_arg(override, 'OTHER')
+    assert has_cmake_cache_arg(override, 'OTHER', 'C')
+    assert not has_cmake_cache_arg(override, 'OTHER', 'A')
+    assert not has_cmake_cache_arg(override, 'OTHER', 'B')
+
 
 def test_make_without_build_dir_fails():
     src_dir = _tmpdir('test_make_without_build_dir_fails')


### PR DESCRIPTION
Fix cmaker parsing command line arguments in the wrong order when verifying them, as reported in followup to #342.