### PR TITLE
Ignore DESTDIR when installing to _skbuild

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,9 @@ Bug fixes
   `distro.id()`. This adds the `distro` package as dependency. See :issue:`458`. Thanks
   :user:`bnavigator` for the contribution.
 
+* Ignore DESTDIR in environment and MAKEFLAGS when installing .so to _skbuild
+  Contributed by :user:`jokva`.
+
 Documentation
 -------------
 

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -23,6 +23,7 @@ from .constants import (CMAKE_BUILD_DIR,
                         SETUPTOOLS_INSTALL_DIR)
 from .platform_specifics import get_platform
 from .exceptions import SKBuildError
+from .utils import push_env
 
 RE_FILE_INSTALL = re.compile(
     r"""[ \t]*file\(INSTALL DESTINATION "([^"]+)".*"([^"]+)"\).*""")
@@ -85,6 +86,32 @@ def get_cmake_version(cmake_executable=CMAKE_DEFAULT_EXECUTABLE):
         version_string = version_string.decode()
 
     return version_string.splitlines()[0].split(' ')[-1]
+
+
+class push_env_without_destdir(push_env):
+    """Remove DESTDIR from MAKEFLAGS and environment
+
+    When scikit-build is invoked as a part of a larger cmake project, makefile,
+    or something else that sets the DESTDIR environment variable, the internal
+    cmake --target install honours it and makes artefacts under DESTDIR/
+
+    The internal install into _skbuild/ should never need to respect DESTDIR,
+    so simply remove it from the environment. When cmake generates the
+    makefiles, it stores the make parameters [1] in the MAKEFLAGS environment
+    variable.  The DESTDIR entry needs to be removed from here as well.
+
+    [1] make DESTDIR=/path install
+    """
+    def __init__(self, **kwargs):
+        kwargs['DESTDIR'] = None
+
+        if 'MAKEFLAGS' in kwargs:
+            makeflags = kwargs['MAKEFLAGS']
+            flags = makeflags.split(' ')
+            flags = [flag for flag in flags if not flag.startswith('DESTDIR=')]
+            kwargs['MAKEFLAGS'] = ' '.join(flags)
+
+        super(push_env_without_destdir, self).__init__(**kwargs)
 
 
 class CMaker(object):
@@ -491,7 +518,15 @@ class CMaker(object):
                    shlex.split(os.environ.get("SKBUILD_BUILD_OPTIONS", "")))
         )
 
