### PR TITLE
Fix bug in python.h lookup logic.

### DIFF
--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -268,7 +268,7 @@ class CMaker(object):
         # if Python.h not found (or python_include_dir is None), try to find a
         # suitable include dir
         found_python_h = (
-            python_include_dir is not None or
+            python_include_dir is not None and
             os.path.exists(os.path.join(python_include_dir, 'Python.h'))
         )
 

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -322,6 +322,15 @@ class CMaker(object):
             if python_version:
                 candidate_versions += ('',)
 
+                pymalloc = None
+                try:
+                    pymalloc = bool(sysconfig.get_config_var('WITH_PYMALLOC'))
+                except AttributeError:
+                    pass
+
+                if pymalloc:
+                    candidate_versions += (python_version + 'm',)
+
             candidates = (
                 os.path.join(prefix, ''.join(('python', ver)))
                 for (prefix, ver) in itertools.product(


### PR DESCRIPTION
Looking at the diff of https://github.com/scikit-build/scikit-build/commit/1c11225560cdefff592cdfd71c9d4f3777765606 it appears that DeMorgan's law bit us here. The net result is that scikit build works if the location of python.h pointed to by sysconfig is accurate, but in a cross-compile type scenario Python.h may be incorrectly marked as found.