### PR TITLE
style: PyUpgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,11 @@ repos:
   - id: requirements-txt-fixer
   - id: trailing-whitespace
 
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.24.0
+  hooks:
+  - id: pyupgrade
+
 - repo: https://github.com/PyCQA/flake8
   rev: 3.9.2
   hooks:

--- a/skbuild/_version.py
+++ b/skbuild/_version.py
@@ -1,4 +1,3 @@
-
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -91,7 +90,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
             return None, None
     else:
         if verbose:
-            print("unable to find command, tried %s" % (commands,))
+            print("unable to find command, tried {}".format(commands))
         return None, None
     stdout = p.communicate()[0].strip()
     if sys.version_info[0] >= 3:
@@ -177,11 +176,11 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         if verbose:
             print("keywords are unexpanded, not using")
         raise NotThisMethod("unexpanded keywords, not a git-archive tarball")
-    refs = set([r.strip() for r in refnames.strip("()").split(",")])
+    refs = {r.strip() for r in refnames.strip("()").split(",")}
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    tags = {r[len(TAG):] for r in refs if r.startswith(TAG)}
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -190,7 +189,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r'\d', r)])
+        tags = {r for r in refs if re.search(r'\d', r)}
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:

--- a/skbuild/platform_specifics/abstract.py
+++ b/skbuild/platform_specifics/abstract.py
@@ -190,7 +190,7 @@ class CMakePlatform(object):
             outer = "-" * 80
             inner = ["-" * ((idx * 5) - 3) for idx in range(1, 8)]
             print(outer if suffix == "" else "\n".join(inner))
-            print("-- Trying \"%s\" generator%s" % (_generator.description, suffix))
+            print("-- Trying \"{}\" generator{}".format(_generator.description, suffix))
             print(outer if suffix != "" else "\n".join(inner[::-1]))
 
         for generator in candidate_generators:
@@ -251,11 +251,11 @@ class CMakeGenerator(object):
         if arch is None:
             description_arch = name
         else:
-            description_arch = "%s %s" % (name, arch)
+            description_arch = "{} {}".format(name, arch)
         if toolset is None:
             self._description = description_arch
         else:
-            self._description = "%s %s" % (description_arch, toolset)
+            self._description = "{} {}".format(description_arch, toolset)
 
     @property
     def name(self):

