### PR TITLE
test: Fix reporting of assert associated with check_wheel_content

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,8 +37,9 @@ Tests
   adds directory entries to ZIP files created by distutils. Thanks :user:`anibali` for the
   contribution. See :issue:`404`.
 
-* Fix ``check_wheel_content()`` to consider change in ``wheel > 0.33.1`` where directory
-  entries are included when building wheel.
+* Fix ``check_wheel_content()`` to consider changes in ``0.33.1 < wheel.__version__ < 0.33.4``
+  where directory entries are included when building wheel.
+  See _`pypa/wheel#294 <https://github.com/pypa/wheel/issues/294>`.
 
 * Fix reporting of ``AssertionError`` raised in ``check_wheel_content()`` function by relocating the
   source code into a dedicated module ``tests.pytest_helpers`` and by adding a ``conftest.py``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,11 @@ Documentation
 Tests
 -----
 
+* Fix reporting of ``AssertionError`` raised in ``check_wheel_content()`` function by relocating the
+  source code into a dedicated module ``tests.pytest_helpers`` and by adding a ``conftest.py``
+  configuration file registering it for pytest assertion rewriting.
+  See https://docs.pytest.org/en/latest/writing_plugins.html#assertion-rewriting and :issue:`403`.
+
 * Fix ``test_generator_selection`` when building with "Visual C++ for Python 2.7"
   installed for all users. This addresses failure associated with ``win_c_compilervs2008cxx_compilervs2008python2.7``
   when running test in `scikit-build-feedstock <https://github.com/conda-forge/scikit-build-feedstock>`_ where

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,12 @@ Documentation
 Tests
 -----
 
+* Introduce ``check_sdist_content()`` and fix tests that are checking content of sdist to
+  account for changes introduced in Python 3.8 and backported to python 2.7, 3.6 and 3.7.
+  The changes introduced in `python/cpython#9419 <https://github.com/python/cpython/pull/9419>`_
+  adds directory entries to ZIP files created by distutils. Thanks :user:`anibali` for the
+  contribution. See :issue:`404`.
+
 * Fix ``check_wheel_content()`` to consider change in ``wheel > 0.33.1`` where directory
   entries are included when building wheel.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,9 @@ Documentation
 Tests
 -----
 
+* Fix ``check_wheel_content()`` to consider change in ``wheel > 0.33.1`` where directory
+  entries are included when building wheel.
+
 * Fix reporting of ``AssertionError`` raised in ``check_wheel_content()`` function by relocating the
   source code into a dedicated module ``tests.pytest_helpers`` and by adding a ``conftest.py``
   configuration file registering it for pytest assertion rewriting.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ codecov>=2.0.5
 coverage>=4.2
 cython>=0.25.1
 flake8>=3.0.4
+pathlib2; python_version < '3.0'
 path.py>=11.5.0
 pytest>=3.0.3
 pytest-cov>=2.4.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,12 @@ import distutils
 import os
 import os.path
 import pkg_resources
+
+try:
+    import pathlib
+except ImportError:
+    import pathlib2 as pathlib  # Python 2.7
+
 import py.path
 import re
 import requests
@@ -292,10 +298,4 @@ def is_site_reachable(url):
 def list_ancestors(path):
     """Return logical ancestors of the path.
     """
-    path = os.path.split(path)[0]
-    if not path:
-        return []
-    elif path == "/":
-        return ["/"]
-    else:
-        return [path + "/"] + list_ancestors(path)
+    return [str(parent) for parent in pathlib.PurePosixPath(path).parents if str(parent) != "."]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -287,3 +287,15 @@ def is_site_reachable(url):
         return request.status_code == 200
     except requests.exceptions.ConnectionError:
         return False
+
+
+def list_ancestors(path):
+    """Return logical ancestors of the path.
+    """
+    path = os.path.split(path)[0]
+    if not path:
+        return []
+    elif path == "/":
+        return ["/"]
+    else:
+        return [path + "/"] + list_ancestors(path)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,18 +11,13 @@ import requests
 import six
 import subprocess
 import sys
-import wheel
 
 from contextlib import contextmanager
 from mock import patch
-from pkg_resources import parse_version
 
