### PR TITLE
chore: Add requires.io hints to requirements files

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,5 @@
 docutils
 pygments
-sphinx<4
+sphinx<4  # rq.filter: <4
 sphinx-issues
 sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 distro
 packaging
 setuptools>=28.0.0;python_version>='3'
-setuptools>=28.0.0,<45;python_version<'3'
+setuptools>=28.0.0,<45;python_version<'3'  # rq.filter: <45
 wheel>=0.29.0


### PR DESCRIPTION
This commit is intended to remove false positive indicating that
requirements are outdated.

Fixes #573