### PR TITLE
travis: Remove obsolete Python 3.4 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,6 @@ matrix:
     - os: osx
       language: generic
       env:
-        - PYTHON_VERSION=3.4.8
-
-    - os: osx
-      language: generic
-      env:
         - PYTHON_VERSION=2.7.15
 
 cache:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,8 @@ Tests
     `sudo apt-get update` issues. See https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html
     and https://github.com/circleci/circleci-images/issues/370#issuecomment-476611431
 
+  * TravisCI: Remove obsolete Python 3.4 testing. It reached [end-of-life on March 18 2019](https://devguide.python.org/devcycle/?highlight=end%20of%20life#end-of-life-branches).
+
 
 Scikit-build 0.9.0
 ==================


### PR DESCRIPTION
See https://devguide.python.org/devcycle/?highlight=end%20of%20life#end-of-life-branches