-from skbuild import __version__ as skbuild_version
 from skbuild.compat import which  # noqa: F401
 from skbuild.utils import push_dir
 from skbuild.platform_specifics import get_platform
-
-from zipfile import ZipFile
 
 
 SAMPLES_DIR = os.path.join(
@@ -292,48 +287,3 @@ def is_site_reachable(url):
         return request.status_code == 200
     except requests.exceptions.ConnectionError:
         return False
-
-
-def check_wheel_content(wheel_archive, expected_distribution_name, expected_content, pure=False):
-    """This function raises an AssertionError if the given wheel_archive
-    does not have the expected content.
-
-    Note that this function already takes care of appending the
-    ``<expected_distribution_name>.dist-info`` files to the ``expected_content``
-    list.
-    """
-
-    expected_content = list(expected_content)
-    expected_content += [
-        '%s.dist-info/top_level.txt' % expected_distribution_name,
-        '%s.dist-info/WHEEL' % expected_distribution_name,
-        '%s.dist-info/RECORD' % expected_distribution_name,
-        '%s.dist-info/METADATA' % expected_distribution_name
-    ]
-
-    if parse_version(wheel.__version__) < parse_version('0.31.0'):
-        expected_content += [
-            '%s.dist-info/DESCRIPTION.rst' % expected_distribution_name,
-            '%s.dist-info/metadata.json' % expected_distribution_name
-        ]
-
-    if pure:
-        assert wheel_archive.endswith('-none-any.whl')
-    else:
-        assert not wheel_archive.endswith('-none-any.whl')
-
-    archive = ZipFile(wheel_archive)
-    member_list = archive.namelist()
-
-    assert sorted(expected_content) == sorted(member_list)
-
-    # PEP-0427: Generator is the name and optionally the version of the
-    # software that produced the archive.
-    # See https://www.python.org/dev/peps/pep-0427/#file-contents
-    current_generator = None
-    with archive.open("%s.dist-info/WHEEL" % expected_distribution_name) as wheel_file:
-        for line in wheel_file:
-            if line.startswith(b"Generator"):
-                current_generator = line.split(b":")[1].strip()
-                break
-    assert current_generator == six.b("skbuild %s" % skbuild_version)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.register_assert_rewrite('tests.pytest_helpers')

--- a/tests/pytest_helpers.py
+++ b/tests/pytest_helpers.py
@@ -1,0 +1,53 @@
+
+import six
+import wheel
+
+from pkg_resources import parse_version
+from zipfile import ZipFile
+
+from skbuild import __version__ as skbuild_version
+
+
+def check_wheel_content(wheel_archive, expected_distribution_name, expected_content, pure=False):
+    """This function raises an AssertionError if the given wheel_archive
+    does not have the expected content.
+
+    Note that this function already takes care of appending the
+    ``<expected_distribution_name>.dist-info`` files to the ``expected_content``
+    list.
+    """
+
+    expected_content = list(expected_content)
+    expected_content += [
+        '%s.dist-info/top_level.txt' % expected_distribution_name,
+        '%s.dist-info/WHEEL' % expected_distribution_name,
+        '%s.dist-info/RECORD' % expected_distribution_name,
+        '%s.dist-info/METADATA' % expected_distribution_name
+    ]
+
+    if parse_version(wheel.__version__) < parse_version('0.31.0'):
+        expected_content += [
+            '%s.dist-info/DESCRIPTION.rst' % expected_distribution_name,
+            '%s.dist-info/metadata.json' % expected_distribution_name
+        ]
+
+    if pure:
+        assert wheel_archive.endswith('-none-any.whl')
+    else:
+        assert not wheel_archive.endswith('-none-any.whl')
+
+    archive = ZipFile(wheel_archive)
+    member_list = archive.namelist()
+
+    assert sorted(expected_content) == sorted(member_list)
+
+    # PEP-0427: Generator is the name and optionally the version of the
+    # software that produced the archive.
+    # See https://www.python.org/dev/peps/pep-0427/#file-contents
+    current_generator = None
+    with archive.open("%s.dist-info/WHEEL" % expected_distribution_name) as wheel_file:
+        for line in wheel_file:
+            if line.startswith(b"Generator"):
+                current_generator = line.split(b":")[1].strip()
+                break
+    assert current_generator == six.b("skbuild %s" % skbuild_version)

--- a/tests/pytest_helpers.py
+++ b/tests/pytest_helpers.py
@@ -40,7 +40,7 @@ def check_wheel_content(wheel_archive, expected_distribution_name, expected_cont
         # See https://github.com/pypa/wheel/issues/287
         directories = set()
         for entry in expected_content:
-            directories = directories.union(list_ancestors(entry))
+            directories = directories.union([entry + "/" for entry in list_ancestors(entry)])
         expected_content += directories
 
     if pure:

--- a/tests/pytest_helpers.py
+++ b/tests/pytest_helpers.py
@@ -73,9 +73,9 @@ def check_wheel_content(wheel_archive, expected_distribution_name, expected_cont
             '%s.dist-info/metadata.json' % expected_distribution_name
         ]
 
-    if parse_version(wheel.__version__) > parse_version('0.33.1'):
+    if parse_version('0.33.1') < parse_version(wheel.__version__) < parse_version('0.33.4'):
         # Include directory entries when building wheel
-        # See https://github.com/pypa/wheel/issues/287
+        # See https://github.com/pypa/wheel/issues/287 and https://github.com/pypa/wheel/issues/294
         directories = set()
         for entry in expected_content:
             directories = directories.union([entry + "/" for entry in list_ancestors(entry)])

--- a/tests/test_cmakelists_not_in_top_level_dir.py
+++ b/tests/test_cmakelists_not_in_top_level_dir.py
@@ -11,14 +11,12 @@ keyword works.
 
 import glob
 import pytest
-import tarfile
 import textwrap
-
-from zipfile import ZipFile
 
 from skbuild.exceptions import SKBuildError
 
 from . import (_tmpdir, execute_setup_py, project_setup_py_test)
+from .pytest_helpers import check_sdist_content
 
 
 @project_setup_py_test("cmakelists-not-in-top-level-dir", ["build"], disable_languages_test=True)
@@ -76,19 +74,12 @@ def test_hello_sdist():
         'hello-1.2.3/hello/__init__.py',
         'hello-1.2.3/hello/__main__.py',
         'hello-1.2.3/setup.py',
-        'hello-1.2.3/PKG-INFO'
     ]
 
-    member_list = None
+    sdist_archive = None
     if sdists_tar:
-        expected_content.extend([
-            'hello-1.2.3',
-            'hello-1.2.3/hello'
-        ])
-        member_list = tarfile.open('dist/hello-1.2.3.tar.gz').getnames()
-
+        sdist_archive = 'dist/hello-1.2.3.tar.gz'
     elif sdists_zip:
-        member_list = ZipFile('dist/hello-1.2.3.zip').namelist()
+        sdist_archive = 'dist/hello-1.2.3.zip'
 
-    assert expected_content and member_list
-    assert sorted(expected_content) == sorted(member_list)
+    check_sdist_content(sdist_archive, 'hello-1.2.3', expected_content)

--- a/tests/test_hello_cpp.py
+++ b/tests/test_hello_cpp.py
@@ -11,16 +11,13 @@ import glob
 import os
 import pytest
 import sysconfig
-import tarfile
 
 from skbuild.constants import CMAKE_BUILD_DIR, CMAKE_INSTALL_DIR, SKBUILD_DIR
 from skbuild.utils import push_dir
 
-from zipfile import ZipFile
-
 from . import project_setup_py_test
 from . import (_copy_dir, _tmpdir, SAMPLES_DIR)
-from .pytest_helpers import check_wheel_content
+from .pytest_helpers import check_sdist_content, check_wheel_content
 
 
 def test_hello_builds():
@@ -64,24 +61,13 @@ def test_hello_sdist():
         'hello-1.2.3/hello/__init__.py',
         'hello-1.2.3/hello/__main__.py',
         'hello-1.2.3/setup.py',
-        'hello-1.2.3/PKG-INFO'
     ]
 
