### PR TITLE
fix: support and always call MSVC with -A

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,8 +15,9 @@ Bug fixes
 ---------
 
 * Support ``-A`` and ``-T`` internally when setting up MSVC generators.
-  :issue:`557` and :issue:`536`. Architecture now always passed through ``-A``
-  to MSVC generators.
+  Architecture now always passed through ``-A`` to MSVC generators. Thanks
+  :user:`henryiii` and :user:`YannickJadoul` for the contribution. See
+  :issue:`557` and :issue:`536`.
 
 * Fixed a regression that caused setuptools to complain about unknown setup option
   (`cmake_process_manifest_hook`).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,8 +8,15 @@ details, see the commit logs at http://github.com/scikit-build/scikit-build
 Next Release
 ============
 
+Features
+--------
+
 Bug fixes
 ---------
+
+* Support ``-A`` and ``-T`` internally when setting up MSVC generators.
+  :issue:`557` and :issue:`536`. Architecture now always passed through ``-A``
+  to MSVC generators.
 
 * Fixed a regression that caused setuptools to complain about unknown setup option
   (`cmake_process_manifest_hook`).

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ tag_prefix = ''
 
 [tool:pytest]
 testpaths = tests
-addopts = -v --cov --cov-report xml -ra --strict-markers
+addopts = -v --cov --cov-report xml -ra --strict-markers --showlocals --color=yes
 markers =
     fortran: fortran testing
 

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -208,6 +208,8 @@ class CMaker(object):
 
         if generator.toolset:
             cmd.extend(['-T', generator.toolset])
+        if generator.architecture:
+            cmd.extend(['-A', generator.architecture])
 
         cmd.extend(clargs)
 

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -168,10 +168,13 @@ class CMaker(object):
         if cli_generator_name is not None:
             generator_name = cli_generator_name
 
+        # if arch is provided on command line, use it
+        clargs, cli_arch = pop_arg('-A', clargs)
+
         generator = self.platform.get_best_generator(
             generator_name, skip_generator_test=skip_generator_test,
             cmake_executable=self.cmake_executable, cmake_args=clargs,
-            languages=languages, cleanup=cleanup)
+            languages=languages, cleanup=cleanup, architecture=cli_arch)
 
         if not os.path.exists(CMAKE_BUILD_DIR()):
             os.makedirs(CMAKE_BUILD_DIR())

--- a/skbuild/platform_specifics/abstract.py
+++ b/skbuild/platform_specifics/abstract.py
@@ -66,6 +66,13 @@ class CMakePlatform(object):
 
         return CMakeGenerator(generator_name)
 
