### PR TITLE
fix: hide warning if SKBUILD is not used

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Bug fixes
 
 * Fixed a regression that caused setuptools to complain about unknown setup option
   (`cmake_process_manifest_hook`).
+* Hide the warning that shows up when `SKBUILD` is unused.
 
 Documentation
 -------------

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -200,7 +200,7 @@ class CMaker(object):
                 python_include_dir),
             ("-DPYTHON_LIBRARY:FILEPATH=" +
                 python_library),
-            ("-DSKBUILD:BOOL=" +
+            ("-DSKBUILD:INTERNAL=" +
                 "TRUE"),
             ("-DCMAKE_MODULE_PATH:PATH=" +
                 os.path.join(os.path.dirname(__file__), "resources", "cmake"))


### PR DESCRIPTION
I believe this should hide the warning whenever SKBUILD is not checked in the CMake files. It also isn't a user-facing variable (that is, users don't set it).