-    member_list = None
+    sdist_archive = 'dist/hello-1.2.3.zip'
     if sdists_tar:
-        expected_content.extend([
-            'hello-1.2.3',
-            'hello-1.2.3/bonjour',
-            'hello-1.2.3/bonjour/data',
-            'hello-1.2.3/hello'
-        ])
-        member_list = tarfile.open('dist/hello-1.2.3.tar.gz').getnames()
+        sdist_archive = 'dist/hello-1.2.3.tar.gz'
 
-    elif sdists_zip:
-        member_list = ZipFile('dist/hello-1.2.3.zip').namelist()
-
-    assert expected_content and member_list
-    assert sorted(expected_content) == sorted(member_list)
+    check_sdist_content(sdist_archive, 'hello-1.2.3', expected_content)
 
 
 def test_hello_wheel():

--- a/tests/test_hello_cpp.py
+++ b/tests/test_hello_cpp.py
@@ -18,8 +18,9 @@ from skbuild.utils import push_dir
 
 from zipfile import ZipFile
 
-from . import check_wheel_content, project_setup_py_test
+from . import project_setup_py_test
 from . import (_copy_dir, _tmpdir, SAMPLES_DIR)
+from .pytest_helpers import check_wheel_content
 
 
 def test_hello_builds():

--- a/tests/test_hello_cython.py
+++ b/tests/test_hello_cython.py
@@ -13,7 +13,8 @@ import tarfile
 
 from zipfile import ZipFile
 