-        rtn = subprocess.call(cmd, cwd=CMAKE_BUILD_DIR(), env=env)
+        # The subprocess.call() expects a modified environment or None (means
+        # inherit process, i.e. os.environ). push_env_without_destdir, however,
+        # uses **kwargs to set/unset parameters
+        if env is None:
+            env = {}
+
+        with push_env_without_destdir(**env):
+            rtn = subprocess.call(cmd, cwd=CMAKE_BUILD_DIR(), env=None)
+
         if rtn != 0:
             raise SKBuildError(
                 "An error occurred while building with CMake.\n"

--- a/skbuild/utils/__init__.py
+++ b/skbuild/utils/__init__.py
@@ -225,3 +225,24 @@ def parse_manifestin(template):
         return file_list.files
     finally:
         template.close()
+
+
+class push_env(ContextDecorator):
+    """This context manager allow to set/unset environment variables.
+    """
+    def __init__(self, **kwargs):
+        self.saved_env = dict(os.environ)
+        self.pushed_env = dict(kwargs)
+
+    def __enter__(self):
+        for var, value in self.pushed_env.items():
+            if value is not None:
+                os.environ[var] = value
+            elif var in os.environ:
+                del os.environ[var]
+        return self
+
+    def __exit__(self, typ, val, traceback):
+        os.environ.clear()
+        for (saved_var, saved_value) in self.saved_env.items():
+            os.environ[saved_var] = saved_value

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -41,22 +41,6 @@ def push_argv(argv):
 
 
 @contextmanager
-def push_env(**kwargs):
-    """This context manager allow to set/unset environment variables.
-    """
-    saved_env = dict(os.environ)
-    for var, value in kwargs.items():
-        if value is not None:
-            os.environ[var] = value
-        elif var in os.environ:
-            del os.environ[var]
-    yield
-    os.environ.clear()
-    for (saved_var, saved_value) in saved_env.items():
-        os.environ[saved_var] = saved_value
-
-
-@contextmanager
 def prepend_sys_path(paths):
     """This context manager allows to prepend paths to ``sys.path`` and restore the
     original list.

--- a/tests/test_broken_project.py
+++ b/tests/test_broken_project.py
@@ -16,10 +16,9 @@ from subprocess import (check_output, CalledProcessError)
 from skbuild.constants import CMAKE_DEFAULT_EXECUTABLE
 from skbuild.exceptions import SKBuildError
 from skbuild.platform_specifics import CMakeGenerator, get_platform
-from skbuild.utils import push_dir
+from skbuild.utils import push_dir, push_env
 
 from . import project_setup_py_test
-from . import push_env
 
 
 def test_cmakelists_with_fatalerror_fails(capfd):

--- a/tests/test_ignore_destdir.py
+++ b/tests/test_ignore_destdir.py
@@ -1,0 +1,33 @@
+import os
+import os.path
+
+from . import (
+    _tmpdir, execute_setup_py, initialize_git_repo_and_commit, prepare_project
+)
+
+
+def test_ignore_DESTDIR_env_skbuild_install():
+    project = 'hello-cpp'
+
+    tmp_dir = _tmpdir('test_install_ignore_destdir')
+    prepare_project(project, tmp_dir)
+    initialize_git_repo_and_commit(tmp_dir, verbose=True)
+
+    destdir = os.path.join(os.getcwd(), 'dest-dir')
+    os.environ['DESTDIR'] = destdir
+    with execute_setup_py(tmp_dir, ["build"]):
+        assert not os.path.exists(destdir)
+
+
+def test_ignore_MAKEFLAGS_DESTDIR_skbuild_install():
+    project = 'hello-cpp'
+
+    tmp_dir = _tmpdir('test_install_ignore_destdir')
+    prepare_project(project, tmp_dir)
+    initialize_git_repo_and_commit(tmp_dir, verbose=True)
+
+    destdir = os.path.join(os.getcwd(), 'dest-dir')
+    makeflags = 'CXXFLAGS=-Wall DESTDIR={}'.format(destdir)
+    os.environ['MAKEFLAGS'] = makeflags
+    with execute_setup_py(tmp_dir, ["build"]):
+        assert not os.path.exists(destdir)

--- a/tests/test_issue342_cmake_osx_args_in_setup.py
+++ b/tests/test_issue342_cmake_osx_args_in_setup.py
@@ -5,7 +5,8 @@ import platform
 
 import skbuild.constants
 
-from . import _tmpdir, execute_setup_py, push_env
+from . import _tmpdir, execute_setup_py
+from skbuild.utils import push_env
 
 params = "osx_deployment_target_env_var,cli_setup_args," \
     "keyword_cmake_args,cli_cmake_args,expected_cmake_osx_deployment_target"

--- a/tests/test_skbuild.py
+++ b/tests/test_skbuild.py
@@ -16,9 +16,10 @@ from skbuild.constants import CMAKE_BUILD_DIR
 from skbuild.exceptions import SKBuildError
 from skbuild.platform_specifics import get_platform
 from skbuild.platform_specifics.windows import find_visual_studio, VS_YEAR_TO_VERSION
+from skbuild.utils import push_env
 
 from . import (get_cmakecache_variables, project_setup_py_test,
-               push_dir, push_env, which)
+               push_dir, which)
 
 
 def test_generator_selection():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,9 +12,10 @@ import pytest
 
 from skbuild.utils import (ContextDecorator, mkdir_p,
                            PythonModuleFinder, push_dir,
-                           to_platform_path, to_unix_path)
+                           to_platform_path, to_unix_path,
+                           push_env)
 
-from . import (list_ancestors, push_env, SAMPLES_DIR)
+from . import (list_ancestors, SAMPLES_DIR)
 
 saved_cwd = os.getcwd()
 


### PR DESCRIPTION
The cmake --build --target install command is used to move built
artefacts to _skbuild/, but when used in an environment with staged
installs (DESTDIR [1] [2]) the _skbuild directory also ends up there.
This is never desired as the _skbuild is an internal detail to the
scikit-build process, and DESTDIR is not meant to be used to specify the
build location.

[1] Happens in larger projects where scikit-build is not the only player
[2] https://github.com/equinor/segyio/blob/0c791d0f0ae4973058a51e2014837946e668902b/python/setup.py