### PR TITLE
feat: Update the default macOS target platform to 10.9

### DIFF
--- a/docs/generators.rst
+++ b/docs/generators.rst
@@ -188,28 +188,28 @@ Default Deployment Target and Architecture
 .. versionadded:: 0.7.0
 
 The default deployment target and architecture selected by scikit-build are
-hard-coded for MacOSX and are respectively ``10.6`` and ``x86_64``.
+hard-coded for MacOSX and are respectively ``10.9`` and ``x86_64``.
 
 This means that the platform name associated with the `bdist_wheel`
 command is::
 
-    macosx-10.6-x86_64
+    macosx-10.9-x86_64
 
 and is equivalent to building the wheel using::
 
-    python setup.py bdist_wheel --plat-name macosx-10.6-x86_64
+    python setup.py bdist_wheel --plat-name macosx-10.9-x86_64
 
 Respectively, the values associated with the corresponding `CMAKE_OSX_DEPLOYMENT_TARGET`_
 and `CMAKE_OSX_ARCHITECTURES`_ CMake options that are automatically used to configure
 the project are the following::
 
-    CMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.6
+    CMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.9
     CMAKE_OSX_ARCHITECTURES:STRING=x86_64
 
 .. _CMAKE_OSX_DEPLOYMENT_TARGET: https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html
 .. _CMAKE_OSX_ARCHITECTURES: https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_ARCHITECTURES.html
 
-As illustrated in the table below, choosing ``10.6`` as deployment target to build
+As illustrated in the table below, choosing ``10.9`` as deployment target to build
 MacOSX wheels will allow them to work on `System CPython`, the `Official CPython`,
 `Macports` and also `Homebrew` installations of CPython.
 
@@ -222,7 +222,7 @@ MacOSX wheels will allow them to work on `System CPython`, the `Official CPython
     |                      +-------------------------+--------------+--------------------------------+
     |                      | 3.8, 3.9                | 10.13        | macosx-10.9-x86_64             |
     |                      +-------------------------+--------------+--------------------------------+
-    |                      | 3.7, 3.6, 3.5, 3.4, 2.7 | 10.12        | macosx-**10.6**-intel          |
+    |                      | 3.7, 3.6, 3.5, 3.4, 2.7 | 10.12        | macosx-10.6-intel              |
     |                      +-------------------------+--------------+                                |
     |                      | 3.4, 2.7                | 10.9         |                                |
     |                      +-------------------------+--------------+                                |

--- a/skbuild/command/bdist_wheel.py
+++ b/skbuild/command/bdist_wheel.py
@@ -66,7 +66,7 @@ class bdist_wheel(set_build_base_mixin, new_style(_bdist_wheel)):
         if sys.platform == 'darwin' and self.plat_name is None and self.distribution.has_ext_modules():
             # The default value is duplicated in setuptools_wrap
             # pylint:disable=access-member-before-definition
-            self.plat_name = os.environ.get('_PYTHON_HOST_PLATFORM', 'macosx-10.6-x86_64')
+            self.plat_name = os.environ.get('_PYTHON_HOST_PLATFORM', 'macosx-10.9-x86_64')
         super(bdist_wheel, self).finalize_options(*args, **kwargs)
 
     def write_wheelfile(self, wheelfile_base, _=None):

--- a/skbuild/constants.py
+++ b/skbuild/constants.py
@@ -82,7 +82,7 @@ def skbuild_plat_name():
     Default value corresponds to :func:`_default_skbuild_plat_name()` and can be overridden
     with :func:`set_skbuild_plat_name()`.
 
-    Examples of values are `macosx-10.6-x86_64`, `linux-x86_64`, `linux-i686` or `win-am64`.
+    Examples of values are `macosx-10.9-x86_64`, `linux-x86_64`, `linux-i686` or `win-am64`.
     """
     return _SKBUILD_PLAT_NAME
 

--- a/tests/test_issue342_cmake_osx_args_in_setup.py
+++ b/tests/test_issue342_cmake_osx_args_in_setup.py
@@ -12,7 +12,7 @@ params = "osx_deployment_target_env_var,cli_setup_args," \
 
 
 @pytest.mark.parametrize(params, [
-    # default plat_name is 'macosx-10.6-x86_64'
+    # default plat_name is 'macosx-10.9-x86_64'
     (
             # osx_deployment_target_env_var
             None,
@@ -23,7 +23,7 @@ params = "osx_deployment_target_env_var,cli_setup_args," \
             # cli_cmake_args
             [],
             # expected_cmake_osx_deployment_target
-            "10.6"
+            "10.9"
     ),
     (
             # osx_deployment_target_env_var
@@ -155,7 +155,7 @@ def test_cmake_args_keyword_osx_default(
         sys.platform = "darwin"
 
         def mock_mac_ver():
-            return "10.6", None, "x84_64"
+            return "10.9", None, "x84_64"
 
         saved_mac_ver = platform.mac_ver
         platform.mac_ver = mock_mac_ver


### PR DESCRIPTION
This is the target for most recent python.org distributions.
