### PR TITLE
typo in cmake_process_manifest_hook

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -140,8 +140,8 @@ For example::
 - ``cmake_source_dir``: Relative directory containing the project ``CMakeLists.txt``.
   By default, it is set to the top-level directory where ``setup.py`` is found.
 
-- ``cmake_manifest_process_hook``: Python function consumming the list of files to be
-  installed produced by cmake. For example, `cmake_manifest_process_hook` can be used
+- ``cmake_process_manifest_hook``: Python function consumming the list of files to be
+  installed produced by cmake. For example, `cmake_process_manifest_hook` can be used
   to exclude static libraries from the built wheel.
 
 For example::


### PR DESCRIPTION
Change `cmake_manifest_process_hook` to `cmake_process_manifest_hook`.

I got confused by this when I was trying to address https://github.com/uber/h3-py/issues/125