### PR TITLE
feat: support CMAKE_ARGS

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -514,6 +514,21 @@ If a file is added to the CMake build system by updating one of the ``CMakeLists
 will not explicitly reconfigure the project. Instead, the generated build-system will automatically
 detect the change and reconfigure the project after :meth:`skbuild.cmaker.CMaker.make` is called.
 
+
+Environment variable configuration
+----------------------------------
+
+Scikit-build support environment variables to configure some options. These are:
+
+``SKBUILD_CONFIGURE_OPTIONS``/``CMAKE_ARGS``
+  This will add configuration options when configuring CMake.
+  ``SKBUILD_CONFIGURE_OPTIONS`` will be used instead of ``CMAKE_ARGS`` if both
+  are defined.
+
+``SKBUILD_BUILD_OPTIONS``
+  Pass options to the build.
+
+
 .. _cross_compilation:
 
 Cross-compilation

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -285,7 +285,14 @@ class CMaker(object):
 
         cmd.extend(clargs)
 
-        cmd.extend(filter(bool, shlex.split(os.environ.get("SKBUILD_CONFIGURE_OPTIONS", ""))))
+        # Parse CMAKE_ARGS only if SKBUILD_CONFIGURE_OPTIONS is not present
+        if "SKBUILD_CONFIGURE_OPTIONS" not in os.environ:
+            env_cmake_args = filter(None, shlex.split(os.environ.get("SKBUILD_CONFIGURE_OPTIONS", "")))
+        else:
+            env_cmake_args = filter(None, shlex.split(os.environ.get("CMAKE_ARGS", "")))
+            env_cmake_args = [s for s in env_cmake_args if "CMAKE_INSTALL_PREFIX" not in s]
+
+        cmd.extend(env_cmake_args)
 
         # changes dir to cmake_build and calls cmake's configure step
         # to generate makefile

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -539,6 +539,13 @@ def setup(*args, **kw):  # noqa: C901
     else:
         cmake_install_target = cmake_install_target_from_setup
 
+    # Parse CMAKE_ARGS
+    env_cmake_args = os.environ["CMAKE_ARGS"].split() if "CMAKE_ARGS" in os.environ else []
+    env_cmake_args = [s for s in env_cmake_args if "CMAKE_INSTALL_PREFIX" not in s]
+
+    # Using the environment variable CMAKE_ARGS has lower precedence than manual options
+    cmake_args = env_cmake_args + cmake_args
+
     if sys.platform == "darwin":
 
         # If no ``--plat-name`` argument was passed, set default value.


### PR DESCRIPTION
Closes #588, would make supporting conda-forge easier, less workarounds like the ones in that issue and https://github.com/conda-forge/correctionlib-feedstock/blob/1d49847e4ac8e69967142146e8cbac81173ee3d3/recipe/setup.patch required.

If this looks like a good idea I can add tests and such.
