### PR TITLE
skbuild: fix IndexError when prefix is empty

### DIFF
--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -598,7 +598,7 @@ def setup(*args, **kw):  # noqa: C901
         sys.exit(ex)
 
     # If any, strip ending slash from each package directory
-    package_dir = {package: prefix[:-1] if prefix[-1] == "/" else prefix
+    package_dir = {package: prefix[:-1] if prefix and prefix[-1] == "/" else prefix
                    for package, prefix in package_dir.items()}
 
     # If needed, set reasonable defaults for package_dir


### PR DESCRIPTION
The example shows `src/hello`.
In my case I had hello at the toplevel of the project.

`package_dir={'': ''}` led to `prefix[-1]` being called, out of bounds,
fixed in this commit.

Note: I also tried `package_dir={'': '.'}` but the code blindly replaces all
dots with `/`, which led to `/MyPackage`.