### PR TITLE
Append 'm' suffix to python version if compiled with pymalloc.

### DIFF
--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -322,6 +322,15 @@ class CMaker(object):
             if python_version:
                 candidate_versions += ('',)
 
+                pymalloc = None
+                try:
+                    pymalloc = bool(sysconfig.get_config_var('WITH_PYMALLOC'))
+                except AttributeError:
+                    pass
+
+                if pymalloc:
+                    candidate_versions += (python_version + 'm',)
+
             candidates = (
                 os.path.join(prefix, ''.join(('python', ver)))
                 for (prefix, ver) in itertools.product(


### PR DESCRIPTION
If python is built with pymalloc, then an 'm' suffix is appended to the version. For example, in a 3.6 pymalloc build, Python.h would live under 'include/python3.6m/Python.h', breaking the current lookup logic.