### PR TITLE
Fix `add_python_library` and `add_python_extension`

### DIFF
--- a/skbuild/resources/cmake/FindPythonExtensions.cmake
+++ b/skbuild/resources/cmake/FindPythonExtensions.cmake
@@ -576,3 +576,4 @@ function(python_modules_header _name)
   set(${_include_dirs_var} ${CMAKE_CURRENT_BINARY_DIR} PARENT_SCOPE)
 endfunction()
 
+include(UsePythonExtensions)


### PR DESCRIPTION
I have the following error when trying to build an extension, even with `find_package(PythonExtensions)` in my `CMakelists.txt`:

```
Unknown CMake command "add_python_extension"
```

I guess this will fix it?