### PR TITLE
Add support for build_ext and --inplace

### DIFF
--- a/skbuild/command/build_ext.py
+++ b/skbuild/command/build_ext.py
@@ -1,13 +1,47 @@
 """This module defines custom implementation of ``build_ext`` setuptools command."""
 
+import os
+
+from distutils.file_util import copy_file
+
 try:
     from setuptools.command.build_ext import build_ext as _build_ext
 except ImportError:
     from distutils.command.build_ext import build_ext as _build_ext
 
 from . import set_build_base_mixin
+from ..constants import CMAKE_INSTALL_DIR
 from ..utils import new_style
 
 
 class build_ext(set_build_base_mixin, new_style(_build_ext)):
     """Custom implementation of ``build_ext`` setuptools command."""
+
+    def copy_extensions_to_source(self):
+        """This function is only-called when doing inplace build.
+
+        It is customized to ensure the extensions compiled using distutils
+        are copied back to the source tree instead of the :func:`skbuild.constants.CMAKE_INSTALL_DIR()`.
+        """
+        build_py = self.get_finalized_command('build_py')
+        for ext in self.extensions:
+            fullname = self.get_ext_fullname(ext.name)
+            filename = self.get_ext_filename(fullname)
+            modpath = fullname.split('.')
+            package = '.'.join(modpath[:-1])
+            package_dir = build_py.get_package_dir(package)
+            # skbuild: strip install dir for inplace build
+            package_dir = package_dir[len(CMAKE_INSTALL_DIR()) + 1:]
+            dest_filename = os.path.join(package_dir,
+                                         os.path.basename(filename))
+            src_filename = os.path.join(self.build_lib, filename)
+
+            # Always copy, even if source is older than destination, to ensure
+            # that the right extensions for the current Python/platform are
+            # used.
+            copy_file(
+                src_filename, dest_filename, verbose=self.verbose,
+                dry_run=self.dry_run
+            )
+            if ext._needs_stub:
+                self.write_stub(package_dir or os.curdir, ext, True)

--- a/skbuild/command/build_ext.py
+++ b/skbuild/command/build_ext.py
@@ -1,0 +1,13 @@
+"""This module defines custom implementation of ``build_ext`` setuptools command."""
+
+try:
+    from setuptools.command.build_ext import build_ext as _build_ext
+except ImportError:
+    from distutils.command.build_ext import build_ext as _build_ext
+
+from . import set_build_base_mixin
+from ..utils import new_style
+
+
+class build_ext(set_build_base_mixin, new_style(_build_ext)):
+    """Custom implementation of ``build_ext`` setuptools command."""

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -37,7 +37,7 @@ from setuptools import setup as upstream_setup
 from setuptools.dist import Distribution as upstream_Distribution
 
 from . import cmaker