--- a/skbuild/platform_specifics/windows.py
+++ b/skbuild/platform_specifics/windows.py
@@ -135,7 +135,7 @@ class CMakeVisualStudioIDEGenerator(CMakeGenerator):
         or 64-bit) and the selected ``toolset`` (if applicable).
         """
         vs_version = VS_YEAR_TO_VERSION[year]
-        vs_base = "Visual Studio %s %s" % (vs_version, year)
+        vs_base = "Visual Studio {} {}".format(vs_version, year)
         if platform.architecture()[0] == "64bit":
             vs_arch = "x64"
         else:
@@ -217,7 +217,7 @@ def _find_visual_studio_2017_or_newer(vs_version):
             extra_args = {'encoding': 'mbcs', 'errors': 'strict'}
         path = subprocess.check_output([
             os.path.join(root, "Microsoft Visual Studio", "Installer", "vswhere.exe"),
-            "-version", "[%.1f, %.1f)" % (vs_version, vs_version + 1),
+            "-version", "[{:.1f}, {:.1f})".format(vs_version, vs_version + 1),
             "-prerelease",
             "-requires", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
             "-property", "installationPath",
@@ -367,4 +367,4 @@ class CMakeVisualStudioCommandLineGenerator(CMakeGenerator):
         vc_env = _get_msvc_compiler_env(VS_YEAR_TO_VERSION[year], toolset)
         env = {str(key.upper()): str(value) for key, value in vc_env.items()}
         super(CMakeVisualStudioCommandLineGenerator, self).__init__(name, env)
-        self._description = "%s (%s)" % (self.name, CMakeVisualStudioIDEGenerator(year, toolset).description)
+        self._description = "{} ({})".format(self.name, CMakeVisualStudioIDEGenerator(year, toolset).description)

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -567,7 +567,7 @@ def setup(*args, **kw):  # noqa: C901
             if cmake_minimum_required_version is not None:
                 if parse_version(cmkr.cmake_version) < parse_version(cmake_minimum_required_version):
                     raise SKBuildError(
-                        "CMake version %s or higher is required. CMake version %s is being used" % (
+                        "CMake version {} or higher is required. CMake version {} is being used".format(
                             cmake_minimum_required_version, cmkr.cmake_version))
             # Used to confirm that the cmake executable is the same, and that the environment
             # didn't change

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -148,7 +148,7 @@ def _copy_dir(target_dir, src_dir, on_duplicate='exception', keep_top_dir=False)
             _copy(entry, target_dir)
         elif on_duplicate == 'exception':
             raise ValueError(
-                "'%s' already exists (src %s)" % (
+                "'{}' already exists (src {})".format(
                     target_entry,
                     entry,
                 )

--- a/tests/pytest_helpers.py
+++ b/tests/pytest_helpers.py
@@ -1,4 +1,3 @@
-
 import six
 import sys
 import tarfile

--- a/tests/samples/cmakelists-not-in-top-level-dir/hello/__main__.py
+++ b/tests/samples/cmakelists-not-in-top-level-dir/hello/__main__.py
@@ -1,4 +1,3 @@
-
 if __name__ == "__main__":
     from . import _hello as hello
     hello.hello("World")

--- a/tests/samples/cython-flags/hello/__main__.py
+++ b/tests/samples/cython-flags/hello/__main__.py
@@ -1,4 +1,3 @@
-
 if __name__ == "__main__":
     from . import _hello as hello
     hello.hello("World")

--- a/tests/samples/fail-hello-with-compile-error/hello/__main__.py
+++ b/tests/samples/fail-hello-with-compile-error/hello/__main__.py
@@ -1,4 +1,3 @@
-
 if __name__ == "__main__":
     from . import _hello as hello
     hello.hello("World")

--- a/tests/samples/hello-cpp/hello/__main__.py
+++ b/tests/samples/hello-cpp/hello/__main__.py
@@ -1,4 +1,3 @@
-
 if __name__ == "__main__":
     from . import _hello as hello
     hello.hello("World")

--- a/tests/samples/hello-cython/hello/__main__.py
+++ b/tests/samples/hello-cython/hello/__main__.py
@@ -1,4 +1,3 @@
-
 if __name__ == "__main__":
     from . import _hello as hello
     hello.hello("World")

--- a/tests/samples/issue-274-support-default-package-dir/src/hello/__init__.py
+++ b/tests/samples/issue-274-support-default-package-dir/src/hello/__init__.py
@@ -1,3 +1,2 @@
-
 def who():
     return "world"

--- a/tests/samples/issue-274-support-one-package-without-package-dir/hello/__init__.py
+++ b/tests/samples/issue-274-support-one-package-without-package-dir/hello/__init__.py
@@ -1,3 +1,2 @@
-
 def who():
     return "world"

--- a/tests/samples/issue-284-build-ext-inplace/setup.py
+++ b/tests/samples/issue-284-build-ext-inplace/setup.py
@@ -1,4 +1,3 @@
-
 from setuptools import Extension
 from skbuild import setup
 

--- a/tests/samples/issue-335-support-cmake-source-dir/wrapping/python/setup.py
+++ b/tests/samples/issue-335-support-cmake-source-dir/wrapping/python/setup.py
@@ -1,4 +1,3 @@
-
 from skbuild import setup
 
 setup(

--- a/tests/samples/test-filter-manifest/wrapping/python/setup.py
+++ b/tests/samples/test-filter-manifest/wrapping/python/setup.py
@@ -1,4 +1,3 @@
-
 from skbuild import setup
 
 

--- a/tests/samples/test-hide-listing/hello/__main__.py
+++ b/tests/samples/test-hide-listing/hello/__main__.py
@@ -1,4 +1,3 @@
-
 if __name__ == "__main__":
     from . import hello
     hello.hello("World")

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,4 +1,3 @@
-
 import os
 import sys
 

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -1,4 +1,3 @@
-
 import os
 import pytest
 

--- a/tests/test_filter_manifest.py
+++ b/tests/test_filter_manifest.py
@@ -1,4 +1,3 @@
-
 import glob
 
 from . import (

--- a/tests/test_issue274_support_default_package_dir.py
+++ b/tests/test_issue274_support_default_package_dir.py
@@ -1,4 +1,3 @@
-
 from . import (
     _tmpdir, execute_setup_py, initialize_git_repo_and_commit,
     prepare_project, project_setup_py_test, push_dir

--- a/tests/test_issue274_support_one_package_without_package_dir.py
+++ b/tests/test_issue274_support_one_package_without_package_dir.py
@@ -1,4 +1,3 @@
-
 from . import (
     _tmpdir, execute_setup_py, initialize_git_repo_and_commit,
     prepare_project, project_setup_py_test, push_dir

--- a/tests/test_issue284_build_ext_inplace.py
+++ b/tests/test_issue284_build_ext_inplace.py
@@ -1,4 +1,3 @@
-
 import os
 
 from . import get_ext_suffix, project_setup_py_test

--- a/tests/test_issue334_configure_cmakelists_non_cp1252_encoding.py
+++ b/tests/test_issue334_configure_cmakelists_non_cp1252_encoding.py
@@ -1,4 +1,3 @@
-
 from . import project_setup_py_test
 
 

--- a/tests/test_issue335_support_cmake_source_dir.py
+++ b/tests/test_issue335_support_cmake_source_dir.py
@@ -1,4 +1,3 @@
-
 import glob
 
 from . import (

--- a/tests/test_issue342_cmake_osx_args_in_setup.py
+++ b/tests/test_issue342_cmake_osx_args_in_setup.py
@@ -187,10 +187,10 @@ def test_cmake_args_keyword_osx_default(
 
     assert found_cmake_osx_deployment_target, \
         textwrap.dedent("""
