### PR TITLE
ENH: flexibly encode the implementation

### DIFF
--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -315,9 +315,10 @@ class CMaker(object):
                 candidate_versions += ('',)
 
             candidates = (
-                os.path.join(prefix, ''.join(('python', ver)))
-                for (prefix, ver) in itertools.product(
+                os.path.join(prefix, ''.join((impl, ver)))
+                for (prefix, impl, ver) in itertools.product(
                     candidate_prefixes,
+                    ('python', 'pypy', 'pypy-c'),
                     candidate_versions
                 )
             )
@@ -381,10 +382,11 @@ class CMaker(object):
             candidates = (
                 os.path.join(
                     libdir,
-                    ''.join((pre, 'python', ver, abi, ext))
+                    ''.join((pre, impl, ver, abi, ext))
                 )
-                for (pre, ext, ver, abi) in itertools.product(
+                for (pre, impl, ext, ver, abi) in itertools.product(
                     candidate_lib_prefixes,
+                    ('python', 'pypy', 'pypy-c'),
                     candidate_extensions,
                     candidate_versions,
                     candidate_abiflags


### PR DESCRIPTION
The interpreter implementation is hard coded, this PR at least extends the range of hard-coded values. It would be even better to read this out somewhere. `platform.python_implementation()` would get a unique name, maybe the possible values could be mapped to a canonical implementation name.

Right now PyPy's is `pypy-c`, but I put in `pypy` as well to maybe future-proof the logic.

With this change, and a few small tweaks to PyPy's sysconfig `'LIB` and `LIBDIR` values, I can successfully build opencv-python (which uses scikit-build) on pypy2.7