### PR TITLE
Fix bdist_wheel command to support wheel >= 0.32.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,13 @@ details, see the commit logs at http://github.com/scikit-build/scikit-build
 Next Release
 ============
 
+Bug fixes
+---------
+
+* Fix ``bdist_wheel`` command to support ``wheel >= 0.32.0``. Thanks :user:`fbudin69500` for reporting
+  issue :issue:`360`.
+
+
 Scikit-build 0.8.0
 ==================
 

--- a/skbuild/command/bdist_wheel.py
+++ b/skbuild/command/bdist_wheel.py
@@ -3,7 +3,13 @@ command."""
 
 import sys
 
-from wheel import archive as _wheel_archive
+try:
+    from wheel.wheelfile import WheelFile
+    _USE_WHEELFILE = True
+except ImportError:
+    from wheel import archive as _wheel_archive  # Not available with wheel >= 0.32.0
+    _USE_WHEELFILE = False
+
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
 from . import set_build_base_mixin
@@ -16,22 +22,42 @@ class bdist_wheel(set_build_base_mixin, new_style(_bdist_wheel)):
     def run(self, *args, **kwargs):
         """Handle --hide-listing option."""
 
-        old_make_wheelfile_inner = _wheel_archive.make_wheelfile_inner
+        if _USE_WHEELFILE:
+            old_write_files = WheelFile.write_files
 
-        def _make_wheelfile_inner(base_name, base_dir='.'):
-            with distribution_hide_listing(self.distribution) as hide_listing:
-                if hide_listing:
-                    zip_filename = base_name + ".whl"
-                    print("creating '%s' and adding '%s' to it"
-                          % (zip_filename, base_dir))
-                old_make_wheelfile_inner(base_name, base_dir)
+            def update_write_files(wheelfile_self, base_dir):
+                with distribution_hide_listing(self.distribution) as hide_listing:
+                    if hide_listing:
+                        zip_filename = wheelfile_self.filename
+                        print("creating '%s' and adding '%s' to it"
+                              % (zip_filename, base_dir))
+                    old_write_files(wheelfile_self, base_dir)
 
-        _wheel_archive.make_wheelfile_inner = _make_wheelfile_inner
+            WheelFile.distribution = self.distribution
+            WheelFile.write_files = update_write_files
 
-        try:
-            super(bdist_wheel, self).run(*args, **kwargs)
-        finally:
-            _wheel_archive.make_wheelfile_inner = old_make_wheelfile_inner
+            try:
+                super(bdist_wheel, self).run(*args, **kwargs)
+            finally:
+                WheelFile.write_files = old_write_files
+                del WheelFile.distribution
+        else:
+            old_make_wheelfile_inner = _wheel_archive.make_wheelfile_inner
+
+            def _make_wheelfile_inner(base_name, base_dir='.'):
+                with distribution_hide_listing(self.distribution) as hide_listing:
+                    if hide_listing:
+                        zip_filename = base_name + ".whl"
+                        print("creating '%s' and adding '%s' to it"
+                              % (zip_filename, base_dir))
+                    old_make_wheelfile_inner(base_name, base_dir)
+
+            _wheel_archive.make_wheelfile_inner = _make_wheelfile_inner
+
+            try:
+                super(bdist_wheel, self).run(*args, **kwargs)
+            finally:
+                _wheel_archive.make_wheelfile_inner = old_make_wheelfile_inner
 
     def finalize_options(self, *args, **kwargs):
         """Ensure MacOSX wheels include ``x86_64`` instead of ``intel``."""


### PR DESCRIPTION
This commit updates scikit-build to support changes integrated in
pypa/wheel@186ca2c

Tests were manually executed against an environment with wheel < 0.32.0 to
ensure older version of wheel are still supported.

Fixes #360