+    def get_generators(self, generator_name):
+        """Loop over generators and return all that match the given name.
+        """
+        return [default_generator
+                for default_generator in self.default_generators
+                if default_generator.name == generator_name]
+
     # TODO: this method name is not great.  Does anyone have a better idea for
     # renaming it?
     def get_best_generator(
@@ -191,6 +198,8 @@ class CMakePlatform(object):
                 cmd = [cmake_exe_path, '../', '-G', generator.name]
                 if generator.toolset:
                     cmd.extend(['-T', generator.toolset])
+                if generator.architecture:
+                    cmd.extend(['-A', generator.architecture])
                 cmd.extend(cmake_args)
 
                 status = subprocess.call(cmd, env=generator.env)
@@ -214,7 +223,7 @@ class CMakeGenerator(object):
     .. automethod:: __init__
     """
 
-    def __init__(self, name, env=None, toolset=None):
+    def __init__(self, name, env=None, toolset=None, arch=None):
         """Instantiate a generator object with the given ``name``.
 
         By default, ``os.environ`` is associated with the generator. Dictionary
@@ -229,10 +238,15 @@ class CMakeGenerator(object):
         self.env = dict(
             list(os.environ.items()) + list(env.items() if env else []))
         self._generator_toolset = toolset
-        if toolset is None:
-            self._description = name
+        self._generator_architecture = arch
+        if arch is None:
+            description_arch = name
         else:
-            self._description = "%s %s" % (name, toolset)
+            description_arch = "%s %s" % (name, arch)
+        if toolset is None:
+            self._description = description_arch
+        else:
+            self._description = "%s %s" % (description_arch, toolset)
 
     @property
     def name(self):
@@ -243,6 +257,11 @@ class CMakeGenerator(object):
     def toolset(self):
         """Toolset specification associated with the CMake generator."""
         return self._generator_toolset
+
+    @property
+    def architecture(self):
+        """Architecture associated with the CMake generator."""
+        return self._generator_architecture
 
     @property
     def description(self):

--- a/skbuild/platform_specifics/abstract.py
+++ b/skbuild/platform_specifics/abstract.py
@@ -122,6 +122,16 @@ class CMakePlatform(object):
             # Lookup CMakeGenerator by name. Doing this allow to get a
             # generator object with its ``env`` property appropriately
             # initialized.
+
+            # MSVC should be used in "-A arch" form
+            if generator_name.startswith("Visual Studio"):
+                if generator_name.endswith(" Win64"):
+                    self.architecture = "x64"
+                    generator_name = generator_name[:-6]
+                elif generator_name.endswith(" ARM"):
+                    self.architecture = "ARM"
+                    generator_name = generator_name[:-4]
+
             candidate_generators = []
             for default_generator in self.default_generators:
                 if default_generator.name == generator_name:

--- a/skbuild/platform_specifics/abstract.py
+++ b/skbuild/platform_specifics/abstract.py
@@ -78,7 +78,7 @@ class CMakePlatform(object):
     def get_best_generator(
             self, generator_name=None, skip_generator_test=False,
             languages=("CXX", "C"), cleanup=True,
-            cmake_executable=CMAKE_DEFAULT_EXECUTABLE, cmake_args=()):
+            cmake_executable=CMAKE_DEFAULT_EXECUTABLE, cmake_args=(), architecture=None):
         """Loop over generators to find one that works by configuring
         and compiling a test project.
 
@@ -124,7 +124,10 @@ class CMakePlatform(object):
             # initialized.
 
             # MSVC should be used in "-A arch" form
-            if generator_name.startswith("Visual Studio"):
+            if architecture is not None:
+                self.architecture = architecture
+            # Support classic names for MSVC generators
+            elif generator_name.startswith("Visual Studio"):
                 if generator_name.endswith(" Win64"):
                     self.architecture = "x64"
                     generator_name = generator_name[:-6]

--- a/skbuild/platform_specifics/windows.py
+++ b/skbuild/platform_specifics/windows.py
@@ -130,10 +130,11 @@ class CMakeVisualStudioIDEGenerator(CMakeGenerator):
         """
         vs_version = VS_YEAR_TO_VERSION[year]
         vs_base = "Visual Studio %s %s" % (vs_version, year)
-        # Python is Win64, build a Win64 module
         if platform.architecture()[0] == "64bit":
-            vs_base += " Win64"
-        super(CMakeVisualStudioIDEGenerator, self).__init__(vs_base, toolset=toolset)
+            vs_arch = "x64"
+        else:
+            vs_arch = "Win32"
+        super(CMakeVisualStudioIDEGenerator, self).__init__(vs_base, toolset=toolset, arch=vs_arch)
 
 
 def _find_visual_studio_2010_to_2015(vs_version):
@@ -312,8 +313,9 @@ def _get_msvc_compiler_env(vs_version, vs_toolset=None):
                 'cmd /u /c "{}" {} {} && set'.format(vcvarsall, arch, vcvars_ver),
                 stderr=subprocess.STDOUT,
             )
