### PR TITLE
Use sdist command from setuptools instead of distutils

### DIFF
--- a/skbuild/command/generate_source_manifest.py
+++ b/skbuild/command/generate_source_manifest.py
@@ -26,7 +26,7 @@ class generate_source_manifest(set_build_base_mixin, new_style(Command)):
     def run(self):
         """
         If neither a `MANIFEST`, nor a `MANIFEST.in` file is provided, and
-        we are in a git repo, try to create a `MANIFEST` file from the output of
+        we are in a git repo, try to create a `MANIFEST.in` file from the output of
         `git ls-tree --name-only -r HEAD`.
 
         We need a reliable way to tell if an existing `MANIFEST` file is one
@@ -49,22 +49,26 @@ class generate_source_manifest(set_build_base_mixin, new_style(Command)):
         if do_generate:
 
             try:
-                with open('MANIFEST', 'wb') as manifest_file:
+                with open('MANIFEST.in', 'wb') as manifest_in_file:
                     # Since Git < 2.11 does not support --recurse-submodules option, fallback to
                     # regular listing.
                     try:
-                        manifest_file.write(
-                            subprocess.check_output(['git', 'ls-files', '--recurse-submodules'])
-                        )
+                        cmd_out = subprocess.check_output(['git', 'ls-files', '--recurse-submodules'])
                     except subprocess.CalledProcessError:
-                        manifest_file.write(
-                             subprocess.check_output(['git', 'ls-files'])
-                         )
+                        cmd_out = subprocess.check_output(['git', 'ls-files'])
+                    git_files = [git_file.strip() for git_file in cmd_out.split(b'\n')]
+                    manifest_text = b'\n'.join([
+                        b'include %s' % git_file.strip()
+                        for git_file in git_files
+                        if git_file
+                    ])
+                    manifest_text += b'\nexclude MANIFEST.in'
+                    manifest_in_file.write(manifest_text)
             except subprocess.CalledProcessError:
                 sys.stderr.write(
                     '\n\n'
                     'Since scikit-build could not find MANIFEST.in or '
-                    'MANIFEST, it tried to generate a MANIFEST file '
+                    'MANIFEST, it tried to generate a MANIFEST.in file '
                     'automatically, but could not because it could not '
                     'determine which source files to include.\n\n'
                     'The command used was "git ls-files"\n'

--- a/skbuild/command/sdist.py
+++ b/skbuild/command/sdist.py
@@ -3,7 +3,7 @@
 import contextlib
 import os
 
-from distutils.command.sdist import sdist as _sdist
+from setuptools.command.sdist import sdist as _sdist
 
 from . import set_build_base_mixin
 from ..utils import distribution_hide_listing, new_style, distutils_log

--- a/skbuild/command/sdist.py
+++ b/skbuild/command/sdist.py
@@ -1,8 +1,5 @@
 """This module defines custom implementation of ``sdist`` setuptools command."""
 
-import contextlib
-import os
-
 from setuptools.command.sdist import sdist as _sdist
 
 from . import set_build_base_mixin
@@ -11,35 +8,6 @@ from ..utils import distribution_hide_listing, new_style, distutils_log
 
 class sdist(set_build_base_mixin, new_style(_sdist)):
     """Custom implementation of ``sdist`` setuptools command."""
-
-    def make_distribution(self):
-        """This function was originally re-implemented in setuptools to workaround
-        https://github.com/pypa/setuptools/issues/516 and later ported to scikit-build
-        to ensure symlinks are maintained.
-        """
-        with self._remove_os_link():
-            super(sdist, self).make_distribution()
-
-    @staticmethod
-    @contextlib.contextmanager
-    def _remove_os_link():
-        """In a context, remove and restore ``os.link`` if it exists.
-        """
-        # copied from setuptools.sdist
-
-        class NoValue:
-            pass
-
-        orig_val = getattr(os, 'link', NoValue)
-        try:
-            del os.link
-        except Exception:
-            pass
-        try:
-            yield
-        finally:
-            if orig_val is not NoValue:
-                os.link = orig_val
 
     def make_release_tree(self, base_dir, files):
         """Handle --hide-listing option."""

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -625,6 +625,8 @@ def setup(*args, **kw):  # noqa: C901
         sys.exit(ex)
 
     # If any, strip ending slash from each package directory
+    # Regular setuptools does not support this
+    # TODO: produce warning and deprecate
     package_dir = {package: prefix[:-1] if prefix and prefix[-1] == "/" else prefix
                    for package, prefix in package_dir.items()}
 
@@ -634,6 +636,8 @@ def setup(*args, **kw):  # noqa: C901
             package_dir[package] = package.replace(".", "/")
             if '' in package_dir:
                 package_dir[package] = to_unix_path(os.path.join(package_dir[''], package_dir[package]))
+
+    kw['package_dir'] = package_dir
 
     package_prefixes = _collect_package_prefixes(package_dir, packages)
 

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -12,6 +12,7 @@ import argparse
 import json
 import platform
 import stat
+import warnings
 
 # Must be imported before distutils
 import setuptools
@@ -372,6 +373,17 @@ def setup(*args, **kw):  # noqa: C901
     version in :func:`skbuild.constants.CMAKE_SPEC_FILE()`: and (3) re-configuring only if either the generator or
     the CMake specs change.
     """