-from .command import (build, build_py, clean,
+from .command import (build, build_ext, build_py, clean,
                       install, install_lib, install_scripts,
                       bdist, bdist_wheel, egg_info,
                       sdist, generate_source_manifest, test)
@@ -296,6 +296,7 @@ def _should_run_cmake(commands, cmake_with_sdist):
     is found in ``commands``."""
     for expected_command in [
         "build",
+        "build_ext",
         "develop",
         "install",
         "install_lib",
@@ -353,6 +354,7 @@ def setup(*args, **kw):  # noqa: C901
     cmdclass = kw.get('cmdclass', {})
     cmdclass['build'] = cmdclass.get('build', build.build)
     cmdclass['build_py'] = cmdclass.get('build_py', build_py.build_py)
+    cmdclass['build_ext'] = cmdclass.get('build_ext', build_ext.build_ext)
     cmdclass['install'] = cmdclass.get('install', install.install)
     cmdclass['install_lib'] = cmdclass.get('install_lib',
                                            install_lib.install_lib)
@@ -606,7 +608,9 @@ def setup(*args, **kw):  # noqa: C901
                            py_modules, new_py_modules,
                            scripts, new_scripts,
                            data_files)
-    if developer_mode:
+
+    # Is there a better way to check the command line args?
+    if developer_mode or '--inplace' in sys.argv:
         # Copy packages
         for package, package_file_list in package_data.items():
             for package_file in package_file_list:
@@ -614,6 +618,8 @@ def setup(*args, **kw):  # noqa: C901
                 cmake_file = os.path.join(CMAKE_INSTALL_DIR(), package_file)
                 if os.path.exists(cmake_file):
                     _copy_file(cmake_file, package_file, hide_listing)
+
+    if developer_mode:
         # Copy modules
         for py_module in py_modules:
             package_file = py_module + ".py"

--- a/tests/samples/issue-284-build-ext-inplace/CMakeLists.txt
+++ b/tests/samples/issue-284-build-ext-inplace/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.5.0)
+
+project(hello)
+
+find_package(PythonExtensions REQUIRED)
+
+add_library(_hello_sk MODULE hello/_hello_sk.cxx)
+python_extension_module(_hello_sk)
+
+install(TARGETS _hello_sk LIBRARY DESTINATION hello)

--- a/tests/samples/issue-284-build-ext-inplace/hello/_hello_ext.cxx
+++ b/tests/samples/issue-284-build-ext-inplace/hello/_hello_ext.cxx
@@ -1,0 +1,65 @@
+
+// Python includes
+#include <Python.h>
+
+// STD includes
+#include <stdio.h>
+
+//-----------------------------------------------------------------------------
+static PyObject *hello_example(PyObject *self, PyObject *args)
+{
+  // Unpack a string from the arguments
+  const char *strArg;
+  if (!PyArg_ParseTuple(args, "s", &strArg))
+    return NULL;
+
+  // Print message and return None
+  PySys_WriteStdout("Hello, %s! :)\n", strArg);
+  Py_RETURN_NONE;
+}
+
+//-----------------------------------------------------------------------------
+static PyObject *elevation_example(PyObject *self, PyObject *args)
+{
+  // Return an integer
+  return PyLong_FromLong(21463L);
+}
+
+//-----------------------------------------------------------------------------
+static PyMethodDef hello_methods[] = {
+  {
+    "hello",
+    hello_example,
+    METH_VARARGS,
+    "Prints back 'Hello <param>', for example example: hello.hello('you')"
+  },
+
+  {
+    "size",
+    elevation_example,
+    METH_VARARGS,
+    "Returns elevation of Nevado Sajama."
+  },
+  {NULL, NULL, 0, NULL}        /* Sentinel */
+};
+
+//-----------------------------------------------------------------------------
+#if PY_MAJOR_VERSION < 3
+PyMODINIT_FUNC init_hello_ext(void)
+{
+  (void) Py_InitModule("_hello_ext", hello_methods);
+}
+#else /* PY_MAJOR_VERSION >= 3 */
+static struct PyModuleDef hello_module_def = {
+  PyModuleDef_HEAD_INIT,
+  "_hello_ext",
+  "Internal \"_hello_ext\" module",
+  -1,
+  hello_methods
+};
+
+PyMODINIT_FUNC PyInit__hello_ext(void)
+{
+  return PyModule_Create(&hello_module_def);
+}
+#endif /* PY_MAJOR_VERSION >= 3 */

--- a/tests/samples/issue-284-build-ext-inplace/hello/_hello_sk.cxx
+++ b/tests/samples/issue-284-build-ext-inplace/hello/_hello_sk.cxx
@@ -1,0 +1,65 @@
+
+// Python includes
+#include <Python.h>
+
+// STD includes
+#include <stdio.h>
+
+//-----------------------------------------------------------------------------
+static PyObject *hello_example(PyObject *self, PyObject *args)
+{
+  // Unpack a string from the arguments
+  const char *strArg;
+  if (!PyArg_ParseTuple(args, "s", &strArg))
+    return NULL;
+
+  // Print message and return None
+  PySys_WriteStdout("Hello, %s! :)\n", strArg);
+  Py_RETURN_NONE;
+}
+
+//-----------------------------------------------------------------------------
+static PyObject *elevation_example(PyObject *self, PyObject *args)
+{
+  // Return an integer
+  return PyLong_FromLong(21463L);
+}
+
+//-----------------------------------------------------------------------------
+static PyMethodDef hello_methods[] = {
+  {
+    "hello",
+    hello_example,
+    METH_VARARGS,
+    "Prints back 'Hello <param>', for example example: hello.hello('you')"
+  },
+
+  {
+    "size",
+    elevation_example,
+    METH_VARARGS,
+    "Returns elevation of Nevado Sajama."
+  },
+  {NULL, NULL, 0, NULL}        /* Sentinel */
+};
+
+//-----------------------------------------------------------------------------
+#if PY_MAJOR_VERSION < 3
+PyMODINIT_FUNC init_hello_sk(void)
+{
+  (void) Py_InitModule("_hello_sk", hello_methods);
+}
+#else /* PY_MAJOR_VERSION >= 3 */
+static struct PyModuleDef hello_module_def = {
+  PyModuleDef_HEAD_INIT,
+  "_hello_sk",
+  "Internal \"_hello_sk\" module",
+  -1,
+  hello_methods
+};
+
+PyMODINIT_FUNC PyInit__hello_sk(void)
+{
+  return PyModule_Create(&hello_module_def);
+}
+#endif /* PY_MAJOR_VERSION >= 3 */

--- a/tests/samples/issue-284-build-ext-inplace/setup.py
+++ b/tests/samples/issue-284-build-ext-inplace/setup.py
@@ -1,0 +1,18 @@
+
+from setuptools import Extension
+from skbuild import setup
+
+setup(
+    name="hello",
+    version="1.2.3",
+    description="a minimal example package",
+    author='The scikit-build team',
+    license="MIT",
+    packages=['hello'],
+    ext_modules=[
+        Extension(
+            'hello._hello_ext',
+            sources=['hello/_hello_ext.cxx'],
+        )
+    ]
+)

--- a/tests/test_issue284_build_ext_inplace.py
+++ b/tests/test_issue284_build_ext_inplace.py
@@ -1,0 +1,15 @@
+
+import os
+import sysconfig
+
+from distutils import sysconfig as du_sysconfig
+
+from . import project_setup_py_test
+
+
+@project_setup_py_test("issue-284-build-ext-inplace", ["build_ext", "--inplace"], disable_languages_test=True)
+def test_build_ext_inplace_command():
+    assert os.path.exists('hello/_hello_sk%s' % sysconfig.get_config_var('SO'))
+
+    # See issue scikit-build #383
+    assert os.path.exists('hello/_hello_ext%s' % du_sysconfig.get_config_var('SO'))


### PR DESCRIPTION
This PR addresses issues (#284 and #352) where command `python setup.py build_ext --inplace` fails when using scikit-build. To allow for running `build_ext`, I wrote a command class following the template I saw in `build` and `build_py`. Unfortunately, this didn't just make the normal `--inplace` option work because the `setuptools.**.build_ext` command only copies registered extension modules, which the cmake outputs are not. To remedy this I simply hacked in a check for `'--inplace' in sys.argv` and then copied the libraries to the source directory as would be done in "developer_mode". 

I'm not 100% this is the best way to implement the feature as (1) setuptools is complex and (2) I'm still getting familiar with how this library works and its standards. 
