### PR TITLE
Sync setup with dev requirments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open('requirements-dev.txt', 'r') as fp:
     dev_requirements = list(filter(bool, (line.strip() for line in fp)))
 
 # Require pytest-runner only when running tests
-pytest_runner = (['pytest-runner>=2.0,<3dev']
+pytest_runner = (['pytest-runner>=2.9']
                  if any(arg in sys.argv for arg in ('pytest', 'test'))
                  else [])
 


### PR DESCRIPTION
Currently ```setup.py``` contains an outdated requirements expression for ```pytest-runner```, which breaks testing with newer versions of the dependency.

This pull request updates this requirement based on the current ```requirements-dev.txt```.