### PR TITLE
Print configuration CMake command line

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ New Features
 * Add support for OS/400 (now known as IBM i).
   Thanks :user:`jwoehr` for the contribution. See :issue:`444`.
 
+* Display CMake command used to configure the project.
+  Thanks :user:`native-api` for the contribution. See :issue:`443`.
+
 * CMake modules:
 
   * Improve CMake module :doc:`/cmake-modules/F2PY` adding `add_f2py_target()` CMake function

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -2,6 +2,7 @@
 This module provides an interface for invoking CMake executable.
 """
 
+from __future__ import print_function
 import argparse
 import distutils.sysconfig as du_sysconfig
 import glob
@@ -214,6 +215,15 @@ class CMaker(object):
 
         # changes dir to cmake_build and calls cmake's configure step
         # to generate makefile
+        print(
+            "Configuring Project\n"
+            "  Working directory:\n"
+            "    {}\n"
+            "  Command:\n"
+            "    {}\n".format(
+                os.path.abspath(CMAKE_BUILD_DIR()),
+                self._formatArgsForDisplay(cmd)
+            ))
         rtn = subprocess.call(cmd, cwd=CMAKE_BUILD_DIR(), env=generator.env)
         if rtn != 0:
             raise SKBuildError(
@@ -517,4 +527,9 @@ class CMaker(object):
         Currently, the only formatting is naively surrounding each argument with
         quotation marks.
         """
-        return ' '.join("\"{}\"".format(arg) for arg in args)
+        try:
+            from shlex import quote
+        except ImportError:
+            from pipes import quote
+
+        return ' '.join(quote(arg) for arg in args)


### PR DESCRIPTION
We are using `scikit-build` in https://github.com/skvark/opencv-python. When something goes wrong, we need to run the exact same CMake invocation with tracing to diagnose. This PR adds printing of it.

Instead of printing the raw argv, [`shlex.join`](https://docs.python.org/3.8/library/shlex.html?highlight=shlex#shlex.join) could be used to produce a copypasteable cmdline. But it's 3.8+