-            if sys.version_info[0] >= 3:
-                out = out.decode('utf-16le', errors='replace')
+            out = out.decode('utf-16le', errors='replace')
+            if sys.version_info[0] < 3:
+                out = out.encode('utf-8')
 
             vc_env = {
                 key.lower(): value

--- a/tests/test_broken_project.py
+++ b/tests/test_broken_project.py
@@ -104,7 +104,7 @@ def test_invalid_cmake(exception, mocker):
     def check_output_mock(*args, **kwargs):
         if args[0] == [CMAKE_DEFAULT_EXECUTABLE, '--version']:
             raise exceptions[exception]
-        check_output_original(*args, **kwargs)
+        return check_output_original(*args, **kwargs)
 
     mocker.patch('skbuild.cmaker.subprocess.check_output',
                  new=check_output_mock)

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -115,8 +115,11 @@ def test_unsupported_platform(mocker):
 
 @pytest.mark.skipif(sys.platform != 'win32', reason='Requires Windows')
 def test_cached_generator():
-    platform = get_platform()
-    generator = platform.get_generator('Ninja')
-    env = generator.env
+    def is_configured_generator(generator):
+        env = generator.env
+        env_lib = env.get('LIB', '')
+        return 'Visual Studio' in env_lib or 'Visual C++' in env_lib
 
-    assert 'Visual Studio' in env['LIB'] or 'Visual C++' in env['LIB']
+    platform = get_platform()
+    ninja_generators = platform.get_generators('Ninja')
+    assert any(is_configured_generator(g) for g in ninja_generators)

--- a/tests/test_skbuild.py
+++ b/tests/test_skbuild.py
@@ -198,7 +198,6 @@ def test_platform_windows_find_visual_studio(vs_year):
 @pytest.mark.skipif(sys.version_info < (3, 5), reason="Python 3.5+ required on Windows")
 @pytest.mark.skipif(sys.platform != 'win32', reason='Requires Windows')
 def test_toolset():
-    version = sys.version_info
     py_35 = sys.version_info[:2] == (3, 5)
 
     has_vs_2017 = find_visual_studio(vs_version=VS_YEAR_TO_VERSION["2017"])
@@ -207,9 +206,11 @@ def test_toolset():
 
     arch = platform.architecture()[0]
     vs_generator = "Visual Studio 15 2017"
-    vs_arch = "x86" if arch == "64bit" else "Win32"
+    orig_generator = vs_generator
+    if arch == "64bit":
+        vs_generator += " Win64"
 
-    @project_setup_py_test("hello-cpp", ["build", "-G", vs_generator, "-A", vs_arch])
+    @project_setup_py_test("hello-cpp", ["build", "-G", vs_generator])
     def run_build():
         pass
 
@@ -219,7 +220,7 @@ def test_toolset():
     variables = get_cmakecache_variables(str(cmakecache))
 
     generator = variables['CMAKE_GENERATOR'][1]
-    assert generator == vs_generator
+    assert generator == orig_generator
 
     var_toolset = variables['CMAKE_GENERATOR_TOOLSET']
     toolset = var_toolset[1]

--- a/tests/test_skbuild.py
+++ b/tests/test_skbuild.py
@@ -230,7 +230,9 @@ def test_toolset():
     generator = variables['CMAKE_GENERATOR'][1]
     assert generator == vs_generator
 
-    toolset = variables['CMAKE_GENERATOR_TOOLSET'][1]
+    var_toolset = variables['CMAKE_GENERATOR_TOOLSET']
+    toolset = var_toolset[1]
+
     if py_35:
         assert toolset == "v140"
     elif py_36_and_above:

--- a/tests/test_skbuild.py
+++ b/tests/test_skbuild.py
@@ -195,20 +195,11 @@ def test_platform_windows_find_visual_studio(vs_year):
         assert find_visual_studio(VS_YEAR_TO_VERSION[vs_year]) == ""
 
 
-@pytest.mark.skipif(sys.platform != 'win32', reason='Requires Visual Studio and ')
+@pytest.mark.skipif(sys.version_info < (3, 5), reason="Python 3.5+ required on Windows")
+@pytest.mark.skipif(sys.platform != 'win32', reason='Requires Windows')
 def test_toolset():
     version = sys.version_info
-    py_35 = (
-        version.major == 3 and
-        version.minor == 5
-    )
-    py_36_and_above = (
-        version.major == 3 and
-        version.minor >= 6
-    )
-
-    if not any([py_35, py_36_and_above]):
-        pytest.skip("python version < 3.5")
+    py_35 = sys.version_info[:2] == (3, 5)
 
     has_vs_2017 = find_visual_studio(vs_version=VS_YEAR_TO_VERSION["2017"])
     if not has_vs_2017:
@@ -216,9 +207,9 @@ def test_toolset():
 
     arch = platform.architecture()[0]
     vs_generator = "Visual Studio 15 2017"
-    vs_generator += (" Win64" if arch == "64bit" else "")
+    vs_arch = "x86" if arch == "64bit" else "Win32"
 
-    @project_setup_py_test("hello-cpp", ["build", "-G", vs_generator])
+    @project_setup_py_test("hello-cpp", ["build", "-G", vs_generator, "-A", vs_arch])
     def run_build():
         pass
 
@@ -235,5 +226,5 @@ def test_toolset():
 
     if py_35:
         assert toolset == "v140"
-    elif py_36_and_above:
+    else:
         assert toolset == "v141"


### PR DESCRIPTION
This takes _just_ the non-2019 changes out of #526. Should make it easier to debug the issue with the failure there.

(pass through architecture, and test fixes)