-                    Argument -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=%s is NOT found near the end of
+                    Argument -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING={} is NOT found near the end of
                     current list of arguments:
-                      keyword_cmake_args  : %s
-                      cli_cmake_args    : %s
-                      current_cmake_args: %s
-                    """ % (expected_cmake_osx_deployment_target,
-                           keyword_cmake_args, cli_cmake_args, current_cmake_args))
+                      keyword_cmake_args  : {}
+                      cli_cmake_args    : {}
+                      current_cmake_args: {}
+                    """.format(expected_cmake_osx_deployment_target,
+                               keyword_cmake_args, cli_cmake_args, current_cmake_args))

--- a/tests/test_skbuild.py
+++ b/tests/test_skbuild.py
@@ -126,7 +126,7 @@ def test_generator(generator, expected_make_program):
 
     this_platform = platform.system().lower()
     if this_platform not in generator_platform[generator]:
-        pytest.skip("%s generator is available only on %s" % (
+        pytest.skip("{} generator is available only on {}".format(
             generator, this_platform.title()))
 
     @project_setup_py_test("hello-cpp", ["build"])

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,4 +1,3 @@
-
 # Version: 0.18
 
 """The Versioneer - like a rocketeer, but for versions.
@@ -405,7 +404,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
             return None, None
     else:
         if verbose:
-            print("unable to find command, tried %s" % (commands,))
+            print("unable to find command, tried {}".format(commands))
         return None, None
     stdout = p.communicate()[0].strip()
     if sys.version_info[0] >= 3:
@@ -418,7 +417,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
     return stdout, p.returncode
 
 
-LONG_VERSION_PY['git'] = '''
+LONG_VERSION_PY['git'] = r'''
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -989,11 +988,11 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         if verbose:
             print("keywords are unexpanded, not using")
         raise NotThisMethod("unexpanded keywords, not a git-archive tarball")
-    refs = set([r.strip() for r in refnames.strip("()").split(",")])
+    refs = {r.strip() for r in refnames.strip("()").split(",")}
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    tags = {r[len(TAG):] for r in refs if r.startswith(TAG)}
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -1002,7 +1001,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r'\d', r)])
+        tags = {r for r in refs if re.search(r'\d', r)}
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -1223,7 +1222,7 @@ def write_to_version_file(filename, versions):
     with open(filename, "w") as f:
         f.write(SHORT_VERSION_PY % contents)
 
-    print("set %s to '%s'" % (filename, versions["version"]))
+    print("set {} to '{}'".format(filename, versions["version"]))
 
 
 def plus_or_dot(pieces):
@@ -1442,7 +1441,7 @@ def get_versions(verbose=False):
     try:
         ver = versions_from_file(versionfile_abs)
         if verbose:
-            print("got version from file %s %s" % (versionfile_abs, ver))
+            print("got version from file {} {}".format(versionfile_abs, ver))
         return ver
     except NotThisMethod:
         pass


### PR DESCRIPTION
This runs PyUpgrade, updating old Python constructs to Python 2.7+ compatible ones. Eventually, this will be used to update to 3.6+ compatible constructs.

- chore: add pyupgrade
- style: run pre-commit
