### PR TITLE
platform_factory: Lazily import platform to support disto<1.2.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,13 @@ details, see the commit logs at http://github.com/scikit-build/scikit-build
 Next Release
 ============
 
+Bug fixes
+---------
+
+* Support using scikit-build with conan where ``distro<1.2.0`` is required.
+  Thanks :user:`AntoinePrv` and :user:`Chrismarsh` for reporting issue :issue:`472`
+  and :issue:`488`.
+
 Documentation
 -------------
 

--- a/skbuild/platform_specifics/platform_factory.py
+++ b/skbuild/platform_specifics/platform_factory.py
@@ -3,11 +3,6 @@
 
 import platform
 
-from . import bsd
-from . import linux
-from . import osx
-from . import windows
-
 
 def get_platform():
     """Return an instance of :class:`.abstract.CMakePlatform` corresponding
@@ -15,15 +10,25 @@ def get_platform():
     this_platform = platform.system().lower()
 
     if this_platform == "windows":
+        from . import windows
         return windows.WindowsPlatform()
-    if this_platform == "linux":
+
+    elif this_platform == "linux":
+        from . import linux
         return linux.LinuxPlatform()
+
     elif this_platform == "freebsd":
+        from . import bsd
         return bsd.BSDPlatform()
+
     elif this_platform == "darwin":
+        from . import osx
         return osx.OSXPlatform()
+
     elif this_platform == "os400":
+        from . import bsd
         return bsd.BSDPlatform()
+
     else:
         raise RuntimeError("Unsupported platform: {:s}. Please contact "
                            "the scikit-build team.".format(this_platform))


### PR DESCRIPTION
Fixes #472
Fixes #488