### PR TITLE
Allow for setting OSX plat_name from cmake args

### DIFF
--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -474,8 +474,31 @@ def setup(*args, **kw):  # noqa: C901
     # specified
     if sys.platform == 'darwin':
         if plat_name is None:
-            # The following code is duplicated in bdist_wheel.finalize_options()
-            plat_name = "macosx-10.6-x86_64"
+            # If cmake osx deployment args are set then set plat_name from them
+            user_set = False
+            if cmaker.has_cmake_cache_arg(
+                    cmake_args, 'CMAKE_OSX_DEPLOYMENT_TARGET'):
+                version = "".join(s for s in cmake_args
+                                  if 'CMAKE_OSX_DEPLOYMENT_TARGET'
+                                  in s).split('=')[1]
+                user_set = True
+            else:
+                version = '10.6'
+
+            if cmaker.has_cmake_cache_arg(
+                    cmake_args, 'CMAKE_OSX_ARCHITECTURES'):
+                machine = "".join(s for s in cmake_args
+                                  if 'CMAKE_OSX_ARCHITECTURES'
+                                  in s).split('=')[1]
+                user_set = True
+            else:
+                machine = 'x86_64'
+
+            plat_name = "macosx-{}-{}".format(version, machine)
+            # Set plat_name sys arg so that next command, e.g. bdist_wheel
+            # inherits this information.
+            if user_set:
+                sys.argv += ['--plat-name', plat_name]
 
         (_, version, machine) = plat_name.split('-')
         if not cmaker.has_cmake_cache_arg(

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -501,7 +501,7 @@ def setup(*args, **kw):  # noqa: C901
             # inherits this information.
             if user_set:
                 sys.argv += ['--plat-name', plat_name]
-        
+
         (_, version, machine) = plat_name.split('-')
         if not cmaker.has_cmake_cache_arg(
                 cmake_args, 'CMAKE_OSX_DEPLOYMENT_TARGET'):

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -474,22 +474,24 @@ def setup(*args, **kw):  # noqa: C901
     # specified
     if sys.platform == 'darwin':
         if plat_name is None:
-            # If cmake osx deployment args are set then set plat_name from them
+            # If cmake osx deployment args are set then set plat from them
             user_set = False
             if cmaker.has_cmake_cache_arg(
                     cmake_args, 'CMAKE_OSX_DEPLOYMENT_TARGET'):
-                version = "".join(s for s in cmake_args
-                                  if 'CMAKE_OSX_DEPLOYMENT_TARGET'
-                                  in s).split('=')[1]
+                # The loop here allows for cli flags to overload
+                # those set in the setup file.
+                for s in cmake_args:
+                    if 'CMAKE_OSX_DEPLOYMENT_TARGET' in s:
+                        version = s.split('=')[1]
                 user_set = True
             else:
                 version = '10.6'
 
             if cmaker.has_cmake_cache_arg(
                     cmake_args, 'CMAKE_OSX_ARCHITECTURES'):
-                machine = "".join(s for s in cmake_args
-                                  if 'CMAKE_OSX_ARCHITECTURES'
-                                  in s).split('=')[1]
+                for s in cmake_args:
+                    if 'CMAKE_OSX_ARCHITECTURES' in s:
+                        machine = s.split('=')[1]
                 user_set = True
             else:
                 machine = 'x86_64'
@@ -499,7 +501,7 @@ def setup(*args, **kw):  # noqa: C901
             # inherits this information.
             if user_set:
                 sys.argv += ['--plat-name', plat_name]
-
+        
         (_, version, machine) = plat_name.split('-')
         if not cmaker.has_cmake_cache_arg(
                 cmake_args, 'CMAKE_OSX_DEPLOYMENT_TARGET'):


### PR DESCRIPTION
It is possible to change the target OSX platform using `--plat-name macosx-10.x-x86_64` or via the cmake args `'-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.x', '-DCMAKE_OSX_ARCHITECTURES:STRING=x86_64'`.  However, only the former sets the platform correctly for output wheels, e.g. via `bdist_wheel`.  Therefore its is possible to build for `macosx-10.9-x86_64`, as required for the latest version of OSX, but have the output wheel still say `macosx-10.6-x86_64`.  

This PR sets the `plat_name` for OSX from the cmake args if they are explicitly set by the user, and propagates this to the later build commands by appending to the `sys.argv` so that it behaves in the same manner as doing `--plat-name macosx-10.x-x86_64`