### PR TITLE
Accommodate packages in separate source directory

### DIFF
--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -900,11 +900,15 @@ def _consolidate_package_modules(
         if _package_data_contain_module(entry, package_data):
             continue
 
-        (package, _, src_module_file) = entry
+        (package, module_name, src_module_file) = entry
 
         # Copy missing module file
         if os.path.exists(src_module_file):
-            dest_module_file = os.path.join(CMAKE_INSTALL_DIR(), src_module_file)
+            dest_module_file = os.path.join(
+                CMAKE_INSTALL_DIR(),
+                *(package.split('.')),
+                module_name + '.py'
+            )
             _copy_file(src_module_file, dest_module_file, hide_listing)
 
         # Since the mapping in package_data expects the package to be associated


### PR DESCRIPTION
I couldn't figure out how to get my package to install correctly when it's in a source directory other than the one containing setup.py.  This change does what I need, though perhaps it's not the best way to go about it.