### PR TITLE
Add option to use modern form of target_link_libraries

### DIFF
--- a/skbuild/resources/cmake/FindPythonExtensions.cmake
+++ b/skbuild/resources/cmake/FindPythonExtensions.cmake
@@ -434,7 +434,7 @@ endfunction()
 
 function(python_standalone_executable _target)
   include_directories(${PYTHON_INCLUDE_DIRS})
-  target_link_libraries(${_target} ${PYTHON_LIBRARIES})
+  target_link_libraries(${_target} ${SKBUILD_LINK_LIBRARIES_KEYWORD} ${PYTHON_LIBRARIES})
 endfunction()
 
 function(python_modules_header _name)

--- a/skbuild/resources/cmake/UsePythonExtensions.cmake
+++ b/skbuild/resources/cmake/UsePythonExtensions.cmake
@@ -258,11 +258,11 @@ function(add_python_library _name)
   endif()
 
   target_include_directories(${_name} PRIVATE ${_args_INCLUDE_DIRECTORIES})
-  target_link_libraries(${_name} ${_args_LINK_LIBRARIES})
+  target_link_libraries(${_name} ${SKBUILD_LINK_LIBRARIES_KEYWORD} ${_args_LINK_LIBRARIES})
 
   if(_has_f2py_targets)
     target_include_directories(${_name} PRIVATE ${F2PY_INCLUDE_DIRS})
-    target_link_libraries(${_name} ${F2PY_LIBRARIES})
+    target_link_libraries(${_name} ${SKBUILD_LINK_LIBRARIES_KEYWORD} ${F2PY_LIBRARIES})
   endif()
 
   if(_args_COMPILE_DEFINITIONS)

--- a/skbuild/resources/cmake/targetLinkLibrariesWithDynamicLookup.cmake
+++ b/skbuild/resources/cmake/targetLinkLibrariesWithDynamicLookup.cmake
@@ -248,7 +248,7 @@ function(_test_weak_link_project
 
     if(link_mod_lib)
       file(APPEND "${test_project_src_dir}/CMakeLists.txt" "
-        target_link_libraries(counter number)
+        target_link_libraries(counter ${SKBUILD_LINK_LIBRARIES_KEYWORD} number)
       ")
     elseif(NOT link_flag STREQUAL "")
       file(APPEND "${test_project_src_dir}/CMakeLists.txt" "
@@ -262,21 +262,21 @@ function(_test_weak_link_project
 
     if(link_exe_lib)
       file(APPEND "${test_project_src_dir}/CMakeLists.txt" "
-        target_link_libraries(main number)
+        target_link_libraries(main ${SKBUILD_LINK_LIBRARIES_KEYWORD} number)
       ")
     elseif(NOT link_flag STREQUAL "")
       file(APPEND "${test_project_src_dir}/CMakeLists.txt" "
-        target_link_libraries(main \"${link_flag}\")
+        target_link_libraries(main ${SKBUILD_LINK_LIBRARIES_KEYWORD} \"${link_flag}\")
       ")
     endif()
 
     if(link_exe_mod)
       file(APPEND "${test_project_src_dir}/CMakeLists.txt" "
-        target_link_libraries(main counter)
+        target_link_libraries(main ${SKBUILD_LINK_LIBRARIES_KEYWORD} counter)
       ")
     else()
       file(APPEND "${test_project_src_dir}/CMakeLists.txt" "
-        target_link_libraries(main \"${CMAKE_DL_LIBS}\")
+        target_link_libraries(main ${SKBUILD_LINK_LIBRARIES_KEYWORD} \"${CMAKE_DL_LIBS}\")
       ")
     endif()
 
@@ -576,6 +576,6 @@ function(target_link_libraries_with_dynamic_lookup target)
 
   set(links "${link_items}" "${link_libs}")
   if(links)
-    target_link_libraries(${target} "${links}")
+    target_link_libraries(${target} ${SKBUILD_LINK_LIBRARIES_KEYWORD} "${links}")
   endif()
 endfunction()


### PR DESCRIPTION
This adds the option SKBUILD_LINK_LIBRARIES_KEYWORD which can be set to PRIVATE,
PUBLIC, or INTERFACE or left empty (the default) to use the old form of
target_link_libraries.

A similar change was done in FindCuda.cmake: https://gitlab.kitware.com/cmake/cmake/-/commit/9f41bfd7b9e6e8a7545f741f872949d2ae801978
This fixes https://github.com/scikit-build/scikit-build/issues/261
This still requires documentation and I have to test it. 
