### PR TITLE
fix: fix regex in test_get_python_version for Python 3.10

### DIFF
--- a/tests/test_cmaker.py
+++ b/tests/test_cmaker.py
@@ -21,7 +21,7 @@ from . import _tmpdir, get_cmakecache_variables
 
 
 def test_get_python_version():
-    assert re.match(r'^[23](\.?)[0-9]$', CMaker.get_python_version())
+    assert re.match(r'^[23](\.?)\d+$', CMaker.get_python_version())
 
 
 def test_get_python_include_dir():


### PR DESCRIPTION
Fix the regular expression in test_get_python_version to permit
the minor version to contain more than one digit.  This fixes the test
on Python 3.10.