### PR TITLE
setuptools_wrap: Remove cmake_process_manifest_hook keyword from argument dict

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,12 @@ details, see the commit logs at http://github.com/scikit-build/scikit-build
 Next Release
 ============
 
+Bug fixes
+---------
+
+* Fixed a regression that caused setuptools to complain about unknown setup option
+  (`cmake_process_manifest_hook`).
+
 Documentation
 -------------
 

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -398,7 +398,8 @@ def setup(*args, **kw):  # noqa: C901
         'cmake_source_dir': '',
         'cmake_with_sdist': False,
         'cmake_languages': ('C', 'CXX'),
-        'cmake_minimum_required_version': None
+        'cmake_minimum_required_version': None,
+        'cmake_process_manifest_hook': None
     }
     skbuild_kw = {param: kw.pop(param, parameters[param])
                   for param in parameters}
@@ -611,7 +612,7 @@ def setup(*args, **kw):  # noqa: C901
 
     # This hook enables custom processing of the cmake manifest
     cmake_manifest = cmkr.install()
-    process_manifest = kw.get('cmake_process_manifest_hook')
+    process_manifest = skbuild_kw.get('cmake_process_manifest_hook')
     if process_manifest is not None:
         if callable(process_manifest):
             cmake_manifest = process_manifest(cmake_manifest)


### PR DESCRIPTION
So that setuptools won't complain about unknown setup options.