### PR TITLE
coverage: Fix "include-ignored" warning

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,6 @@
 [run]
 branch = True
 source = skbuild
-include = */skbuild/*
 
 [xml]
 output = tests/coverage.xml


### PR DESCRIPTION
This commit fixes the following warning:

  --include is ignored because --source is set (include-ignored)