### PR TITLE
feat: add VS2022 support on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,17 @@ jobs:
     - name: Setup nox
       uses: excitedleigh/setup-nox@v2.0.0
 
-    - name: Setup Python 3.10 dev
+    - name: Setup Python 3.5
       uses: actions/setup-python@v2
+      if: matrix.runs-on != 'windows-2022'
       with:
-        python-version: 3.10-dev
+        python-version: 3.5
+
+    - name: Setup Python 3.6
+      uses: actions/setup-python@v2
+      if: runner.os == 'Linux'
+      with:
+        python-version: 3.6
 
     # We check all Python's on Linux, because it's fast.
     # We check Python 2.7 on Linux and macOS, it's not supported on Windows.
@@ -67,7 +74,7 @@ jobs:
       if: runner.os != 'Windows'
       run: nox --forcecolor -s tests-2.7
     - name: Test on 🐍 3.5
-      if: matrix.runs-on != 'windows-latest'
+      if: matrix.runs-on != 'windows-2022'
       run: nox --forcecolor -s tests-3.5
     - name: Test on 🐍 3.6
       if: runner.os == 'Linux'
@@ -102,6 +109,7 @@ jobs:
         echo "SKBUILD_TEST_FIND_VS2015_INSTALLATION_EXPECTED=1" >> $GITHUB_ENV
         echo "SKBUILD_TEST_FIND_VS2017_INSTALLATION_EXPECTED=1" >> $GITHUB_ENV
         echo "SKBUILD_TEST_FIND_VS2019_INSTALLATION_EXPECTED=1" >> $GITHUB_ENV
+        echo "SKBUILD_TEST_FIND_VS2022_INSTALLATION_EXPECTED=0" >> $GITHUB_ENV
 
     - name: Setup nox
       uses: excitedleigh/setup-nox@v2.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       if: runner.os == 'Linux'
       run: nox --forcecolor -s tests-3.6
     - name: Test on 🐍 3.7
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' || matrix.runs-on == 'windows-2022'
       run: nox --forcecolor -s tests-3.7
     - name: Test on 🐍 3.8
       if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, macos-latest, windows-2016, windows-latest]
+        runs-on: [ubuntu-latest, macos-latest, windows-2016, windows-2022]
 
     name: Tests on ${{ matrix.runs-on }}
     steps:
@@ -43,11 +43,13 @@ jobs:
       if: matrix.runs-on == 'windows-2016'
       run: |
         echo "SKBUILD_TEST_FIND_VS2019_INSTALLATION_EXPECTED=0" >> $GITHUB_ENV
+        echo "SKBUILD_TEST_FIND_VS2022_INSTALLATION_EXPECTED=0" >> $GITHUB_ENV
 
     - name: Set environment for available GHA MSVCs
       if: matrix.runs-on == 'windows-latest'
       run: |
         echo "SKBUILD_TEST_FIND_VS2019_INSTALLATION_EXPECTED=1" >> $GITHUB_ENV
+        echo "SKBUILD_TEST_FIND_VS2022_INSTALLATION_EXPECTED=1" >> $GITHUB_ENV
 
     - name: Setup nox
       uses: excitedleigh/setup-nox@v2.0.0

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,7 +6,7 @@ import nox
 nox.options.sessions = ["lint", "tests"]
 
 PYTHON_ALL_VERSIONS = ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
-MSVC_ALL_VERSIONS = {"2008", "2010", "2013", "2015", "2017", "2019"}
+MSVC_ALL_VERSIONS = {"2008", "2010", "2013", "2015", "2017", "2019", "2022"}
 
 
 @nox.session

--- a/skbuild/platform_specifics/windows.py
+++ b/skbuild/platform_specifics/windows.py
@@ -74,9 +74,9 @@ class WindowsPlatform(abstract.CMakePlatform):
                 """
             ).strip()
 
-        # For Python 3.6 and above: VS2019, VS2017
+        # For Python 3.6 and above: VS2022, VS2019, VS2017
         elif version.major == 3 and version.minor >= 6:
-            supported_vs_years = [("2019", "v142"), ("2017", "v141")]
+            supported_vs_years = [("2022", "v143"), ("2019", "v142"), ("2017", "v141")]
             self._vs_help = vs_help_template % (
                 supported_vs_years[0][0],
                 "Visual Studio 2017",
@@ -85,6 +85,10 @@ class WindowsPlatform(abstract.CMakePlatform):
             self._vs_help += "\n\n" + textwrap.dedent(
                 """
                 Or with "Visual Studio 2019":
+
+                  https://visualstudio.microsoft.com/vs/
+
+                Or with "Visual Studio 2022":
 
                   https://visualstudio.microsoft.com/vs/
                 """
@@ -113,6 +117,7 @@ VS_YEAR_TO_VERSION = {
     "2015": 14,
     "2017": 15,
     "2019": 16,
+    "2022": 17,
 }
 """Describes the version of `Visual Studio` supported by
 :class:`CMakeVisualStudioIDEGenerator` and

--- a/tests/test_skbuild.py
+++ b/tests/test_skbuild.py
@@ -65,6 +65,7 @@ def test_generator_selection():
 
         has_vs_2017 = find_visual_studio(vs_version=VS_YEAR_TO_VERSION["2017"])
         has_vs_2019 = find_visual_studio(vs_version=VS_YEAR_TO_VERSION["2019"])