-from . import check_wheel_content, project_setup_py_test
+from . import project_setup_py_test
+from .pytest_helpers import check_wheel_content
 
 
 @project_setup_py_test("hello-cython", ["build"])

--- a/tests/test_hello_cython.py
+++ b/tests/test_hello_cython.py
@@ -9,12 +9,9 @@ Tries to build and test the `hello-cython` sample project.
 
 import glob
 import sysconfig
-import tarfile
-
-from zipfile import ZipFile
 
 from . import project_setup_py_test
-from .pytest_helpers import check_wheel_content
+from .pytest_helpers import check_sdist_content, check_wheel_content
 
 
 @project_setup_py_test("hello-cython", ["build"])
@@ -40,22 +37,13 @@ def test_hello_cython_sdist():
         'hello-cython-1.2.3/hello/__init__.py',
         'hello-cython-1.2.3/hello/__main__.py',
         'hello-cython-1.2.3/setup.py',
-        'hello-cython-1.2.3/PKG-INFO'
     ]
 
-    member_list = None
+    sdist_archive = 'dist/hello-cython-1.2.3.zip'
     if sdists_tar:
-        expected_content.extend([
-            'hello-cython-1.2.3',
-            'hello-cython-1.2.3/hello'
-        ])
-        member_list = tarfile.open('dist/hello-cython-1.2.3.tar.gz').getnames()
+        sdist_archive = 'dist/hello-cython-1.2.3.tar.gz'
 
-    elif sdists_zip:
-        member_list = ZipFile('dist/hello-cython-1.2.3.zip').namelist()
-
-    assert expected_content and member_list
-    assert sorted(expected_content) == sorted(member_list)
+    check_sdist_content(sdist_archive, 'hello-cython-1.2.3', expected_content)
 
 
 @project_setup_py_test("hello-cython", ["bdist_wheel"])

--- a/tests/test_hello_pure.py
+++ b/tests/test_hello_pure.py
@@ -15,7 +15,8 @@ from skbuild.utils import push_dir
 
 from zipfile import ZipFile
 
-from . import check_wheel_content, project_setup_py_test
+from . import project_setup_py_test
+from .pytest_helpers import check_wheel_content
 
 
 @project_setup_py_test("hello-pure", ["build"], disable_languages_test=True)