+
+    # If any, strip ending slash from each package directory
+    # Regular setuptools does not support this
+    # TODO: will become an error in the future
+    if 'package_dir' in kw:
+        for package, prefix in kw['package_dir'].items():
+            if prefix.endswith('/'):
+                msg = 'package_dir={{{!r}: {!r}}} ends with a trailing slash, which is not supported by setuptools.'.format(package, prefix)
+                warnings.warn(msg, FutureWarning, stacklevel=2)
+                kw['package_dir'][package] = prefix[:-1]
+
     sys.argv, cmake_executable, skip_generator_test, cmake_args, make_args = parse_args()
 
     # work around https://bugs.python.org/issue1011113
@@ -623,12 +635,6 @@ def setup(*args, **kw):  # noqa: C901
         traceback.print_tb(sys.exc_info()[2])
         print('')
         sys.exit(ex)
-
-    # If any, strip ending slash from each package directory
-    # Regular setuptools does not support this
-    # TODO: produce warning and deprecate
-    package_dir = {package: prefix[:-1] if prefix and prefix[-1] == "/" else prefix
-                   for package, prefix in package_dir.items()}
 
     # If needed, set reasonable defaults for package_dir
     for package in packages:

--- a/tests/pytest_helpers.py
+++ b/tests/pytest_helpers.py
@@ -24,9 +24,9 @@ def check_sdist_content(sdist_archive, expected_distribution_name, expected_cont
     expected_name = '_'.join(expected_distribution_name.split('-')[:-1])
 
     if not package_dir:
-        egg_info_dir = '%s/%s.egg-info' % (expected_distribution_name, expected_name)
+        egg_info_dir = '{}/{}.egg-info'.format(expected_distribution_name, expected_name)
     else:
-        egg_info_dir = '%s/%s/%s.egg-info' % (expected_distribution_name, package_dir, expected_name)
+        egg_info_dir = '{}/{}/{}.egg-info'.format(expected_distribution_name, package_dir, expected_name)
 
     expected_content += [
        '%s/PKG-INFO' % expected_distribution_name,

--- a/tests/pytest_helpers.py
+++ b/tests/pytest_helpers.py
@@ -11,7 +11,7 @@ from skbuild import __version__ as skbuild_version
 from . import list_ancestors
 
 
-def check_sdist_content(sdist_archive, expected_distribution_name, expected_content):
+def check_sdist_content(sdist_archive, expected_distribution_name, expected_content, package_dir=''):
     """This function raises an AssertionError if the given sdist_archive
     does not have the expected content.
     """
@@ -21,8 +21,20 @@ def check_sdist_content(sdist_archive, expected_distribution_name, expected_cont
 
     expected_content = list(expected_content)
 
+    expected_name = '_'.join(expected_distribution_name.split('-')[:-1])
+
+    if not package_dir:
+        egg_info_dir = '%s/%s.egg-info' % (expected_distribution_name, expected_name)
+    else:
+        egg_info_dir = '%s/%s/%s.egg-info' % (expected_distribution_name, package_dir, expected_name)
+
     expected_content += [
        '%s/PKG-INFO' % expected_distribution_name,
+       '%s/setup.cfg' % expected_distribution_name,
+       '%s/dependency_links.txt' % egg_info_dir,
+       '%s/top_level.txt' % egg_info_dir,
+       '%s/PKG-INFO' % egg_info_dir,
+       '%s/SOURCES.txt' % egg_info_dir,
     ]
 
     if sdist_zip and (

--- a/tests/samples/hello-cython/setup.py
+++ b/tests/samples/hello-cython/setup.py
@@ -8,5 +8,5 @@ setup(
     license="MIT",
     packages=['hello_cython'],
     # The extra '/' was *only* added to check that scikit-build can handle it.
-    package_dir={'hello_cython': 'hello'},
+    package_dir={'hello_cython': 'hello/'},
 )

--- a/tests/samples/hello-cython/setup.py
+++ b/tests/samples/hello-cython/setup.py
@@ -8,5 +8,5 @@ setup(
     license="MIT",
     packages=['hello_cython'],
     # The extra '/' was *only* added to check that scikit-build can handle it.
-    package_dir={'hello_cython': 'hello/'},
+    package_dir={'hello_cython': 'hello'},
 )

--- a/tests/samples/test-include-exclude-data-with-base/MANIFEST.in
+++ b/tests/samples/test-include-exclude-data-with-base/MANIFEST.in
@@ -5,3 +5,4 @@ include src/hello/data/subdata/*.txt
 include src/hello2/data2/subdata2/*.txt
 
 exclude src/*/data*/subdata*/*_exclude_from_manifest.txt
+exclude MANIFEST.in

--- a/tests/samples/test-include-exclude-data/MANIFEST.in
+++ b/tests/samples/test-include-exclude-data/MANIFEST.in
@@ -5,3 +5,4 @@ include hello/data/subdata/*.txt
 include hello2/data2/subdata2/*.txt
 
 exclude */data*/subdata*/*_exclude_from_manifest.txt
+exclude MANIFEST.in

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -180,7 +180,7 @@ def test_hide_listing(action, hide_listing, capfd, caplog):
         assert to_platform_path("bonjour/__init__.py") in out
 
     if action == "sdist":
-        assert "copied 10 files" in out
+        assert "copied 15 files" in out
     elif action == "bdist_wheel":
         assert "copied 6 files" in out  # build_py
         assert "copied 9 files" in out  # install_lib

--- a/tests/test_hello_cython.py
+++ b/tests/test_hello_cython.py
@@ -42,7 +42,7 @@ def test_hello_cython_sdist():
     if sdists_tar:
         sdist_archive = 'dist/hello-cython-1.2.3.tar.gz'
 
-    check_sdist_content(sdist_archive, 'hello-cython-1.2.3', expected_content)
+    check_sdist_content(sdist_archive, 'hello-cython-1.2.3', expected_content, package_dir='hello')
 
 
 @project_setup_py_test("hello-cython", ["bdist_wheel"])

--- a/tests/test_include_exclude_data.py
+++ b/tests/test_include_exclude_data.py
@@ -60,7 +60,7 @@ def check_sdist(proj, base=''):
     if sdists_tar:
         sdist_archive = 'dist/%s.tar.gz' % proj
 
-    check_sdist_content(sdist_archive, proj, expected_content)
+    check_sdist_content(sdist_archive, proj, expected_content, package_dir=base)
 
 
 @project_setup_py_test("test-include-exclude-data", ["bdist_wheel"])

--- a/tests/test_issue401_sdist_with_symlinks.py
+++ b/tests/test_issue401_sdist_with_symlinks.py
@@ -20,6 +20,7 @@ def test_sdist_with_symlinks():
     assert sdists_tar or sdists_zip
 
     expected_content = [
+        'hello-1.2.3/MANIFEST.in',
         'hello-1.2.3/README',
         'hello-1.2.3/setup.py',
         'hello-1.2.3/VERSION',

--- a/tests/test_manifest_in.py
+++ b/tests/test_manifest_in.py
@@ -21,7 +21,8 @@ def test_manifest_in_sdist():
 
     expected_content = [
         'manifest-in-1.2.3/hello/__init__.py',
-        'manifest-in-1.2.3/setup.py'
+        'manifest-in-1.2.3/setup.py',
+        'manifest-in-1.2.3/MANIFEST.in',
     ]
 
     sdist_archive = 'dist/manifest-in-1.2.3.zip'


### PR DESCRIPTION
Fixes https://github.com/scikit-build/scikit-build/issues/401.

Notes:
* Updated `generate_source_manifest.py` to produce a `MANIFEST.in` file instead of a `MANIFEST` file.