### PR TITLE
FindF2PY: Ensure python version specific of f2py executable is looked up first

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,7 +30,11 @@ Bug fixes
   * Fix warning using `EXT_SUFFIX` config variable instead of deprecated `SO` variable. See :issue:`381`.
 
 * Honor the `MACOSX_DEPLOYMENT_TARGET` environment variable if it is defined on
-  macOS. Thanks :user:`certik` for the contribution. See :issue`441`.
+  macOS. Thanks :user:`certik` for the contribution. See :issue:`441`.
+
+* Fix CMake module :doc:`/cmake-modules/F2PY` to ensure the `f2py` executable specific to
+  the python version being used is found. See :issue:`449`. Thanks :user:`bnavigator` for
+  the contribution.
 
 Documentation
 -------------

--- a/skbuild/resources/cmake/FindF2PY.cmake
+++ b/skbuild/resources/cmake/FindF2PY.cmake
@@ -66,7 +66,7 @@
 #   case, CMake is not used to find the compiler and configure the associated build system.
 #
 
-find_program(F2PY_EXECUTABLE NAMES f2py f2py${PYTHON_VERSION_MAJOR})
+find_program(F2PY_EXECUTABLE NAMES f2py${PYTHON_VERSION_MAJOR} f2py)
 
 if(F2PY_EXECUTABLE)
   # extract the version string


### PR DESCRIPTION
See #449

Co-authored-by: Ben <code@bnavigator.de>