--- a/tests/test_hello_pure.py
+++ b/tests/test_hello_pure.py
@@ -8,15 +8,12 @@ Tries to build and test the `hello-pure` sample project.
 """
 
 import glob
-import tarfile
 
 from skbuild.constants import SKBUILD_DIR
 from skbuild.utils import push_dir
 
-from zipfile import ZipFile
-
 from . import project_setup_py_test
-from .pytest_helpers import check_wheel_content
+from .pytest_helpers import check_sdist_content, check_wheel_content
 
 
 @project_setup_py_test("hello-pure", ["build"], disable_languages_test=True)
@@ -30,34 +27,22 @@ def test_hello_pure_builds(capsys):
 #     pass
 
 
-@project_setup_py_test("hello-pure", ["sdist"], disable_languages_test=True)
-def test_hello_pure_sdist():
+@project_setup_py_test("hello-pure", ["sdist"])
+def test_hello_cython_sdist():
     sdists_tar = glob.glob('dist/*.tar.gz')
     sdists_zip = glob.glob('dist/*.zip')
     assert sdists_tar or sdists_zip
 
-    member_list = None
-    expected_content = None
+    expected_content = [
+        'hello-pure-1.2.3/hello/__init__.py',
+        'hello-pure-1.2.3/setup.py',
+    ]
+
+    sdist_archive = 'dist/hello-pure-1.2.3.zip'
     if sdists_tar:
-        expected_content = [
-            'hello-pure-1.2.3',
-            'hello-pure-1.2.3/hello',
-            'hello-pure-1.2.3/hello/__init__.py',
-            'hello-pure-1.2.3/setup.py',
-            'hello-pure-1.2.3/PKG-INFO'
-        ]
-        member_list = tarfile.open('dist/hello-pure-1.2.3.tar.gz').getnames()
+        sdist_archive = 'dist/hello-pure-1.2.3.tar.gz'
 
-    elif sdists_zip:
-        expected_content = [
-            'hello-pure-1.2.3/hello/__init__.py',
-            'hello-pure-1.2.3/setup.py',
-            'hello-pure-1.2.3/PKG-INFO'
-        ]
-        member_list = ZipFile('dist/hello-pure-1.2.3.zip').namelist()
-
-    assert expected_content and member_list
-    assert sorted(expected_content) == sorted(member_list)
+    check_sdist_content(sdist_archive, 'hello-pure-1.2.3', expected_content)
 
 
 @project_setup_py_test("hello-pure", ["bdist_wheel"], disable_languages_test=True)

--- a/tests/test_include_exclude_data.py
+++ b/tests/test_include_exclude_data.py
@@ -1,14 +1,13 @@
 import glob
 import os
 import tarfile
-import wheel
 
-from pkg_resources import parse_version
 from zipfile import ZipFile
 
 from skbuild.utils import to_unix_path
 
 from . import project_setup_py_test
+from .pytest_helpers import check_wheel_content
 
 
 def check_whls(project_name):
@@ -17,10 +16,6 @@ def check_whls(project_name):
     assert not whls[0].endswith('-none-any.whl')
 
     expected_content = [
-        '%s.dist-info/top_level.txt' % project_name,
-        '%s.dist-info/WHEEL' % project_name,
-        '%s.dist-info/RECORD' % project_name,
-        '%s.dist-info/METADATA' % project_name,
         'hello/__init__.py',
         'hello/cmake_generated_module.py',
         'hello/data/subdata/hello_data1_include_from_manifest.txt',
@@ -37,15 +32,10 @@ def check_whls(project_name):
         'hello2/data2/subdata2/hello2_data2_include_from_manifest.txt',
         'hello2/hello2_include_from_manifest.txt',
     ]
-    if parse_version(wheel.__version__) < parse_version('0.31.0'):
-        expected_content += [
-            '%s.dist-info/DESCRIPTION.rst' % project_name,
-            '%s.dist-info/metadata.json' % project_name
-        ]
 
-    archive = ZipFile(whls[0])
-    member_list = archive.namelist()
-    assert sorted(expected_content) == sorted(member_list)
+    expected_distribution_name = project_name
+
+    check_wheel_content(whls[0], expected_distribution_name, expected_content)
 
 
 def check_sdist(proj, base=''):

--- a/tests/test_include_exclude_data.py
+++ b/tests/test_include_exclude_data.py
@@ -1,13 +1,10 @@
 import glob
 import os
-import tarfile
-
-from zipfile import ZipFile
 
 from skbuild.utils import to_unix_path
 
 from . import project_setup_py_test
-from .pytest_helpers import check_wheel_content
+from .pytest_helpers import check_sdist_content, check_wheel_content
 
 
 def check_whls(project_name):
@@ -56,30 +53,14 @@ def check_sdist(proj, base=''):
         to_unix_path(os.path.join(proj, base, 'hello2/data2/subdata2/hello2_data2_include_from_manifest.txt')),
         to_unix_path(os.path.join(
             proj, base, 'hello2/data2/subdata2/hello2_data4_include_from_manifest_and_exclude_from_setup.txt')),
-        to_unix_path(os.path.join(proj, base, 'hello2/hello2_include_from_manifest.txt')),
-        to_unix_path(os.path.join(proj, 'PKG-INFO'))
+        to_unix_path(os.path.join(proj, base, 'hello2/hello2_include_from_manifest.txt'))
     ]
 
-    member_list = None
+    sdist_archive = 'dist/%s.zip' % proj
     if sdists_tar:
-        if base != '':
-            expected_content.extend([to_unix_path(os.path.join(proj, base))])
-        expected_content.extend([
-            proj,
-            to_unix_path(os.path.join(proj, base, 'hello')),
-            to_unix_path(os.path.join(proj, base, 'hello/data')),
-            to_unix_path(os.path.join(proj, base, 'hello/data/subdata')),
-            to_unix_path(os.path.join(proj, base, 'hello2')),
-            to_unix_path(os.path.join(proj, base, 'hello2/data2')),
-            to_unix_path(os.path.join(proj, base, 'hello2/data2/subdata2'))
-        ])
-        member_list = tarfile.open('dist/%s.tar.gz' % proj).getnames()
+        sdist_archive = 'dist/%s.tar.gz' % proj
 
-    elif sdists_zip:
-        member_list = ZipFile('dist/%s.zip' % proj).namelist()
-
-    assert expected_content and member_list
-    assert sorted(expected_content) == sorted(member_list)
+    check_sdist_content(sdist_archive, proj, expected_content)
 
 
 @project_setup_py_test("test-include-exclude-data", ["bdist_wheel"])

--- a/tests/test_issue335_support_cmake_source_dir.py
+++ b/tests/test_issue335_support_cmake_source_dir.py
@@ -2,8 +2,9 @@
 import glob
 
 from . import (
-    _tmpdir, check_wheel_content, execute_setup_py, initialize_git_repo_and_commit, prepare_project
+    _tmpdir, execute_setup_py, initialize_git_repo_and_commit, prepare_project
 )
+from .pytest_helpers import check_wheel_content
 
 
 def test_bdist_wheel_command():

--- a/tests/test_manifest_in.py
+++ b/tests/test_manifest_in.py
@@ -8,12 +8,9 @@ Tries to build and test the `manifest-in` sample project.
 """
 
 import glob
