### PR TITLE
Handle updates to CYTHON_FLAGS from CMake code

### DIFF
--- a/skbuild/resources/cmake/UseCython.cmake
+++ b/skbuild/resources/cmake/UseCython.cmake
@@ -101,7 +101,6 @@ set(CYTHON_ANNOTATE OFF
 set(CYTHON_FLAGS "" CACHE STRING
     "Extra flags to the cython compiler.")
 mark_as_advanced(CYTHON_ANNOTATE CYTHON_FLAGS)
-string(REGEX REPLACE " " ";" CYTHON_FLAGS_LIST "${CYTHON_FLAGS}")
 
 find_package(PythonLibs REQUIRED)
 
@@ -357,6 +356,8 @@ function(add_cython_target _name)
 
   list(REMOVE_DUPLICATES pxd_dependencies)
   list(REMOVE_DUPLICATES c_header_dependencies)
+
+  string(REGEX REPLACE " " ";" CYTHON_FLAGS_LIST "${CYTHON_FLAGS}")
 
   # Add the command to run the compiler.
   add_custom_command(OUTPUT ${generated_file}

--- a/tests/samples/cython-flags/CMakeLists.txt
+++ b/tests/samples/cython-flags/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.5.0)
+
+project(cython_flags)
+
+find_package(PythonExtensions REQUIRED)
+find_package(Cython REQUIRED)
+
+add_subdirectory(hello)

--- a/tests/samples/cython-flags/hello/CMakeLists.txt
+++ b/tests/samples/cython-flags/hello/CMakeLists.txt
@@ -1,0 +1,7 @@
+
+set(CYTHON_FLAGS "-X c_string_encoding=default")
+add_cython_target(_hello CXX)
+add_library(_hello MODULE ${_hello})
+python_extension_module(_hello)
+
+install(TARGETS _hello LIBRARY DESTINATION hello)

--- a/tests/samples/cython-flags/hello/__main__.py
+++ b/tests/samples/cython-flags/hello/__main__.py
@@ -1,0 +1,4 @@
+
+if __name__ == "__main__":
+    from . import _hello as hello
+    hello.hello("World")

--- a/tests/samples/cython-flags/hello/_hello.pyx
+++ b/tests/samples/cython-flags/hello/_hello.pyx
@@ -1,0 +1,7 @@
+
+from libc.stdio cimport printf
+
+cpdef void hello(str strArg):
+    "Prints back 'Hello <param>', for example example: hello.hello('you')"
+    printf("Hello, %s! :)\n", <char*>strArg)
+

--- a/tests/samples/cython-flags/setup.py
+++ b/tests/samples/cython-flags/setup.py
@@ -1,0 +1,12 @@
+from skbuild import setup
+
+setup(
+    name="cython-flags",
+    version="1.2.3",
+    description="a minimal example package (cython version)",
+    author='The scikit-build team',
+    license="MIT",
+    packages=['cython_flags'],
+    package_dir={'cython_flags': 'hello'},
+
+)

--- a/tests/test_cython_flags.py
+++ b/tests/test_cython_flags.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""test_cython_flags
+----------------------------------
+
+Tries to build the `cython-flags` sample project.
+"""
+
+from . import project_setup_py_test
+
+
+@project_setup_py_test("cython-flags", ["build"])
+def test_hello_cython_builds():
+    pass


### PR DESCRIPTION
At the moment, CYTHON_FLAGS is read only once, when `include(UseCython)` is called. This means further changes to this variable from CMake code are not taken into account. This PR allows users to update CYTHON_FLAGS as needed (for instance when defining multiple modules with different flags).