### PR TITLE
Add hook to process manifest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,8 @@ New Features
 Bug fixes
 ---------
 
+* Fix python 2.7 installation ensuring setuptools < 45 is required. See :issue:`478`.
+
 * Fix unclosed file resource in :meth:`skbuild.cmaker.CMaker.check_for_bad_installs`.
   Thanks :user:`Nic30` for the suggestion. See :issue:`429`.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ New Features
 * Add a hook to process the cmake install manifest building the wheel. The hook
   function can be specified as an argument to the `setup()` function. This can be used e.g.
   to prevent installing cmake configuration files, headers, or static libraries with the wheel.
+  Thanks :user:`SylvainCorlay` for the contribution. See :issue:`473`.
 
 * Add support for passing :ref:`CMake configure options <usage_cmake_configure_options>` like `-DFOO:STRING:bar`
   as global `setuptools` or `pip` options.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ Next Release
 New Features
 ------------
 
+* Add a hook to process the cmake install manifest building the wheel. The hook
+  function can be specified as an argument to the `setup()` function. This can be used e.g.
+  to prevent installing cmake configuration files, headers, or static libraries with the wheel.
+
 * Add support for passing :ref:`CMake configure options <usage_cmake_configure_options>` like `-DFOO:STRING:bar`
   as global `setuptools` or `pip` options.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,6 +78,9 @@ Tests
   * Update Azure Pipelines configuration for running tests using `PyPy3 <https://pypy.org/>`_ on Linux.
     Thanks :user:`mattip` for the contribution. See :issue:`418`.
 
+* Update :func:`initialize_git_repo_and_commit` to prevent signing message on system with commit signing
+  enabled globally.
+
 Scikit-build 0.10.0
 ===================
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -140,6 +140,21 @@ For example::
 - ``cmake_source_dir``: Relative directory containing the project ``CMakeLists.txt``.
   By default, it is set to the top-level directory where ``setup.py`` is found.
 
