### PR TITLE
Detect python library on macos + pypy

### DIFF
--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -455,7 +455,13 @@ class CMaker(object):
                 candidate_implementations = ['pypy-c', 'pypy3-c']
 
             candidate_extensions = ['.lib', '.so', '.a']
-            if sysconfig.get_config_var('WITH_DYLD'):
+            # On pypy + MacOS, the variable WITH_DYLD is not set. It would
+            # actually be possible to determine the python library there using
+            # LDLIBRARY + LIBDIR. As a simple fix, we check if the LDLIBRARY
+            # ends with .dylib and add it to the candidate matrix in this case.
+            with_ld = sysconfig.get_config_var('WITH_DYLD')
+            ld_lib = sysconfig.get_config_var('LDLIBRARY')
+            if with_ld or (ld_lib and ld_lib.endswith('.dylib')):
                 candidate_extensions.insert(0, '.dylib')
 
             candidate_versions = [python_version]

--- a/tests/test_cmaker.py
+++ b/tests/test_cmaker.py
@@ -8,7 +8,6 @@ Tests for CMaker functionality.
 """
 
 import os
-import sys
 import pytest
 import re
 import textwrap
@@ -19,8 +18,6 @@ from skbuild.exceptions import SKBuildError
 from skbuild.utils import push_dir, to_unix_path
 
 from . import _tmpdir, get_cmakecache_variables
-
-PYPY = hasattr(sys, "implementation") and sys.implementation.name == "pypy"
 
 
 def test_get_python_version():
@@ -33,8 +30,6 @@ def test_get_python_include_dir():
     assert os.path.exists(python_include_dir)
 
 
-@pytest.mark.xfail(PYPY and sys.platform.startswith('darwin'),
-                   reason="Broken on PyPy on macOS")
 def test_get_python_library():
     python_library = CMaker.get_python_library(CMaker.get_python_version())
     assert python_library


### PR DESCRIPTION
This improves on #624 reenabling the test for the python library which is found correctly now. I did not know how to fix the inplace build test, though.