### PR TITLE
Add cmake_target to change the target used by CMake

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -112,6 +112,10 @@ Scikit-build 0.11.0
 
 New Features
 ------------
+* Add support for `--install-target` scikit-build command line option.
+  And `cmake_install_target` in `setup.py`. Allowing to
+  provide an install target different than the default `install`.
+  Thanks :user:`phcerdan` for the contribution. See :issue:`477`.
 
 * Add a hook to process the cmake install manifest building the wheel. The hook
   function can be specified as an argument to the `setup()` function. This can be used e.g.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -175,6 +175,21 @@ For example::
 - ``cmake_minimum_required_version``: String identifying the minimum version of CMake required
   to configure the project.
 
+- ``cmake_install_target``: Name of the target to "build" for installing the artifacts into the wheel.
+  By default, this option is set to ``install``, which is always provided by CMake.
+  This can be used to only install certain components.
+
+For example::
+
+    install(TARGETS foo COMPONENT runtime)
+    add_custom_target(foo-install-runtime
+        ${CMAKE_COMMAND}
+        -DCMAKE_INSTALL_COMPONENT=runtime
+        -P "${PROJECT_BINARY_DIR}/cmake_install.cmake"
+        DEPENDS foo
+        )
+
+
 Scikit-build changes the following options:
 
 .. versionadded:: 0.7.0

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -573,17 +573,57 @@ class CMaker(object):
                     ("      " + _install) for _install in bad_installs)
             )))
 
-    def make(self, clargs=(), config="Release", source_dir=".", env=None):
+    def make(self, clargs=(), config="Release", source_dir=".",
+             install_target="install", env=None):
         """Calls the system-specific make program to compile code.
+
+           install_target: string
+                Name of the target responsible to install the project.
+                Default is "install".
+
+                .. note::
+
+                   To workaround CMake issue #8438.
+                   See https://gitlab.kitware.com/cmake/cmake/-/issues/8438
+                   Due to a limitation of CMake preventing from adding a dependency
+                   on the "build-all" built-in target, we explicitly build the project first when
+                   the install target is different from the default on.
         """
         clargs, config = pop_arg('--config', clargs, config)
+        clargs, install_target = pop_arg('--install-target', clargs, install_target)
         if not os.path.exists(CMAKE_BUILD_DIR()):
             raise SKBuildError(("CMake build folder ({}) does not exist. "
                                 "Did you forget to run configure before "
                                 "make?").format(CMAKE_BUILD_DIR()))
 
-        cmd = [self.cmake_executable, "--build", source_dir,
-               "--target", "install", "--config", config, "--"]
+        # Workaround CMake issue #8438
+        # See https://gitlab.kitware.com/cmake/cmake/-/issues/8438
+        # Due to a limitation of CMake preventing from adding a dependency
+        # on the "build-all" built-in target, we explicitly build
+        # the project first when
+        # the install target is different from the default on.
+        if install_target != "install":
+            self.make_impl(clargs=clargs, config=config, source_dir=source_dir,
+                           install_target=None, env=env)
+
+        self.make_impl(clargs=clargs, config=config, source_dir=source_dir,
+                       install_target=install_target, env=env)
+
+    def make_impl(self, clargs, config, source_dir, install_target, env=None):
+        """
+        Precondition: clargs does not have --config nor --install-target options.
+        These command line arguments are extracted in the caller function
+        `make` with `clargs, config = pop_arg('--config', clargs, config)`
+
+        This is a refactor effort for calling the function `make` twice in
+        case the install_target is different than the default `install`.
+        """
+        if not install_target:
+            cmd = [self.cmake_executable, "--build", source_dir,
+                   "--config", config, "--"]
+        else:
+            cmd = [self.cmake_executable, "--build", source_dir,
+                   "--target", install_target, "--config", config, "--"]
         cmd.extend(clargs)
         cmd.extend(
             filter(bool,
@@ -591,17 +631,25 @@ class CMaker(object):
         )
 
         rtn = subprocess.call(cmd, cwd=CMAKE_BUILD_DIR(), env=env)
+        # For reporting errors (if any)
+        if not install_target:
+            install_target = "internal build step [valid]"
+
         if rtn != 0:
             raise SKBuildError(
                 "An error occurred while building with CMake.\n"
                 "  Command:\n"
                 "    {}\n"
+                "  Install target:\n"
+                "    {}\n"
                 "  Source directory:\n"
                 "    {}\n"
                 "  Working directory:\n"
                 "    {}\n"
-                "Please see CMake's output for more information.".format(
+                "Please check the install target is valid and see CMake's output for more "
+                "information.".format(
                     self._formatArgsForDisplay(cmd),
+                    install_target,
                     os.path.abspath(source_dir),
                     os.path.abspath(CMAKE_BUILD_DIR())))
 

--- a/tests/samples/test-cmake-target/CMakeLists.txt
+++ b/tests/samples/test-cmake-target/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.5.0)
+project(test-cmake-target NONE)
+file(WRITE "${CMAKE_BINARY_DIR}/foo.txt" "# foo")
+file(WRITE "${CMAKE_BINARY_DIR}/runtime.txt" "# runtime")
+install(FILES "${CMAKE_BINARY_DIR}/foo.txt" DESTINATION ".")
+install(CODE "message(STATUS \"Project has been installed\")")
+install(FILES "${CMAKE_BINARY_DIR}/runtime.txt" DESTINATION "." COMPONENT runtime)
+install(CODE "message(STATUS \"Runtime component has been installed\")" COMPONENT runtime)
+# Add custom target to only install component: runtime (libraries)
+add_custom_target(install-runtime
+    ${CMAKE_COMMAND}
+    -DCMAKE_INSTALL_COMPONENT=runtime
+    -P "${PROJECT_BINARY_DIR}/cmake_install.cmake"
+    )

--- a/tests/samples/test-cmake-target/setup.py
+++ b/tests/samples/test-cmake-target/setup.py
@@ -1,0 +1,10 @@
+from skbuild import setup
+
+setup(
+    name="test-cmake-target",
+    version="1.2.3",
+    description="a minimal example package using a non-default target",
+    author='The scikit-build team',
+    license="MIT",
+    cmake_target="install-runtime",
+)

--- a/tests/test_cmake_target.py
+++ b/tests/test_cmake_target.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""test_cmake_target
+----------------------------------
+
+Tries to build and test the `test-cmake-target` sample
+project. It basically checks that using the `cmake_target` keyword
+in setup.py works.
+"""
+
+from . import project_setup_py_test
+
+
+@project_setup_py_test("test-cmake-target", ["build"], disable_languages_test=True)
+def test_cmake_target_build(capsys):
+    out, err = capsys.readouterr()
+    dist_warning = "Unknown distribution option: 'cmake_target'"
+    assert (dist_warning not in err and dist_warning not in out)


### PR DESCRIPTION
Parses the command line for the `--target` option.
And also provide the `cmake_install_target` parameter in `setup.py`

The command line argument has preference over the `cmake_install_target` from
`setup.py`.

This allows the user to point to targets other than 'install'.
The user has to set a target in CMake to install only a specific
component.

```cmake
install(TARGETS foo COMPONENT runtime)
add_custom_target(foo-install-runtime
    ${CMAKE_COMMAND}
    -DCMAKE_INSTALL_COMPONENT=runtime
    -P "${PROJECT_BINARY_DIR}/cmake_install.cmake")
```