+- ``cmake_manifest_process_hook`: Python function consumming the list of files to be
+  installed produced by cmake. For example, `cmake_manifest_process_hook` can be used
+  to exclude static libraries from the built wheel.
+
+For example::
+
+    def exclude_static_libraries(cmake_manifest):
+        return list(filter(lambda name: not (name.endswith('.a')), cmake_manifest))
+
+    setup(
+      [...]
+      cmake_process_manifest_hook=exclude_static_libraries
+      [...]
+    )
+
 .. _usage-cmake_with_sdist:
 
 .. versionadded:: 0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 wheel>=0.29.0
-setuptools>=28.0.0
+setuptools>=28.0.0;python_version>='3'
+setuptools>=28.0.0,<45;python_version<'3'
 packaging
 distro

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -609,7 +609,13 @@ def setup(*args, **kw):  # noqa: C901
 
     package_prefixes = _collect_package_prefixes(package_dir, packages)
 
-    _classify_installed_files(cmkr.install(), package_data, package_prefixes,
+    # This hook enables custom processing of the cmake manifest
+    cmake_manifest = cmkr.install()
+    process_manifest = kw.get('cmake_process_manifest_hook')
+    if callable(process_manifest):
+        cmake_manifest = process_manifest(cmake_manifest)
+
+    _classify_installed_files(cmake_manifest, package_data, package_prefixes,
                               py_modules, new_py_modules,
                               scripts, new_scripts,
                               data_files,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -178,6 +178,7 @@ def initialize_git_repo_and_commit(project_dir, verbose=True):
             ['git', 'init'],
             ['git', 'config', 'user.name', 'scikit-build'],
             ['git', 'config', 'user.email', 'test@test'],
+            ['git', 'config', 'commit.gpgsign', 'false'],
             ['git', 'add', '-A'],
             ['git', 'reset', '.gitignore'],
             ['git', 'commit', '-m', 'Initial commit']

--- a/tests/samples/issue-335-support-cmake-source-dir/wrapping/python/CMakeLists.txt
+++ b/tests/samples/issue-335-support-cmake-source-dir/wrapping/python/CMakeLists.txt
@@ -1,8 +1,12 @@
+# Use .pyd extension on all platforms. This will avoid failure
+# on macOS where wheel wheel/macosx_libfile.py attempts to extract
+# shared library information.
+
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/swig_mwe.py" "")
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/_swig_mwe.so" "")
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/_swig_mwe.pyd" "")
 
 install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/swig_mwe.py
-    ${CMAKE_CURRENT_BINARY_DIR}/_swig_mwe.so
+    ${CMAKE_CURRENT_BINARY_DIR}/_swig_mwe.pyd
   DESTINATION hello
   )

--- a/tests/samples/test-filter-manifest/CMakeLists.txt
+++ b/tests/samples/test-filter-manifest/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.2)
+
+project(hello NONE)
+
+# Headers
+file(WRITE "bar.h" "")
+file(WRITE "foo.h" "")
+install(FILES "bar.h" "foo.h" DESTINATION include)
+
+# Static libraries
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/libbar.a" "")
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/libfoo.a" "")
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/libbar.a"
+    "${CMAKE_CURRENT_BINARY_DIR}/libfoo.a"
+  DESTINATION lib/static
+  )
+
+# Executables
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/hello" "")
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/hello"
+  DESTINATION bin
+  )
+
+add_subdirectory(wrapping/python)

--- a/tests/samples/test-filter-manifest/wrapping/python/CMakeLists.txt
+++ b/tests/samples/test-filter-manifest/wrapping/python/CMakeLists.txt
@@ -1,0 +1,8 @@
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/swig_mwe.py" "")
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/_swig_mwe.so" "")
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/swig_mwe.py
+    ${CMAKE_CURRENT_BINARY_DIR}/_swig_mwe.so
+  DESTINATION hello
+  )

--- a/tests/samples/test-filter-manifest/wrapping/python/CMakeLists.txt
+++ b/tests/samples/test-filter-manifest/wrapping/python/CMakeLists.txt
@@ -1,8 +1,13 @@
+
+# Use .pyd extension on all platforms. This will avoid failure
+# on macOS where wheel wheel/macosx_libfile.py attempts to extract
+# shared library information.
+
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/swig_mwe.py" "")
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/_swig_mwe.so" "")
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/_swig_mwe.pyd" "")
 
 install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/swig_mwe.py
-    ${CMAKE_CURRENT_BINARY_DIR}/_swig_mwe.so
+    ${CMAKE_CURRENT_BINARY_DIR}/_swig_mwe.pyd
   DESTINATION hello
   )

--- a/tests/samples/test-filter-manifest/wrapping/python/setup.py
+++ b/tests/samples/test-filter-manifest/wrapping/python/setup.py
@@ -1,0 +1,20 @@
+
+from skbuild import setup
+
+
+def exclude_dev_files(cmake_manifest):
+    return list(filter(lambda name: not (name.endswith('.a') or name.endswith('.h')), cmake_manifest))
+
+
+setup(
+    name="hello",
+    version="1.2.3",
+    description="a minimal example package (cpp version)",
+    author='The scikit-build team',
+    license="MIT",
+    packages=['hello'],
+    tests_require=[],
+    setup_requires=[],
+    cmake_source_dir="../../",
+    cmake_process_manifest_hook=exclude_dev_files
+)

--- a/tests/test_filter_manifest.py
+++ b/tests/test_filter_manifest.py
@@ -13,7 +13,7 @@ def test_bdist_wheel_command():
     expected_content = [
         'hello/__init__.py',
         'hello/swig_mwe.py',
-        'hello/_swig_mwe.so',
+        'hello/_swig_mwe.pyd',
         'hello-1.2.3.data/data/bin/hello',
     ]
 

--- a/tests/test_filter_manifest.py
+++ b/tests/test_filter_manifest.py
@@ -1,0 +1,31 @@
+
+import glob
+
+from . import (
+    _tmpdir, execute_setup_py, initialize_git_repo_and_commit, prepare_project
+)
+from .pytest_helpers import check_wheel_content
+
+
+def test_bdist_wheel_command():
+    project = "test-filter-manifest"
+
+    expected_content = [
+        'hello/__init__.py',
+        'hello/swig_mwe.py',
+        'hello/_swig_mwe.so',
+        'hello-1.2.3.data/data/bin/hello',
+    ]
+
+    expected_distribution_name = 'hello-1.2.3'
+
+    tmp_dir = _tmpdir('test_bdist_wheel_command')
+    prepare_project(project, tmp_dir)
+    initialize_git_repo_and_commit(tmp_dir, verbose=True)
+
+    relative_setup_path = 'wrapping/python/'
+
+    with execute_setup_py(tmp_dir.join(relative_setup_path), ["bdist_wheel"]):
+        whls = glob.glob('dist/*.whl')
+        assert len(whls) == 1
+        check_wheel_content(whls[0], expected_distribution_name, expected_content)

--- a/tests/test_issue335_support_cmake_source_dir.py
+++ b/tests/test_issue335_support_cmake_source_dir.py
@@ -13,7 +13,7 @@ def test_bdist_wheel_command():
     expected_content = [
         'hello/__init__.py',
         'hello/swig_mwe.py',
-        'hello/_swig_mwe.so',
+        'hello/_swig_mwe.pyd',
         'hello-1.2.3.data/data/bin/hello',
         'hello-1.2.3.data/data/lib/static/libbar.a',
         'hello-1.2.3.data/data/lib/static/libfoo.a',


### PR DESCRIPTION
This is a simple hook to enable custom processing of the cmake manifest before producing the wheel.

The goal for us is to drop static binaries of dependencies, as well as their headers, and other artefacts such as cmake files, as we want the wheel to only include what is required at runtime.

I am using this here: https://github.com/jupyter-xeus/xeus-python-wheel/pull/36

Fixes #473 
