### PR TITLE
docs: Remove broken "Health" badge from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,10 +52,6 @@ Overall Health
 .. image:: https://codecov.io/gh/scikit-build/scikit-build/branch/master/graph/badge.svg
     :target: https://codecov.io/gh/scikit-build/scikit-build
 
-.. image:: https://landscape.io/github/scikit-build/scikit-build/master/landscape.svg?style=flat
-    :target: https://landscape.io/github/scikit-build/scikit-build
-    :alt: Code Health
-
 Miscellaneous
 -------------
 


### PR DESCRIPTION
This commit removes the badge because the website https://landscape.io
is not responsive.