+        has_vs_2022 = find_visual_studio(vs_version=VS_YEAR_TO_VERSION["2022"])
 
         # Apply to VS <= 14 (2015)
         has_vs_ide_vcvars = any([
@@ -92,7 +93,7 @@ def test_generator_selection():
         ) and which("ninja.exe"):
             generator = "Ninja"
 
-        elif has_vs_2017 or has_vs_2019:
+        elif has_vs_2017 or has_vs_2019 or has_vs_2022:
             # ninja is provided by the CMake extension bundled with Visual Studio 2017
             # C:/Program Files (x86)/Microsoft Visual Studio/2017/Professional/Common7/IDE/CommonExtensions/Microsoft/CMake/Ninja/ninja.exe  # noqa: E501
             generator = "Ninja"
@@ -175,7 +176,7 @@ def test_invalid_generator(generator_args):
 
 
 @pytest.mark.parametrize(
-    "vs_year", ["2008", "2010", "2012", "2013", "2015", "2017", "2019"]
+    "vs_year", ["2008", "2010", "2012", "2013", "2015", "2017", "2019", "2022"]
 )
 def test_platform_windows_find_visual_studio(vs_year):
     """If the environment variable ``SKBUILD_TEST_FIND_VS<vs_year>_INSTALLATION_EXPECTED`` is set,


### PR DESCRIPTION
Tested on Windows 11 (21H2) with Python 3.9.9 and Visual Studio Community 2022 (17.0.5).

<details><summary>Nox results</summary>

```
$Env:SKBUILD_TEST_FIND_VS2022_INSTALLATION_EXPECTED=1   
nox
nox > Running session lint
nox > Creating virtual environment (virtualenv) using python.exe in .nox\lint
nox > python -m pip install pre-commit
nox > pre-commit run -a
check for added large files..............................................Passed
check for case conflicts.................................................Passed
check for merge conflicts................................................Passed
check for broken symlinks............................(no files to check)Skipped
check yaml...............................................................Passed
debug statements (python)................................................Passed
fix end of files.........................................................Passed
mixed line ending........................................................Passed
fix requirements.txt.....................................................Passed
trim trailing whitespace.................................................Passed
pyupgrade................................................................Passed
flake8...................................................................Passed
codespell................................................................Passed
nox > Session lint was successful.
nox > Running session tests-2.7
nox > Session tests-2.7 skipped: Python interpreter 2.7 not found.
nox > Running session tests-3.5
nox > Session tests-3.5 skipped: Python interpreter 3.5 not found.
nox > Running session tests-3.6
nox > Session tests-3.6 skipped: Python interpreter 3.6 not found.
nox > Running session tests-3.7
nox > Session tests-3.7 skipped: Python interpreter 3.7 not found.
nox > Running session tests-3.8
nox > Session tests-3.8 skipped: Python interpreter 3.8 not found.
nox > Running session tests-3.9
nox > Creating virtual environment (virtualenv) using python3.9 in .nox\tests-3-9
nox > python -m pip install '.[test]'
nox > pytest 
======================================================================== test session starts =========================================================================
platform win32 -- Python 3.9.9, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- C:\Users\piete\Documents\GitHub\scikit-build\.nox\tests-3-9\Scripts\python.EXE
cachedir: .pytest_cache
rootdir: C:\Users\piete\Documents\GitHub\scikit-build, configfile: setup.cfg, testpaths: tests
plugins: cov-3.0.0, mock-3.6.1, shutil-1.7.0, virtualenv-1.7.0, xdoctest-0.15.10
collected 237 items

tests/test_broken_project.py::test_cmakelists_with_fatalerror_fails PASSED                                                                                      [  0%]
tests/test_broken_project.py::test_cmakelists_with_syntaxerror_fails PASSED                                                                                     [  0%]
tests/test_broken_project.py::test_hello_with_compileerror_fails PASSED                                                                                         [  1%]
tests/test_broken_project.py::test_invalid_cmake[CalledProcessError] PASSED                                                                                     [  1%]
tests/test_broken_project.py::test_invalid_cmake[OSError] PASSED                                                                                                [  2%]
tests/test_broken_project.py::test_first_invalid_generator PASSED                                                                                               [  2%]
tests/test_broken_project.py::test_invalid_generator PASSED                                                                                                     [  2%]
tests/test_cmakelists_not_in_top_level_dir.py::test_build PASSED                                                                                                [  3%]
tests/test_cmakelists_not_in_top_level_dir.py::test_cmake_source_dir[invalid-True] PASSED                                                                       [  3%]
tests/test_cmakelists_not_in_top_level_dir.py::test_cmake_source_dir[-False] PASSED                                                                             [  4%]
tests/test_cmakelists_not_in_top_level_dir.py::test_cmake_source_dir[.-False] PASSED                                                                            [  4%]
tests/test_cmakelists_not_in_top_level_dir.py::test_hello_sdist PASSED                                                                                          [  5%]
tests/test_cmaker.py::test_get_python_version PASSED                                                                                                            [  5%] 
tests/test_cmaker.py::test_get_python_include_dir PASSED                                                                                                        [  5%] 
tests/test_cmaker.py::test_get_python_library PASSED                                                                                                            [  6%] 
tests/test_cmaker.py::test_cmake_executable PASSED                                                                                                              [  6%]
tests/test_cmaker.py::test_has_cmake_cache_arg PASSED                                                                                                           [  7%] 
tests/test_cmaker.py::test_make_without_build_dir_fails PASSED                                                                                                  [  7%]
tests/test_cmaker.py::test_make_without_configure_fails PASSED                                                                                                  [  8%]
tests/test_cmaker.py::test_make[True] PASSED                                                                                                                    [  8%]
tests/test_cmaker.py::test_make[False] PASSED                                                                                                                   [  8%]
tests/test_cmaker.py::test_configure_with_cmake_args PASSED                                                                                                     [  9%]
tests/test_cmaker.py::test_check_for_bad_installs PASSED                                                                                                        [  9%]
tests/test_command_line.py::test_help PASSED                                                                                                                    [ 10%]
tests/test_command_line.py::test_help_commands PASSED                                                                                                           [ 10%]
tests/test_command_line.py::test_metadata_display PASSED                                                                                                        [ 10%]
tests/test_command_line.py::test_no_command PASSED                                                                                                              [ 11%]
tests/test_command_line.py::test_invalid_command PASSED                                                                                                         [ 11%]
tests/test_command_line.py::test_too_many_separators PASSED                                                                                                     [ 12%]
tests/test_command_line.py::test_cmake_args PASSED                                                                                                              [ 12%]
tests/test_command_line.py::test_cmake_cache_entry_as_global_option PASSED                                                                                      [ 13%]
tests/test_command_line.py::test_cmake_initial_cache_as_global_option PASSED                                                                                    [ 13%]
tests/test_command_line.py::test_cmake_executable_arg PASSED                                                                                                    [ 13%]
tests/test_command_line.py::test_hide_listing[True-sdist] PASSED                                                                                                [ 14%]
tests/test_command_line.py::test_hide_listing[True-bdist_wheel] PASSED                                                                                          [ 14%]
tests/test_command_line.py::test_hide_listing[False-sdist] PASSED                                                                                               [ 15%]
tests/test_command_line.py::test_hide_listing[False-bdist_wheel] PASSED                                                                                         [ 15%]
tests/test_command_line.py::test_run_cmake_arg PASSED                                                                                                           [ 16%]
tests/test_command_line.py::test_skip_cmake_arg PASSED                                                                                                          [ 16%]
tests/test_constants.py::test_set_skbuild_plat_name PASSED                                                                                                      [ 16%]
tests/test_cython_flags.py::test_hello_cython_builds PASSED                                                                                                     [ 17%]
tests/test_distribution.py::test_source_distribution PASSED                                                                                    [ 17%]
tests/test_distribution.py::test_wheel PASSED                                                                                                  [ 18%] 
tests/test_filter_manifest.py::test_bdist_wheel_command PASSED                                                                                 [ 18%] 
tests/test_hello_cpp.py::test_hello_builds PASSED                                                                                              [ 18%] 
tests/test_hello_cpp.py::test_hello_sdist PASSED                                                                                               [ 19%] 
tests/test_hello_cpp.py::test_hello_wheel PASSED                                                                                               [ 19%] 
tests/test_hello_cpp.py::test_hello_clean[with-dry-run] PASSED                                                                                 [ 20%] 
tests/test_hello_cpp.py::test_hello_clean[without-dry-run] PASSED                                                                              [ 20%] 
tests/test_hello_cpp.py::test_hello_cleans PASSED                                                                                              [ 21%] 
tests/test_hello_cpp.py::test_hello_develop PASSED                                                                                             [ 21%] 
tests/test_hello_cython.py::test_hello_cython_builds PASSED                                                                                    [ 21%] 
tests/test_hello_cython.py::test_hello_cython_sdist PASSED                                                                                     [ 22%] 
tests/test_hello_cython.py::test_hello_cython_wheel PASSED                                                                                     [ 22%] 
tests/test_hello_pure.py::test_hello_pure_builds PASSED                                                                                        [ 23%] 
tests/test_hello_pure.py::test_hello_pure_sdist PASSED                                                                                         [ 23%] 
tests/test_hello_pure.py::test_hello_pure_wheel PASSED                                                                                         [ 24%] 
tests/test_hello_pure.py::test_hello_clean PASSED                                                                                              [ 24%] 
tests/test_include_exclude_data.py::test_include_exclude_data PASSED                                                                           [ 24%] 
tests/test_include_exclude_data.py::test_hello_sdist PASSED                                                                                    [ 25%] 
tests/test_include_exclude_data.py::test_include_exclude_data_with_base PASSED                                                                 [ 25%] 
tests/test_include_exclude_data.py::test_hello_sdist_with_base PASSED                                                                          [ 26%] 
tests/test_issue274_support_default_package_dir.py::test_install_command PASSED                                                                [ 26%] 
tests/test_issue274_support_default_package_dir.py::test_test_command PASSED                                                                   [ 27%] 
tests/test_issue274_support_one_package_without_package_dir.py::test_install_command PASSED                                                    [ 27%] 
tests/test_issue274_support_one_package_without_package_dir.py::test_test_command PASSED                                                       [ 27%] 
tests/test_issue284_build_ext_inplace.py::test_build_ext_inplace_command PASSED                                                                [ 28%]
tests/test_issue334_configure_cmakelists_non_cp1252_encoding.py::test_install_command PASSED                                                   [ 28%]
tests/test_issue335_support_cmake_source_dir.py::test_bdist_wheel_command PASSED                                                               [ 29%]
tests/test_issue342_cmake_osx_args_in_setup.py::test_cmake_args_keyword_osx_default[None-cli_setup_args0-keyword_cmake_args0-cli_cmake_args0-10.9] PASSED [ 29%]
tests/test_issue342_cmake_osx_args_in_setup.py::test_cmake_args_keyword_osx_default[10.7-cli_setup_args1-keyword_cmake_args1-cli_cmake_args1-10.7] PASSED [ 29%]
tests/test_issue342_cmake_osx_args_in_setup.py::test_cmake_args_keyword_osx_default[10.7-cli_setup_args2-keyword_cmake_args2-cli_cmake_args2-10.9] PASSED [ 30%]
tests/test_issue342_cmake_osx_args_in_setup.py::test_cmake_args_keyword_osx_default[None-cli_setup_args3-keyword_cmake_args3-cli_cmake_args3-10.6] PASSED [ 30%]
tests/test_issue342_cmake_osx_args_in_setup.py::test_cmake_args_keyword_osx_default[None-cli_setup_args4-keyword_cmake_args4-cli_cmake_args4-10.7] PASSED [ 31%]
tests/test_issue342_cmake_osx_args_in_setup.py::test_cmake_args_keyword_osx_default[None-cli_setup_args5-keyword_cmake_args5-cli_cmake_args5-10.7] PASSED [ 31%]
tests/test_issue342_cmake_osx_args_in_setup.py::test_cmake_args_keyword_osx_default[None-cli_setup_args6-keyword_cmake_args6-cli_cmake_args6-10.7] PASSED [ 32%]
tests/test_issue342_cmake_osx_args_in_setup.py::test_cmake_args_keyword_osx_default[None-cli_setup_args7-keyword_cmake_args7-cli_cmake_args7-10.8] PASSED [ 32%]
tests/test_issue342_cmake_osx_args_in_setup.py::test_cmake_args_keyword_osx_default[None-cli_setup_args8-keyword_cmake_args8-cli_cmake_args8-10.8] PASSED [ 32%]
tests/test_issue352_isolated_environment_support.py::test_isolated_env_trigger_reconfigure PASSED                                              [ 33%]
tests/test_issue401_sdist_with_symlinks.py::test_sdist_with_symlinks SKIPPED (Symlinks not supported on Windows)                               [ 33%] 
tests/test_logging.py::test_hide_listing PASSED                                                                                                [ 34%]
tests/test_logging.py::test_no_hide_listing PASSED                                                                                             [ 34%] 
tests/test_manifest_in.py::test_manifest_in_sdist PASSED                                                                                       [ 35%]
tests/test_manifest_in.py::test_manifest_in_wheel PASSED                                                                                       [ 35%]
tests/test_outside_project_root.py::test_outside_project_root_fails[None] PASSED                                                               [ 35%]
tests/test_outside_project_root.py::test_outside_project_root_fails[-DINSTALL_FILE:BOOL=1] PASSED                                              [ 36%]
tests/test_outside_project_root.py::test_outside_project_root_fails[-DINSTALL_PROJECT:BOOL=1] PASSED                                           [ 36%]
tests/test_platform.py::test_platform_has_entries PASSED                                                                                       [ 37%] 
tests/test_platform.py::test_write_compiler_test_file PASSED                                                                                   [ 37%]
tests/test_platform.py::test_cxx_compiler PASSED                                                                                               [ 37%]
tests/test_platform.py::test_fortran_compiler SKIPPED (no fortran compiler is available by default)                                            [ 38%] 
tests/test_platform.py::test_generator_cleanup PASSED                                                                                          [ 38%] 
tests/test_platform.py::test_known_platform[darwin] PASSED                                                                                     [ 39%]
tests/test_platform.py::test_known_platform[freebsd] PASSED                                                                                    [ 39%]
tests/test_platform.py::test_known_platform[openbsd] PASSED                                                                                    [ 40%]
tests/test_platform.py::test_known_platform[linux] PASSED                                                                                      [ 40%]
tests/test_platform.py::test_known_platform[windows] PASSED                                                                                    [ 40%]
tests/test_platform.py::test_known_platform[os400] PASSED                                                                                      [ 41%] 
tests/test_platform.py::test_unsupported_platform PASSED                                                                                       [ 41%]
tests/test_platform.py::test_cached_generator PASSED                                                                                           [ 42%]
tests/test_setup.py::test_distribution_is_pure[unknown] PASSED                                                                                 [ 42%]
tests/test_setup.py::test_distribution_is_pure[py_modules] PASSED                                                                              [ 43%]
tests/test_setup.py::test_distribution_is_pure[packages] PASSED                                                                                [ 43%]
tests/test_setup.py::test_distribution_is_pure[skbuild] PASSED                                                                                 [ 43%]
tests/test_setup.py::test_cmake_args_keyword[cmake_args0] PASSED                                                                               [ 44%]
tests/test_setup.py::test_cmake_args_keyword[cmake_args1] PASSED                                                                               [ 44%]
tests/test_setup.py::test_cmake_install_dir_keyword[None-True-str] PASSED                                                                      [ 45%]
tests/test_setup.py::test_cmake_install_dir_keyword[-True-str] PASSED                                                                          [ 45%]
tests/test_setup.py::test_cmake_install_dir_keyword[C:\\Users\\piete\\AppData\\Local\\Temp\\scikit-build-True-SKBuildError] PASSED             [ 45%]
tests/test_setup.py::test_cmake_install_dir_keyword[banana-False-str] PASSED                                                                   [ 46%]
tests/test_setup.py::test_cmake_with_sdist_keyword[True] PASSED                                                                                [ 46%]
tests/test_setup.py::test_cmake_with_sdist_keyword[False] PASSED                                                                               [ 47%]
tests/test_setup.py::test_cmake_minimum_required_version_keyword PASSED                                                                        [ 47%]
tests/test_setup.py::test_setup_requires_keyword_include_cmake XPASS (Timing issue with Ninja & MSVC 2019- needs investigation)                [ 48%]
tests/test_setup.py::test_script_keyword[pure] PASSED                                                                                          [ 48%]
tests/test_setup.py::test_script_keyword[skbuild] PASSED                                                                                       [ 48%]
tests/test_setup.py::test_py_modules_keyword[pure] PASSED                                                                                      [ 49%]
tests/test_setup.py::test_py_modules_keyword[skbuild] PASSED                                                                                   [ 49%]
tests/test_setup.py::test_strip_package[package_parts0--] PASSED                                                                               [ 50%] 
tests/test_setup.py::test_strip_package[package_parts1-file.py-file.py] PASSED                                                                 [ 50%] 
tests/test_setup.py::test_strip_package[package_parts2-foo/file.py-foo/file.py] PASSED                                                         [ 51%]
tests/test_setup.py::test_strip_package[package_parts3--] PASSED                                                                               [ 51%] 
tests/test_setup.py::test_strip_package[package_parts4--] PASSED                                                                               [ 51%] 
tests/test_setup.py::test_strip_package[package_parts5-foo/file.py-file.py] PASSED                                                             [ 52%]
tests/test_setup.py::test_strip_package[package_parts6-foo\\file.py-file.py] PASSED                                                            [ 52%] 
tests/test_setup.py::test_strip_package[package_parts7-foo/file.py-foo/file.py] PASSED                                                         [ 53%]
tests/test_setup.py::test_strip_package[package_parts8-foo/bar/file.py-file.py] PASSED                                                         [ 53%] 
tests/test_setup.py::test_strip_package[package_parts9-foo/bar/baz/file.py-baz/file.py] PASSED                                                 [ 54%]
tests/test_setup.py::test_strip_package[package_parts10-/foo/file.py-/foo/file.py] PASSED                                                      [ 54%] 
tests/test_setup.py::test_setup_inputs[0-0-0-0-0-0] PASSED                                                                                     [ 54%]
tests/test_setup.py::test_setup_inputs[0-0-0-0-0-1] PASSED                                                                                     [ 55%]
tests/test_setup.py::test_setup_inputs[0-0-0-0-1-0] PASSED                                                                                     [ 55%]
tests/test_setup.py::test_setup_inputs[0-0-0-0-1-1] PASSED                                                                                     [ 56%]
tests/test_setup.py::test_setup_inputs[0-0-0-1-0-0] PASSED                                                                                     [ 56%]
tests/test_setup.py::test_setup_inputs[0-0-0-1-0-1] PASSED                                                                                     [ 56%]
tests/test_setup.py::test_setup_inputs[0-0-0-1-1-0] PASSED                                                                                     [ 57%]
tests/test_setup.py::test_setup_inputs[0-0-0-1-1-1] PASSED                                                                                     [ 57%]
tests/test_setup.py::test_setup_inputs[0-0-1-0-0-0] PASSED                                                                                     [ 58%]
tests/test_setup.py::test_setup_inputs[0-0-1-0-0-1] PASSED                                                                                     [ 58%]
tests/test_setup.py::test_setup_inputs[0-0-1-0-1-0] PASSED                                                                                     [ 59%]
tests/test_setup.py::test_setup_inputs[0-0-1-0-1-1] PASSED                                                                                     [ 59%]
tests/test_setup.py::test_setup_inputs[0-0-1-1-0-0] PASSED                                                                                     [ 59%]
tests/test_setup.py::test_setup_inputs[0-0-1-1-0-1] PASSED                                                                                     [ 60%]
tests/test_setup.py::test_setup_inputs[0-0-1-1-1-0] PASSED                                                                                     [ 60%]
tests/test_setup.py::test_setup_inputs[0-0-1-1-1-1] PASSED                                                                                     [ 61%]
tests/test_setup.py::test_setup_inputs[0-1-0-0-0-0] PASSED                                                                                     [ 61%]
tests/test_setup.py::test_setup_inputs[0-1-0-0-0-1] PASSED                                                                                     [ 62%]
tests/test_setup.py::test_setup_inputs[0-1-0-0-1-0] PASSED                                                                                     [ 62%]
tests/test_setup.py::test_setup_inputs[0-1-0-0-1-1] PASSED                                                                                     [ 62%]
tests/test_setup.py::test_setup_inputs[0-1-0-1-0-0] PASSED                                                                                     [ 63%]
tests/test_setup.py::test_setup_inputs[0-1-0-1-0-1] PASSED                                                                                     [ 63%]
tests/test_setup.py::test_setup_inputs[0-1-0-1-1-0] PASSED                                                                                     [ 64%]
tests/test_setup.py::test_setup_inputs[0-1-0-1-1-1] PASSED                                                                                     [ 64%]
tests/test_setup.py::test_setup_inputs[0-1-1-0-0-0] PASSED                                                                                     [ 64%]
tests/test_setup.py::test_setup_inputs[0-1-1-0-0-1] PASSED                                                                                     [ 65%]
tests/test_setup.py::test_setup_inputs[0-1-1-0-1-0] PASSED                                                                                     [ 65%]
tests/test_setup.py::test_setup_inputs[0-1-1-0-1-1] PASSED                                                                                     [ 66%]
tests/test_setup.py::test_setup_inputs[0-1-1-1-0-0] PASSED                                                                                     [ 66%]
tests/test_setup.py::test_setup_inputs[0-1-1-1-0-1] PASSED                                                                                     [ 67%]
tests/test_setup.py::test_setup_inputs[0-1-1-1-1-0] PASSED                                                                                     [ 67%]
tests/test_setup.py::test_setup_inputs[0-1-1-1-1-1] PASSED                                                                                     [ 67%]
tests/test_setup.py::test_setup_inputs[1-0-0-0-0-0] PASSED                                                                                     [ 68%]
tests/test_setup.py::test_setup_inputs[1-0-0-0-0-1] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 68%]
tests/test_setup.py::test_setup_inputs[1-0-0-0-1-0] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 69%]
tests/test_setup.py::test_setup_inputs[1-0-0-0-1-1] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 69%]
tests/test_setup.py::test_setup_inputs[1-0-0-1-0-0] PASSED                                                                                     [ 70%]
tests/test_setup.py::test_setup_inputs[1-0-0-1-0-1] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 70%]
tests/test_setup.py::test_setup_inputs[1-0-0-1-1-0] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 70%]
tests/test_setup.py::test_setup_inputs[1-0-0-1-1-1] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 71%]
tests/test_setup.py::test_setup_inputs[1-0-1-0-0-0] PASSED                                                                                     [ 71%]
tests/test_setup.py::test_setup_inputs[1-0-1-0-0-1] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 72%]
tests/test_setup.py::test_setup_inputs[1-0-1-0-1-0] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 72%]
tests/test_setup.py::test_setup_inputs[1-0-1-0-1-1] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 72%]
tests/test_setup.py::test_setup_inputs[1-0-1-1-0-0] PASSED                                                                                     [ 73%]
tests/test_setup.py::test_setup_inputs[1-0-1-1-0-1] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 73%]
tests/test_setup.py::test_setup_inputs[1-0-1-1-1-0] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 74%]
tests/test_setup.py::test_setup_inputs[1-0-1-1-1-1] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 74%]
tests/test_setup.py::test_setup_inputs[1-1-0-0-0-0] PASSED                                                                                     [ 75%]
tests/test_setup.py::test_setup_inputs[1-1-0-0-0-1] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 75%]
tests/test_setup.py::test_setup_inputs[1-1-0-0-1-0] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 75%]
tests/test_setup.py::test_setup_inputs[1-1-0-0-1-1] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 76%]
tests/test_setup.py::test_setup_inputs[1-1-0-1-0-0] PASSED                                                                                     [ 76%]
tests/test_setup.py::test_setup_inputs[1-1-0-1-0-1] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 77%]
tests/test_setup.py::test_setup_inputs[1-1-0-1-1-0] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 77%]
tests/test_setup.py::test_setup_inputs[1-1-0-1-1-1] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 78%]
tests/test_setup.py::test_setup_inputs[1-1-1-0-0-0] PASSED                                                                                     [ 78%]
tests/test_setup.py::test_setup_inputs[1-1-1-0-0-1] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 78%]
tests/test_setup.py::test_setup_inputs[1-1-1-0-1-0] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 79%]
tests/test_setup.py::test_setup_inputs[1-1-1-0-1-1] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 79%]
tests/test_setup.py::test_setup_inputs[1-1-1-1-0-0] PASSED                                                                                     [ 80%]
tests/test_setup.py::test_setup_inputs[1-1-1-1-0-1] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 80%]
tests/test_setup.py::test_setup_inputs[1-1-1-1-1-0] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 81%]
tests/test_setup.py::test_setup_inputs[1-1-1-1-1-1] SKIPPED (unsupported configuration: python package fully generated by CMake does *NOT*...) [ 81%]
tests/test_setup.py::test_cmake_install_into_pure_package[0] PASSED                                                                            [ 81%]
tests/test_setup.py::test_cmake_install_into_pure_package[1] PASSED                                                                            [ 82%]
tests/test_setup.py::test_zip_safe_default[None] PASSED                                                                                        [ 82%]
tests/test_setup.py::test_zip_safe_default[False] PASSED                                                                                       [ 83%]
tests/test_setup.py::test_zip_safe_default[True] PASSED                                                                                        [ 83%]
tests/test_skbuild.py::test_generator_selection PASSED                                                                                         [ 83%]
tests/test_skbuild.py::test_generator[NMake Makefiles-nmake] PASSED                                                                            [ 84%]
tests/test_skbuild.py::test_generator[Unix Makefiles-make] SKIPPED (Unix Makefiles generator is available only on Windows)                     [ 84%] 
tests/test_skbuild.py::test_invalid_generator[generator_args0] PASSED                                                                          [ 85%]
tests/test_skbuild.py::test_invalid_generator[generator_args1] PASSED                                                                          [ 85%]
tests/test_skbuild.py::test_platform_windows_find_visual_studio[2008] SKIPPED (env. variable SKBUILD_TEST_FIND_VS2008_INSTALLATION_EXPECTE...) [ 86%] 
tests/test_skbuild.py::test_platform_windows_find_visual_studio[2010] SKIPPED (env. variable SKBUILD_TEST_FIND_VS2010_INSTALLATION_EXPECTE...) [ 86%] 
tests/test_skbuild.py::test_platform_windows_find_visual_studio[2012] SKIPPED (env. variable SKBUILD_TEST_FIND_VS2012_INSTALLATION_EXPECTE...) [ 86%] 
tests/test_skbuild.py::test_platform_windows_find_visual_studio[2013] SKIPPED (env. variable SKBUILD_TEST_FIND_VS2013_INSTALLATION_EXPECTE...) [ 87%]
tests/test_skbuild.py::test_platform_windows_find_visual_studio[2015] SKIPPED (env. variable SKBUILD_TEST_FIND_VS2015_INSTALLATION_EXPECTE...) [ 87%] 
tests/test_skbuild.py::test_platform_windows_find_visual_studio[2017] SKIPPED (env. variable SKBUILD_TEST_FIND_VS2017_INSTALLATION_EXPECTE...) [ 88%]
tests/test_skbuild.py::test_platform_windows_find_visual_studio[2019] SKIPPED (env. variable SKBUILD_TEST_FIND_VS2019_INSTALLATION_EXPECTE...) [ 88%] 
tests/test_skbuild.py::test_platform_windows_find_visual_studio[2022] PASSED                                                                   [ 89%]
tests/test_skbuild.py::test_toolset SKIPPED (Visual Studio 15 2017 is not found)                                                               [ 89%]
tests/test_skbuild_variable.py::test_skbuild_variable_builds PASSED                                                                            [ 89%]
tests/test_skbuild_variable.py::test_skbuild_variable_sdist PASSED                                                                             [ 90%]
tests/test_skbuild_variable.py::test_skbuild_variable_wheel PASSED                                                                             [ 90%]
tests/test_utils.py::test_context_decorator PASSED                                                                                             [ 91%] 
tests/test_utils.py::test_push_dir PASSED                                                                                                      [ 91%]
tests/test_utils.py::test_push_dir_decorator PASSED                                                                                            [ 91%]
tests/test_utils.py::test_mkdir_p PASSED                                                                                                       [ 92%]
tests/test_utils.py::test_push_env PASSED                                                                                                      [ 92%]
tests/test_utils.py::test_python_module_finder PASSED                                                                                          [ 93%]
tests/test_utils.py::test_to_platform_path[None-None] PASSED                                                                                   [ 93%] 
tests/test_utils.py::test_to_platform_path[-] PASSED                                                                                           [ 94%] 
tests/test_utils.py::test_to_platform_path[/bar/foo/baz-\\bar\\foo\\baz] PASSED                                                                [ 94%] 
tests/test_utils.py::test_to_platform_path[C:\\bar\\foo\\baz-C:\\bar\\foo\\baz] PASSED                                                         [ 94%]
tests/test_utils.py::test_to_platform_path[C:\\bar/foo\\baz/-C:\\bar\\foo\\baz\\] PASSED                                                       [ 95%] 
tests/test_utils.py::test_to_unix_path[None-None] PASSED                                                                                       [ 95%]
tests/test_utils.py::test_to_unix_path[-] PASSED                                                                                               [ 96%]
tests/test_utils.py::test_to_unix_path[/bar/foo/baz-/bar/foo/baz] PASSED                                                                       [ 96%] 
tests/test_utils.py::test_to_unix_path[C:\\bar\\foo\\baz-C:/bar/foo/baz] PASSED                                                                [ 97%]
tests/test_utils.py::test_to_unix_path[C:\\bar/foo\\baz/-C:/bar/foo/baz/] PASSED                                                               [ 97%] 
tests/test_utils.py::test_list_ancestors[-expected_ancestors0] PASSED                                                                          [ 97%] 
tests/test_utils.py::test_list_ancestors[.-expected_ancestors1] PASSED                                                                         [ 98%] 
tests/test_utils.py::test_list_ancestors[part1/part2/part3/part4-expected_ancestors2] PASSED                                                   [ 98%] 
tests/test_utils.py::test_list_ancestors[part1\\part2\\part3\\part4-expected_ancestors3] PASSED                                                [ 99%]
tests/test_utils.py::test_list_ancestors[/part1/part2/part3/part4-expected_ancestors4] PASSED                                                  [ 99%]
tests/test_utils.py::test_list_ancestors[C:/part1/part2/part3/part4-expected_ancestors5] PASSED                                                [100%]

================================================================= warnings summary ================================================================== 
tests/test_command_line.py: 2 warnings
tests/test_filter_manifest.py: 1 warning
tests/test_hello_cpp.py: 2 warnings
tests/test_hello_cython.py: 1 warning
tests/test_hello_pure.py: 1 warning
tests/test_include_exclude_data.py: 2 warnings
tests/test_issue274_support_default_package_dir.py: 2 warnings
tests/test_issue274_support_one_package_without_package_dir.py: 2 warnings
tests/test_issue334_configure_cmakelists_non_cp1252_encoding.py: 1 warning
tests/test_issue335_support_cmake_source_dir.py: 1 warning
tests/test_manifest_in.py: 1 warning
tests/test_outside_project_root.py: 3 warnings
tests/test_skbuild_variable.py: 1 warning
  C:\Users\piete\Documents\GitHub\scikit-build\.nox\tests-3-9\lib\site-packages\setuptools\command\install.py:34: SetuptoolsDeprecationWarning: setup.py install is deprecated. Use build and pip and other standards-based tools.
    warnings.warn(

tests/test_command_line.py::test_hide_listing[True-bdist_wheel]
tests/test_command_line.py::test_hide_listing[False-bdist_wheel]
tests/test_filter_manifest.py::test_bdist_wheel_command
tests/test_hello_cpp.py::test_hello_wheel
tests/test_hello_cython.py::test_hello_cython_wheel
tests/test_include_exclude_data.py::test_include_exclude_data
tests/test_include_exclude_data.py::test_include_exclude_data_with_base
tests/test_issue335_support_cmake_source_dir.py::test_bdist_wheel_command
tests/test_skbuild_variable.py::test_skbuild_variable_wheel
  C:\Users\piete\Documents\GitHub\scikit-build\.nox\tests-3-9\lib\site-packages\wheel\bdist_wheel.py:80: RuntimeWarning: Config variable 'Py_DEBUG' is unset, Python ABI tag may be incorrect
    if get_flag('Py_DEBUG',

tests/test_hello_cpp.py::test_hello_develop
tests/test_issue274_support_default_package_dir.py::test_install_command
tests/test_issue274_support_default_package_dir.py::test_test_command
tests/test_issue274_support_one_package_without_package_dir.py::test_install_command
tests/test_issue274_support_one_package_without_package_dir.py::test_test_command
tests/test_issue334_configure_cmakelists_non_cp1252_encoding.py::test_install_command
tests/test_outside_project_root.py::test_outside_project_root_fails[None]
  C:\Users\piete\Documents\GitHub\scikit-build\.nox\tests-3-9\lib\site-packages\setuptools\command\easy_install.py:156: EasyInstallDeprecationWarning: easy_install command is deprecated. Use build and pip and other standards-based tools.
    warnings.warn(

tests/test_setup.py::test_setup_requires_keyword_include_cmake
  C:\Users\piete\Documents\GitHub\scikit-build\.nox\tests-3-9\lib\site-packages\setuptools\installer.py:27: SetuptoolsDeprecationWarning: setuptools.installer is deprecated. Requirements should be satisfied by a PEP 517 installer.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html

----------- coverage: platform win32, python 3.9.9-final-0 -----------
Coverage XML written to file tests/coverage.xml

============================================================== short test summary info ==============================================================
SKIPPED [1] tests\test_issue401_sdist_with_symlinks.py:12: Symlinks not supported on Windows
SKIPPED [1] tests\test_platform.py:63: no fortran compiler is available by default
SKIPPED [24] tests\test_setup.py:561: unsupported configuration: python package fully generated by CMake does *NOT* work. At least __init__.py should be in the project source tree
SKIPPED [1] tests\test_skbuild.py:130: Unix Makefiles generator is available only on Windows
SKIPPED [1] tests\test_skbuild.py:191: env. variable SKBUILD_TEST_FIND_VS2008_INSTALLATION_EXPECTED is not set
SKIPPED [1] tests\test_skbuild.py:191: env. variable SKBUILD_TEST_FIND_VS2010_INSTALLATION_EXPECTED is not set
SKIPPED [1] tests\test_skbuild.py:191: env. variable SKBUILD_TEST_FIND_VS2012_INSTALLATION_EXPECTED is not set
SKIPPED [1] tests\test_skbuild.py:191: env. variable SKBUILD_TEST_FIND_VS2013_INSTALLATION_EXPECTED is not set
SKIPPED [1] tests\test_skbuild.py:191: env. variable SKBUILD_TEST_FIND_VS2015_INSTALLATION_EXPECTED is not set
SKIPPED [1] tests\test_skbuild.py:191: env. variable SKBUILD_TEST_FIND_VS2017_INSTALLATION_EXPECTED is not set
SKIPPED [1] tests\test_skbuild.py:191: env. variable SKBUILD_TEST_FIND_VS2019_INSTALLATION_EXPECTED is not set
SKIPPED [1] tests\test_skbuild.py:207: Visual Studio 15 2017 is not found
XPASS tests/test_setup.py::test_setup_requires_keyword_include_cmake Timing issue with Ninja & MSVC 2019- needs investigation
======================================== 201 passed, 35 skipped, 1 xpassed, 37 warnings in 480.45s (0:08:00) ========================================
nox > Session tests-3.9 was successful.
nox > Running session tests-3.10
nox > Session tests-3.10 skipped: Python interpreter 3.10 not found.
nox > Ran multiple sessions:
nox > * lint: success
nox > * tests-2.7: skipped
nox > * tests-3.5: skipped
nox > * tests-3.6: skipped
nox > * tests-3.7: skipped
nox > * tests-3.8: skipped
nox > * tests-3.9: success
nox > * tests-3.10: skipped
```