### PR TITLE
[WIP] Add ctypes examle

### DIFF
--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -733,6 +733,8 @@ def _classify_installed_files(install_paths, package_data, package_prefixes,
                               scripts, new_scripts,
                               data_files,
                               cmake_source_dir, cmake_install_dir):
+
+    print('-- CLASSIFY INSTALLED FILES --')
     assert not os.path.isabs(cmake_source_dir)
     assert cmake_source_dir != "."
 
@@ -754,12 +756,16 @@ def _classify_installed_files(install_paths, package_data, package_prefixes,
                        py_modules, new_py_modules,
                        scripts, new_scripts,
                        data_files)
+    print('-- DONE CLASSIFY INSTALLED FILES --')
 
 
 def _classify_file(path, package_data, package_prefixes,
                    py_modules, new_py_modules,
                    scripts, new_scripts,
                    data_files):
+    print('-- CLASSIFY FILE --')
+    print(' * package_data = {!r}'.format(package_data))
+    print(' * path = {!r}'.format(path))
     found_package = False
     found_module = False
     found_script = False
@@ -780,6 +786,7 @@ def _classify_file(path, package_data, package_prefixes,
             break
 
     if found_package:
+        print(' * found_package = {!r}'.format(found_package))
         return
     # If control reaches this point, then this installed file is not part of
     # a package.
@@ -792,6 +799,7 @@ def _classify_file(path, package_data, package_prefixes,
             break
 
     if found_module:
+        print(' * found_module = {!r}'.format(found_module))
         return
     # If control reaches this point, then this installed file is not a
     # module
@@ -804,6 +812,7 @@ def _classify_file(path, package_data, package_prefixes,
             break
 
     if found_script:
+        print(' * found_script = {!r}'.format(found_script))
         return
     # If control reaches this point, then this installed file is not a
     # script
@@ -817,6 +826,7 @@ def _classify_file(path, package_data, package_prefixes,
         file_set = set()
         data_files[parent_dir] = file_set
     file_set.add(os.path.join(CMAKE_INSTALL_DIR(), path))
+    print(' * fallback to generic data file')
 
 
 def _copy_file(src_file, dest_file, hide_listing=True):

--- a/tests/samples/hello-ctypes/CMakeLists.txt
+++ b/tests/samples/hello-ctypes/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.0)
+cmake_minimum_required(VERSION 3.13.0)
 
 project(hello LANGUAGES C CXX)
 
@@ -7,11 +7,10 @@ set(SOURCE_FILES
 
 add_library(hello SHARED ${SOURCE_FILES})
 
-install(TARGETS hello LIBRARY DESTINATION "hello")
-
 # set compiler-specific flags
-if(${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
-    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # Set the DLLEXPORT variable to export symbols
     target_compile_definitions(hello PRIVATE HELLO_WIN_EXPORT)
 endif()
+
+install(TARGETS hello LIBRARY DESTINATION "hello")

--- a/tests/samples/hello-ctypes/CMakeLists.txt
+++ b/tests/samples/hello-ctypes/CMakeLists.txt
@@ -5,7 +5,8 @@ project(hello LANGUAGES C CXX)
 set(SOURCE_FILES
     src/hello.cxx)
 
-add_library(hello SHARED ${SOURCE_FILES})
+#add_library(hello SHARED ${SOURCE_FILES})
+add_library(hello MODULE ${SOURCE_FILES})
 
 # set compiler-specific flags
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/tests/samples/hello-ctypes/CMakeLists.txt
+++ b/tests/samples/hello-ctypes/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.5.0)
+
+project(hello LANGUAGES C CXX)
+
+set(SOURCE_FILES
+    src/hello.cxx)
+
+add_library(hello SHARED ${SOURCE_FILES})
+
+install(TARGETS hello LIBRARY DESTINATION "hello")

--- a/tests/samples/hello-ctypes/CMakeLists.txt
+++ b/tests/samples/hello-ctypes/CMakeLists.txt
@@ -8,3 +8,10 @@ set(SOURCE_FILES
 add_library(hello SHARED ${SOURCE_FILES})
 
 install(TARGETS hello LIBRARY DESTINATION "hello")
+
+# set compiler-specific flags
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+    # Set the DLLEXPORT variable to export symbols
+    target_compile_definitions(hello PRIVATE HELLO_WIN_EXPORT)
+endif()

--- a/tests/samples/hello-ctypes/hello/__init__.py
+++ b/tests/samples/hello-ctypes/hello/__init__.py
@@ -1,0 +1,48 @@
+import ctypes
+
+
+def _get_lib_ext():
+    if sys.platform.startswith('win32'):
+        ext = '.dll'
+    elif sys.platform.startswith('darwin'):
+        ext = '.dylib'
+    elif sys.platform.startswith('linux'):
+        ext = '.so'
+    else:
+        raise Exception('Unknown operating system: %s' % sys.platform)
+    return ext
+
+def _find_ctypes_lib(libname, root_dir):
+    ext = _get_lib_ext()
+    import glob
+    # windows doesnt always start names with lib
+    candidates = list(glob.glob(join(root_dir, libname + '*' + ext)))
+    candidates += list(glob.glob(join(root_dir, 'lib' + libname + '*' + ext)))
+    print('candidates = {!r}'.format(candidates))
+    lib_fpath = candidates[0]
+    return lib_fpath
+
+
+def _load_ctypes_lib():
+    root_dir = realpath(dirname(__file__))
+    libname = '_hello'
+    lib_fpath = _find_ctypes_lib(libname, root_dir)
+
+    def def_cfunc(clib, return_type, func_name, arg_type_list):
+        """ define the types that python needs to talk to c """
+        cfunc = getattr(clib, func_name)
+        cfunc.restype = return_type
+        cfunc.argtypes = arg_type_list
+
+    clib = ctypes.cdll[lib_fpath]
+    clib.__LIB_FPATH__ = lib_fpath
+
+    def_cfunc(clib, ctypes.c_int, 'elevation_example',        [])
+    return clib
+
+
+HELLO_CLIB = _load_ctypes_lib()
+
+
+def elevation_example():
+    return HELLO_CLIB.elevation_example()

--- a/tests/samples/hello-ctypes/hello/__init__.py
+++ b/tests/samples/hello-ctypes/hello/__init__.py
@@ -33,7 +33,6 @@ def _find_ctypes_lib(libname, root_dir):
     if len(candidates) > 1:
         raise Exception('Too many matching libs: {}'.format(candidates))
 
-    print('candidates = {!r}'.format(candidates))
     lib_fpath = candidates[0]
     return lib_fpath
 

--- a/tests/samples/hello-ctypes/hello/__init__.py
+++ b/tests/samples/hello-ctypes/hello/__init__.py
@@ -1,4 +1,8 @@
 import ctypes
+import sys
+from os.path import realpath
+from os.path import dirname
+from os.path import join
 
 
 def _get_lib_ext():
@@ -16,8 +20,19 @@ def _find_ctypes_lib(libname, root_dir):
     ext = _get_lib_ext()
     import glob
     # windows doesnt always start names with lib
-    candidates = list(glob.glob(join(root_dir, libname + '*' + ext)))
-    candidates += list(glob.glob(join(root_dir, 'lib' + libname + '*' + ext)))
+    print('Loading ctypes lib from root_dir = {!r}'.format(root_dir))
+    print('libname = {!r}'.format(libname))
+    candidates = []
+    if sys.platform.startswith('win32'):
+        candidates += list(glob.glob(join(root_dir, libname + '*' + ext)))
+    else:
+        candidates += list(glob.glob(join(root_dir, 'lib' + libname + '*' + ext)))
+
+    if len(candidates) == 0:
+        raise Exception('Unable to find ctype lib {} in {}'.format(libname, root_dir))
+    if len(candidates) > 1:
+        raise Exception('Too many matching libs: {}'.format(candidates))
+
     print('candidates = {!r}'.format(candidates))
     lib_fpath = candidates[0]
     return lib_fpath
@@ -25,7 +40,7 @@ def _find_ctypes_lib(libname, root_dir):
 
 def _load_ctypes_lib():
     root_dir = realpath(dirname(__file__))
-    libname = '_hello'
+    libname = 'hello'
     lib_fpath = _find_ctypes_lib(libname, root_dir)
 
     def def_cfunc(clib, return_type, func_name, arg_type_list):

--- a/tests/samples/hello-ctypes/hello/__init__.py
+++ b/tests/samples/hello-ctypes/hello/__init__.py
@@ -16,6 +16,7 @@ def _get_lib_ext():
         raise Exception('Unknown operating system: %s' % sys.platform)
     return ext
 
+
 def _find_ctypes_lib(libname, root_dir):
     ext = _get_lib_ext()
     import glob

--- a/tests/samples/hello-ctypes/hello/__main__.py
+++ b/tests/samples/hello-ctypes/hello/__main__.py
@@ -1,0 +1,5 @@
+
+if __name__ == "__main__":
+    import hello
+    elevation = hello.elevation_example()
+    print('Hello called ctypes elevation = {!r}'.format(elevation))

--- a/tests/samples/hello-ctypes/setup.py
+++ b/tests/samples/hello-ctypes/setup.py
@@ -13,6 +13,7 @@ def _get_lib_ext():
         raise Exception('Unknown operating system: %s' % sys.platform)
     return ext
 
+
 setup(
     name="hello",
     version="1.2.3",

--- a/tests/samples/hello-ctypes/setup.py
+++ b/tests/samples/hello-ctypes/setup.py
@@ -1,6 +1,5 @@
 from skbuild import setup
 import sys
-from os.path import normpath
 
 
 def _get_lib_ext():
@@ -23,6 +22,6 @@ setup(
     packages=['hello'],
     package_data={'hello': [
         '*' + _get_lib_ext(),
-        normpath('bin/*' + _get_lib_ext()),
+        'bin/*' + _get_lib_ext(),
     ]},
 )

--- a/tests/samples/hello-ctypes/setup.py
+++ b/tests/samples/hello-ctypes/setup.py
@@ -1,5 +1,6 @@
 from skbuild import setup
 import sys
+from os.path import normpath
 
 
 def _get_lib_ext():
@@ -20,5 +21,8 @@ setup(
     author='The scikit-build team',
     license="MIT",
     packages=['hello'],
-    package_data={'hello': ['*' + _get_lib_ext()]},
+    package_data={'hello': [
+        '*' + _get_lib_ext()
+        normpath('bin/*' + _get_lib_ext())
+    ]},
 )

--- a/tests/samples/hello-ctypes/setup.py
+++ b/tests/samples/hello-ctypes/setup.py
@@ -22,7 +22,7 @@ setup(
     license="MIT",
     packages=['hello'],
     package_data={'hello': [
-        '*' + _get_lib_ext()
-        normpath('bin/*' + _get_lib_ext())
+        '*' + _get_lib_ext(),
+        normpath('bin/*' + _get_lib_ext()),
     ]},
 )

--- a/tests/samples/hello-ctypes/setup.py
+++ b/tests/samples/hello-ctypes/setup.py
@@ -1,0 +1,24 @@
+from skbuild import setup
+import sys
+
+
+def _get_lib_ext():
+    if sys.platform.startswith('win32'):
+        ext = '.dll'
+    elif sys.platform.startswith('darwin'):
+        ext = '.dylib'
+    elif sys.platform.startswith('linux'):
+        ext = '.so'
+    else:
+        raise Exception('Unknown operating system: %s' % sys.platform)
+    return ext
+
+setup(
+    name="hello",
+    version="1.2.3",
+    description="a minimal example package",
+    author='The scikit-build team',
+    license="MIT",
+    packages=['hello'],
+    package_data={'hello': ['*' + _get_lib_ext()]},
+)

--- a/tests/samples/hello-ctypes/src/hello.cxx
+++ b/tests/samples/hello-ctypes/src/hello.cxx
@@ -1,0 +1,27 @@
+#ifndef HELLO_EXPORT
+#ifdef WIN32
+#define HELLO_EXPORT __declspec(dllexport)
+#else
+#define HELLO_EXPORT
+#endif
+#endif
+
+
+// BEGIN PYTHON BINDINGS
+// * python's ctypes module can talk to extern c code
+// http://nbviewer.ipython.org/github/pv/SciPy-CookBook/blob/master/ipython/Ctypes.ipynb
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+HELLO_EXPORT int elevation_example()
+{
+  // Return an integer
+  return 21463;
+}
+
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/tests/samples/hello-ctypes/src/hello.cxx
+++ b/tests/samples/hello-ctypes/src/hello.cxx
@@ -1,39 +1,10 @@
-// Define HELLO_EXPORTED for any platform
-// References: https://atomheartother.github.io/c++/2018/07/12/CPPDynLib.html
-#if defined _WIN32 || defined __CYGWIN__
-  #ifdef HELLO_WIN_EXPORT
-    // Exporting...
-    #ifdef __GNUC__
-      #define HELLO_EXPORTED __attribute__ ((dllexport))
-    #else
-      #define HELLO_EXPORTED __declspec(dllexport) // Note: actually gcc seems to also supports this syntax.
-    #endif
-  #else
-    #ifdef __GNUC__
-      #define HELLO_EXPORTED __attribute__ ((dllimport))
-    #else
-      #define HELLO_EXPORTED __declspec(dllimport) // Note: actually gcc seems to also supports this syntax.
-    #endif
-  #endif
-  #define HELLO_NOT_EXPORTED
-#else
-  #if __GNUC__ >= 4
-    #define HELLO_EXPORTED __attribute__ ((visibility ("default")))
-    #define HELLO_NOT_EXPORTED  __attribute__ ((visibility ("hidden")))
-  #else
-    #define HELLO_EXPORTED
-    #define HELLO_NOT_EXPORTED
-  #endif
-#endif
-
+#include "hello.h"
 
 
 // BEGIN PYTHON BINDINGS
 // * python's ctypes module can talk to extern c code
 // http://nbviewer.ipython.org/github/pv/SciPy-CookBook/blob/master/ipython/Ctypes.ipynb
-#ifdef __cplusplus
 extern "C" {
-#endif
 
 
 HELLO_EXPORTED int elevation_example()
@@ -43,6 +14,4 @@ HELLO_EXPORTED int elevation_example()
 }
 
 
-#ifdef __cplusplus
 } // extern "C"
-#endif

--- a/tests/samples/hello-ctypes/src/hello.cxx
+++ b/tests/samples/hello-ctypes/src/hello.cxx
@@ -1,10 +1,31 @@
-#ifndef HELLO_EXPORT
-#ifdef WIN32
-#define HELLO_EXPORT __declspec(dllexport)
+// Define HELLO_EXPORTED for any platform
+// References: https://atomheartother.github.io/c++/2018/07/12/CPPDynLib.html
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef HELLO_WIN_EXPORT
+    // Exporting...
+    #ifdef __GNUC__
+      #define HELLO_EXPORTED __attribute__ ((dllexport))
+    #else
+      #define HELLO_EXPORTED __declspec(dllexport) // Note: actually gcc seems to also supports this syntax.
+    #endif
+  #else
+    #ifdef __GNUC__
+      #define HELLO_EXPORTED __attribute__ ((dllimport))
+    #else
+      #define HELLO_EXPORTED __declspec(dllimport) // Note: actually gcc seems to also supports this syntax.
+    #endif
+  #endif
+  #define HELLO_NOT_EXPORTED
 #else
-#define HELLO_EXPORT
+  #if __GNUC__ >= 4
+    #define HELLO_EXPORTED __attribute__ ((visibility ("default")))
+    #define HELLO_NOT_EXPORTED  __attribute__ ((visibility ("hidden")))
+  #else
+    #define HELLO_EXPORTED
+    #define HELLO_NOT_EXPORTED
+  #endif
 #endif
-#endif
+
 
 
 // BEGIN PYTHON BINDINGS
@@ -15,7 +36,7 @@ extern "C" {
 #endif
 
 
-HELLO_EXPORT int elevation_example()
+HELLO_EXPORTED int elevation_example()
 {
   // Return an integer
   return 21463;

--- a/tests/samples/hello-ctypes/src/hello.h
+++ b/tests/samples/hello-ctypes/src/hello.h
@@ -1,0 +1,33 @@
+#ifndef _HELLO_H
+
+// Define HELLO_EXPORTED for any platform
+// References: https://atomheartother.github.io/c++/2018/07/12/CPPDynLib.html
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef HELLO_WIN_EXPORT
+    // Exporting...
+    #ifdef __GNUC__
+      #define HELLO_EXPORTED __attribute__ ((dllexport))
+    #else
+      #define HELLO_EXPORTED __declspec(dllexport) // Note: actually gcc seems to also supports this syntax.
+    #endif
+  #else
+    #ifdef __GNUC__
+      #define HELLO_EXPORTED __attribute__ ((dllimport))
+    #else
+      #define HELLO_EXPORTED __declspec(dllimport) // Note: actually gcc seems to also supports this syntax.
+    #endif
+  #endif
+  #define HELLO_NOT_EXPORTED
+#else
+  #if __GNUC__ >= 4
+    #define HELLO_EXPORTED __attribute__ ((visibility ("default")))
+    #define HELLO_NOT_EXPORTED  __attribute__ ((visibility ("hidden")))
+  #else
+    #define HELLO_EXPORTED
+    #define HELLO_NOT_EXPORTED
+  #endif
+#endif
+
+
+#define _HELLO_H
+#endif


### PR DESCRIPTION
I'm having issues similar to #434 which have to do with how scikit-build is finding extension modules. For reference the repo where I'm having these issues is: https://github.com/Erotemic/hesaff/tree/dev/wheels which uses `ctypes` for python bindings.

I also noticed that there was no ctypes example in the samples, so I made one as a MWE of my issue. Once my problem is resolved this MWE should be useful as a sample in the master branch of scikit-build, hence why this is a PR. 

This original library I'm having issues with was based on a pure C++ project and the python bindings were added afterwards, so the CMakeLists is completely standalone, which makes a somewhat different than other scikit-build examples I've seen. 

Because the CMakeLists is builds a pure C++ project, I explicitly point package_data in the `setup.py` file at a pattern that should match the compiled libraries. Ideally running `setup.py` will run CMake, compile the libs, copy them into the correct install/wheel/inplace destination depending on the setup.py command. 


------ 
I have things mostly working and building, the issue is that package data on windows and linux are inconsistent. You'll notice this PR has added some debug statements to `setuptools_wrap.py`. This allows me to determine how scikit-build handles the output of CMake. 


On Linux it does what I expect it to do: 

```
cd $HOME/code/scikit-build/tests/samples/hello-ctypes
python setup.py build_ext --inplace
```

I see
```
-- CLASSIFY FILE --
 * package_data = {'hello': ['*.so']}
 * path = 'hello/libhello.so'
 * found_package = True
```
which means it found `libhello.so` and recognized it as package data, just as I would expect based on my `CMakeLists.txt` and `setup.py`.


However, on Windows:
```
cd %HOME%/code/scikit-build/tests/samples/hello-ctypes
call "C:/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/VC/Auxiliary/Build/vcvars64.bat"
python setup.py build_ext --inplace -- -G "Visual Studio 15 2017 Win64"
```

The library is put into `<INSTALL>/bin/hello.dll` instead of `<INSTALL>/hello/hello.dll`, which seems to prevent it from registering as a library file, and thus its put into the data folder.
```
-- CLASSIFY FILE --                                                                                                             
 * package_data = {'hello': ['*.dll']}                                                                                          
 * path = 'lib/hello.lib'                                                                                                       
 * fallback to generic data file                                                                                                
-- CLASSIFY FILE --                                                                                                             
 * package_data = {'hello': ['*.dll']}                                                                                          
 * path = 'bin/hello.dll'                                                                                                       
 * fallback to generic data file                                                                                                
```

-----

PS: 

I was about to post this, but I went to double check my MWE against hello-cpp, and I noticed the `add_library` command in the skbuild example i using MODULE instead of SHARED. When I change to use MODULE then CMake installs to `<INSTALL>/hello/hello.dll` and thus skbuild handles the dll appropriately. 

I'm leaving the above post as-is because at the very least, its still think its a gotcha that should be documented. On the other hand does it make sense (ie does scikit-build explicitly require) that your binary-extensions are MODULES and not SHARED libraries? I can think of some instances where you may want to link against a CFFI-ctypes library, so perhaps the inconsistency between windows and linux for SHARED objects is still a concern?


This is getting long so perhaps its best to summarize my questions: 

- [ ] Has scikit-build been designed to CFFI ctypes extensions similar to the example in the PR? Am I doing something this project simply hasn't considered yet? 
- [ ] Am I doing anything blatantly wrong or using bad practices in my example? (I am not a C expert, so I have doubts). 
- [ ] Should `add_library` calls for CFFI libraries always use MODULE or should SHARED also be allowed?
