### PR TITLE
Respect CMAKE_OSX_ARCHITECTURES and correctly produce universal2 macOS wheels

### DIFF
--- a/skbuild/constants.py
+++ b/skbuild/constants.py
@@ -32,8 +32,18 @@ def _default_skbuild_plat_name():
         release = os.environ.get("MACOSX_DEPLOYMENT_TARGET", release)
         split_ver = release.split('.')
         machine = os.environ.get("CMAKE_OSX_ARCHITECTURES", machine)
+
+        # Handle universal2 wheels, if two architectures are requested.
         if set(machine.split(';')) == {'x86_64', 'arm64'}:
             machine = 'universal2'
+
+        # If Apple Silicon ARM64 wheels are requested, the minimum version is 11.0.
+        # Ignore if ``release``` cannot be parsed to an int.
+        try:
+            if machine == 'arm64' and int(split_ver[0]) < 11:
+                split_ver = [11, 0]
+        except ValueError:
+            pass
         return 'macosx-{}.{}-{}'.format(split_ver[0], split_ver[1], machine)
     else:
         return get_platform()

--- a/skbuild/constants.py
+++ b/skbuild/constants.py
@@ -31,6 +31,9 @@ def _default_skbuild_plat_name():
         release, _, machine = platform.mac_ver()
         release = os.environ.get("MACOSX_DEPLOYMENT_TARGET", release)
         split_ver = release.split('.')
+        machine = os.environ.get("CMAKE_OSX_ARCHITECTURES", machine)
+        if set(machine.split(';')) == {'x86_64', 'arm64'}:
+            machine = 'universal2'
         return 'macosx-{}.{}-{}'.format(split_ver[0], split_ver[1], machine)
     else:
         return get_platform()

--- a/skbuild/constants.py
+++ b/skbuild/constants.py
@@ -32,18 +32,9 @@ def _default_skbuild_plat_name():
         release = os.environ.get("MACOSX_DEPLOYMENT_TARGET", release)
         split_ver = release.split('.')
         machine = os.environ.get("CMAKE_OSX_ARCHITECTURES", machine)
-
-        # Handle universal2 wheels, if two architectures are requested.
+        # Handle universal2 wheels, if those two architectures are requested.
         if set(machine.split(';')) == {'x86_64', 'arm64'}:
             machine = 'universal2'
-
-        # If Apple Silicon ARM64 wheels are requested, the minimum version is 11.0.
-        # Ignore if ``release``` cannot be parsed to an int.
-        try:
-            if machine == 'arm64' and int(split_ver[0]) < 11:
-                split_ver = [11, 0]
-        except ValueError:
-            pass
         return 'macosx-{}.{}-{}'.format(split_ver[0], split_ver[1], machine)
     else:
         return get_platform()

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -506,6 +506,8 @@ def setup(*args, **kw):  # noqa: C901
                 version = cmake_arg.split('=')[1]
             if 'CMAKE_OSX_ARCHITECTURES' in cmake_arg:
                 machine = cmake_arg.split('=')[1]
+                if set(machine.split(';')) == {'x86_64', 'arm64'}:
+                    machine = 'universal2'
 
         set_skbuild_plat_name("macosx-{}-{}".format(version, machine))
 
@@ -524,8 +526,9 @@ def setup(*args, **kw):  # noqa: C901
             )
         if not cmaker.has_cmake_cache_arg(
                 cmake_args, 'CMAKE_OSX_ARCHITECTURES'):
+            machine_archs = 'x86_64;arm64' if machine == 'universal2' else machine
             cmake_args.append(
-                '-DCMAKE_OSX_ARCHITECTURES:STRING=%s' % machine
+                '-DCMAKE_OSX_ARCHITECTURES:STRING=%s' % machine_archs
             )
 
     # Install cmake if listed in `setup_requires`

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -509,20 +509,12 @@ def setup(*args, **kw):  # noqa: C901
                 if set(machine.split(';')) == {'x86_64', 'arm64'}:
                     machine = 'universal2'
 
-        # If Apple Silicon ARM64 wheels are requested, the minimum version is 11.0.
-        # Ignore if ``version``` cannot be parsed to an int.
-        try:
-            if machine == 'arm64' and int(version.split('.')[0]) < 11:
-                version = '11.0'
-        except ValueError:
-            pass
-
         set_skbuild_plat_name("macosx-{}-{}".format(version, machine))
 
         # Set platform env. variable so that commands (e.g. bdist_wheel)
         # uses this information. The _PYTHON_HOST_PLATFORM env. variable is
         # used in distutils.util.get_platform() function.
-        os.environ['_PYTHON_HOST_PLATFORM'] = skbuild_plat_name()
+        os.environ.setdefault('_PYTHON_HOST_PLATFORM', skbuild_plat_name())
 
         # Set CMAKE_OSX_DEPLOYMENT_TARGET and CMAKE_OSX_ARCHITECTURES if not already
         # specified

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -509,6 +509,14 @@ def setup(*args, **kw):  # noqa: C901
                 if set(machine.split(';')) == {'x86_64', 'arm64'}:
                     machine = 'universal2'
 
+        # If Apple Silicon ARM64 wheels are requested, the minimum version is 11.0.
+        # Ignore if ``version``` cannot be parsed to an int.
+        try:
+            if machine == 'arm64' and int(version.split('.')[0]) < 11:
+                version = '11.0'
+        except ValueError:
+            pass
+
         set_skbuild_plat_name("macosx-{}-{}".format(version, machine))
 
         # Set platform env. variable so that commands (e.g. bdist_wheel)


### PR DESCRIPTION
A first, partial fix for #529. This PR does two things: 1) it makes sure that `CMAKE_OSX_ARCHITECTURES` is not overridden if set externally, and 2) it makes sure that the correct wheel file name is given for `universal2` wheels (when `CMAKE_OSX_ARCHITECTURES` contains both `arm64` and `x86_64`).