-import tarfile
-
-from zipfile import ZipFile
 
 from . import project_setup_py_test
-from .pytest_helpers import check_wheel_content
+from .pytest_helpers import check_sdist_content, check_wheel_content
 
 
 @project_setup_py_test("manifest-in", ["sdist"], disable_languages_test=True)
@@ -22,28 +19,16 @@ def test_manifest_in_sdist():
     sdists_zip = glob.glob('dist/*.zip')
     assert sdists_tar or sdists_zip
 
-    member_list = None
-    expected_content = None
+    expected_content = [
+        'manifest-in-1.2.3/hello/__init__.py',
+        'manifest-in-1.2.3/setup.py'
+    ]
+
+    sdist_archive = 'dist/manifest-in-1.2.3.zip'
     if sdists_tar:
-        expected_content = [
-            'manifest-in-1.2.3',
-            'manifest-in-1.2.3/hello',
-            'manifest-in-1.2.3/hello/__init__.py',
-            'manifest-in-1.2.3/setup.py',
-            'manifest-in-1.2.3/PKG-INFO'
-        ]
-        member_list = tarfile.open('dist/manifest-in-1.2.3.tar.gz').getnames()
+        sdist_archive = 'dist/manifest-in-1.2.3.tar.gz'
 
-    elif sdists_zip:
-        expected_content = [
-            'manifest-in-1.2.3/hello/__init__.py',
-            'manifest-in-1.2.3/setup.py',
-            'manifest-in-1.2.3/PKG-INFO'
-        ]
-        member_list = ZipFile('dist/manifest-in-1.2.3.zip').namelist()
-
-    assert expected_content and member_list
-    assert sorted(expected_content) == sorted(member_list)
+    check_sdist_content(sdist_archive, 'manifest-in-1.2.3', expected_content)
 
 
 @project_setup_py_test("manifest-in", ["bdist_wheel"], disable_languages_test=True)

