### PR TITLE
Os400 unsupported

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,10 @@ New Features
   as global `setuptools` or `pip` options.
 
 * Add support for building project using PyPy or PyPy3. See https://pypy.org
-  Thanks :user:`mattip` for the contribution. See :issue:`407`.
+  See :issue:`407`.
+
+* Add support for OS/400 (now known as IBM i).
+  Thanks :user:`jwoehr` for the contribution. See :issue:`444`.
 
 Bug fixes
 ---------

--- a/skbuild/platform_specifics/platform_factory.py
+++ b/skbuild/platform_specifics/platform_factory.py
@@ -22,6 +22,8 @@ def get_platform():
         return bsd.BSDPlatform()
     elif this_platform == "darwin":
         return osx.OSXPlatform()
+    elif this_platform == "os400":
+        return bsd.BSDPlatform()
     else:
         raise RuntimeError("Unsupported platform: {:s}. Please contact "
                            "the scikit-build team.".format(this_platform))

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -84,14 +84,15 @@ def test_generator_cleanup():
 
 
 @pytest.mark.parametrize("supported_platform",
-                         ['darwin', 'freebsd', 'linux', 'windows'])
+                         ['darwin', 'freebsd', 'linux', 'windows', 'os400'])
 def test_known_platform(supported_platform, mocker):
     mocker.patch('platform.system', return_value=supported_platform)
     platforms = {
         'freebsd': 'BSD',
         'linux': 'Linux',
         'darwin': 'OSX',
-        'windows': 'Windows'
+        'windows': 'Windows',
+        'os400': 'BSD'
     }
     expected_platform_classname = "%sPlatform" % platforms[supported_platform]
     assert get_platform().__class__.__name__ == expected_platform_classname


### PR DESCRIPTION
Addresses #444 and thus allows scikit-build to build on `os400` (i.e., IBM i PASE).