### PR TITLE
ci: Revert to a simpler appveyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,22 +58,22 @@ cache:
   - C:\\cmake-3.6.2
 
 init:
-  - ps: Invoke-Expression "$env:PYTHON_DIR/python -m pip install -U scikit-ci scikit-ci-addons"
-  - ps: Invoke-Expression "$env:PYTHON_DIR/python -m ci_addons --install ../addons"
+  - python -m pip install -U scikit-ci scikit-ci-addons
+  - python -m ci_addons --install ../addons
 
   - ps: ../addons/appveyor/rolling-build.ps1
 
 install:
-  - ps: Invoke-Expression "$env:PYTHON_DIR/python -m ci install"
+  - python -m ci install
 
 build_script:
-  - ps: Invoke-Expression "$env:PYTHON_DIR/python -m ci build"
+  - python -m ci build
 
 test_script:
-  - ps: Invoke-Expression "$env:PYTHON_DIR/python -m ci test"
+  - python -m ci test
 
 after_test:
-  - ps: Invoke-Expression "$env:PYTHON_DIR/python -m ci after_test"
+  - python -m ci after_test
 
 on_finish:
   - ps: ../addons/appveyor/enable-worker-remote-access.ps1 -check_for_block


### PR DESCRIPTION
Follow the release of python 2.7 wheels on pypi for ruamel-ordereddict
package, this commit reverts eb1759376 (ci: Attempt to fix appveyor
failure)

References:
* https://sourceforge.net/p/ruamel-ordereddict/tickets/14/
* https://pypi.org/project/ruamel.ordereddict/0.4.15/#files