--- a/tests/test_manifest_in.py
+++ b/tests/test_manifest_in.py
@@ -9,12 +9,11 @@ Tries to build and test the `manifest-in` sample project.
 
 import glob
 import tarfile
-import wheel
 
-from pkg_resources import parse_version
 from zipfile import ZipFile
 
 from . import project_setup_py_test
+from .pytest_helpers import check_wheel_content
 
 
 @project_setup_py_test("manifest-in", ["sdist"], disable_languages_test=True)
@@ -51,21 +50,11 @@ def test_manifest_in_sdist():
 def test_manifest_in_wheel():
     whls = glob.glob('dist/*.whl')
     assert len(whls) == 1
-    assert whls[0].endswith('-none-any.whl')
 
     expected_content = [
-        'manifest_in-1.2.3.dist-info/top_level.txt',
-        'manifest_in-1.2.3.dist-info/WHEEL',
-        'manifest_in-1.2.3.dist-info/RECORD',
-        'manifest_in-1.2.3.dist-info/METADATA',
         'hello/__init__.py'
     ]
 
-    if parse_version(wheel.__version__) < parse_version('0.31.0'):
-        expected_content += [
-            'manifest_in-1.2.3.dist-info/DESCRIPTION.rst',
-            'manifest_in-1.2.3.dist-info/metadata.json'
-        ]
+    expected_distribution_name = 'manifest_in-1.2.3'
 
-    member_list = ZipFile(whls[0]).namelist()
-    assert sorted(expected_content) == sorted(member_list)
+    check_wheel_content(whls[0], expected_distribution_name, expected_content, pure=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,7 @@ from skbuild.utils import (ContextDecorator, mkdir_p,
                            PythonModuleFinder, push_dir,
                            to_platform_path, to_unix_path)
 
-from . import (push_env, SAMPLES_DIR)
+from . import (list_ancestors, push_env, SAMPLES_DIR)
 
 saved_cwd = os.getcwd()
 
@@ -207,3 +207,17 @@ def test_to_platform_path(input_path, expected_path):
 )
 def test_to_unix_path(input_path, expected_path):
     assert to_unix_path(input_path) == expected_path
+
+
+@pytest.mark.parametrize(
+    "input_path, expected_ancestors", (
+        ('', []),
+        ('.', []),
+        ('part1/part2/part3/part4', ['part1/part2/part3/', 'part1/part2/', 'part1/']),
+        ('part1\\part2\\part3\\part4', []),
+        ('/part1/part2/part3/part4', ['/part1/part2/part3/', '/part1/part2/', '/part1/', '/']),
+        ('C:/part1/part2/part3/part4', ['C:/part1/part2/part3/', 'C:/part1/part2/', 'C:/part1/', 'C:/']),
+    )
+)
+def test_list_ancestors(input_path, expected_ancestors):
+    assert list_ancestors(input_path) == expected_ancestors

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -213,10 +213,10 @@ def test_to_unix_path(input_path, expected_path):
     "input_path, expected_ancestors", (
         ('', []),
         ('.', []),
-        ('part1/part2/part3/part4', ['part1/part2/part3/', 'part1/part2/', 'part1/']),
+        ('part1/part2/part3/part4', ['part1/part2/part3', 'part1/part2', 'part1']),
         ('part1\\part2\\part3\\part4', []),
-        ('/part1/part2/part3/part4', ['/part1/part2/part3/', '/part1/part2/', '/part1/', '/']),
-        ('C:/part1/part2/part3/part4', ['C:/part1/part2/part3/', 'C:/part1/part2/', 'C:/part1/', 'C:/']),
+        ('/part1/part2/part3/part4', ['/part1/part2/part3', '/part1/part2', '/part1', '/']),
+        ('C:/part1/part2/part3/part4', ['C:/part1/part2/part3', 'C:/part1/part2', 'C:/part1', 'C:']),
     )
 )
 def test_list_ancestors(input_path, expected_ancestors):


### PR DESCRIPTION
To allow pytest to display useful information, the tests containing
the helper function is registered.

See https://docs.pytest.org/en/latest/writing_plugins.html#assertion-rewriting