### PR TITLE
Replace linux_distribution() missing in Python 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 wheel>=0.29.0
 setuptools>=28.0.0
 packaging
+distro

--- a/skbuild/platform_specifics/linux.py
+++ b/skbuild/platform_specifics/linux.py
@@ -1,5 +1,6 @@
 """This module defines object specific to Linux platform."""
 
+import distro
 import platform
 import sys
 import textwrap
@@ -24,7 +25,7 @@ class LinuxPlatform(unix.UnixPlatform):
         """
         # gentoo, slackware: Compiler is available by default.
 
-        distribution_name = platform.linux_distribution()[0]
+        distribution_name = distro.id()
         cmd = ""
         if distribution_name in [
                 'debian', 'Ubuntu', 'mandrake', 'mandriva']:


### PR DESCRIPTION
`platform.linux_distribution()` was removed in Python 3.8. Move to `distro.id()`