### PR TITLE
fix: pull ninja path if module available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,12 @@ jobs:
       with:
         python-version: 3.5
 
+    - name: Hack for Ninja finding GCC on windows-2016
+      uses: ilammy/msvc-dev-cmd@v1
+      if: matrix.runs-on == 'windows-2016'
+      with:
+        toolset: "14.0"
+
     - name: Setup Python 3.6
       uses: actions/setup-python@v2
       if: runner.os == 'Linux'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+build>=0.5
 codecov>=2.0.5
 coverage>=4.2
 cython>=0.25.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ tag_prefix = ''
 [tool:pytest]
 testpaths = tests
 addopts = -v --cov --cov-report xml -ra --strict-markers --showlocals --color=yes
+norecursedirs = _skbuild
 markers =
     fortran: fortran testing
 

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -210,14 +210,6 @@ class CMaker(object):
         if cli_generator_name is not None:
             generator_name = cli_generator_name
 
-        ninja_executable_path = None
-        if (generator_name is None or generator_name == "Ninja"):
-            try:
-                import ninja
-                ninja_executable_path = os.path.join(ninja.BIN_DIR, "ninja")
-            except ImportError:
-                pass
-
         # if arch is provided on command line, use it
         clargs, cli_arch = pop_arg('-A', clargs)
 
@@ -225,6 +217,14 @@ class CMaker(object):
             generator_name, skip_generator_test=skip_generator_test,
             cmake_executable=self.cmake_executable, cmake_args=clargs,
             languages=languages, cleanup=cleanup, architecture=cli_arch)
+
+        ninja_executable_path = None
+        if generator.name == "Ninja":
+            try:
+                import ninja
+                ninja_executable_path = os.path.join(ninja.BIN_DIR, "ninja")
+            except ImportError:
+                pass
 
         if not os.path.exists(CMAKE_BUILD_DIR()):
             os.makedirs(CMAKE_BUILD_DIR())

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -133,13 +133,13 @@ class CMaker(object):
         self.cmake_version = get_cmake_version(self.cmake_executable)
         self.platform = get_platform()
 
-    def get_cached(self, item):
-        """Return the cached value if possible, otherwise return None"""
-        item = '{}:'.format(item)
+    def get_cached(self, variable_name):
+        """If set, returns the variable cached value from the :func:`skbuild.constants.CMAKE_BUILD_DIR()`, otherwise returns None"""
+        variable_name = '{}:'.format(variable_name)
         try:
             with open(os.path.join(CMAKE_BUILD_DIR(), 'CMakeCache.txt')) as fp:
                 for line in fp:
-                    if line.startswith(item):
+                    if line.startswith(variable_name):
                         return line.split("=", 1)[-1].strip()
         except (OSError, IOError):
             pass
@@ -210,11 +210,11 @@ class CMaker(object):
         if cli_generator_name is not None:
             generator_name = cli_generator_name
 
-        ninja_path = None
+        ninja_executable_path = None
         if (generator_name is None or generator_name == "Ninja"):
             try:
                 import ninja
-                ninja_path = os.path.join(ninja.BIN_DIR, "ninja")
+                ninja_executable_path = os.path.join(ninja.BIN_DIR, "ninja")
             except ImportError:
                 pass
 
@@ -263,8 +263,8 @@ class CMaker(object):
             cmd.extend(['-T', generator.toolset])
         if generator.architecture:
             cmd.extend(['-A', generator.architecture])
-        if ninja_path is not None:
-            cmd.append('-DCMAKE_MAKE_PROGRAM:FILEPATH=' + ninja_path)
+        if ninja_executable_path is not None:
+            cmd.append('-DCMAKE_MAKE_PROGRAM:FILEPATH=' + ninja_executable_path)
 
         cmd.extend(clargs)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,29 @@
+import subprocess
+import sys
+import os
+
 import pytest
 
+DIR = os.path.dirname(os.path.abspath(__file__))
+BASE = os.path.dirname(DIR)
+
+
 pytest.register_assert_rewrite('tests.pytest_helpers')
+
+
+@pytest.fixture(scope="session")
+def pep518_wheelhouse(tmpdir_factory):
+    wheelhouse = tmpdir_factory.mktemp("wheelhouse")
+    dist = tmpdir_factory.mktemp("dist")
+    subprocess.check_call([sys.executable, "-m", "build", "--wheel", "--outdir", str(dist)], cwd=BASE)
+    (wheel_path,) = dist.visit("*.whl")
+    subprocess.check_call([sys.executable, "-m", "pip", "download", "-q", "-d", str(wheelhouse), str(wheel_path)])
+    subprocess.check_call([sys.executable, "-m", "pip", "download", "-q", "-d", str(wheelhouse), "build", "setuptools", "wheel", "ninja", "cmake"])
+    return str(wheelhouse)
+
+
+@pytest.fixture
+def pep518(pep518_wheelhouse, monkeypatch):
+    monkeypatch.setenv("PIP_FIND_LINKS", pep518_wheelhouse)
+    monkeypatch.setenv("PIP_NO_INDEX", "true")
+    return pep518_wheelhouse

--- a/tests/samples/hello-pep518/CMakeLists.txt
+++ b/tests/samples/hello-pep518/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.14...3.18)
+
+project(hello-pybind11 VERSION "0.1")
+
+# Define CMAKE_INSTALL_xxx: LIBDIR, INCLUDEDIR
+include(GNUInstallDirs)
+
+# Fetch pybind11
+include(FetchContent)
+
+FetchContent_Declare(
+  pybind11
+  URL https://github.com/pybind/pybind11/archive/refs/tags/v2.6.2.tar.gz
+  URL_HASH SHA256=8ff2fff22df038f5cd02cea8af56622bc67f5b64534f1b83b9f133b8366acff2
+)
+FetchContent_MakeAvailable(pybind11)
+
+set(python_module_name _hello)
+pybind11_add_module(${python_module_name} MODULE
+  src/hello/hello_py.cpp
+  )
+
+install(TARGETS ${python_module_name} DESTINATION .)
+
+# Quiet a warning, since this project is only valid with SKBUILD
+set(ignoreMe "${SKBUILD}")

--- a/tests/samples/hello-pep518/MANIFEST
+++ b/tests/samples/hello-pep518/MANIFEST
@@ -1,0 +1,8 @@
+CMakeLists.txt
+README.md
+pyproject.toml
+setup.py
+src/hello/__init__.py
+src/hello/hello_py.cpp
+tests/test_hello_pybind11.py
+tox.ini

--- a/tests/samples/hello-pep518/README.md
+++ b/tests/samples/hello-pep518/README.md
@@ -1,0 +1,19 @@
+# PyBind11 + Scikit Build example
+
+
+## Building
+
+To build, you must have pip 10 or greater, *or* you need to manually install
+`scikit-build` and `cmake`. Once you create a wheel, that wheel can be used in
+earlier versions of pip.
+
+Example build and install sequence:
+
+```bash
+pip install .
+python -c "import hello; hello.hello()"
+```
+
+This should print "Hello, World!".
+
+```

--- a/tests/samples/hello-pep518/pyproject.toml
+++ b/tests/samples/hello-pep518/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+    "scikit-build",
+    "cmake",
+    "ninja",
+]
+build-backend = "setuptools.build_meta"

--- a/tests/samples/hello-pep518/setup.py
+++ b/tests/samples/hello-pep518/setup.py
@@ -1,0 +1,25 @@
+from __future__ import print_function
+
+import sys
+
+try:
+    import skbuild
+    from skbuild import setup
+except ImportError:
+    print('Please update pip, you need pip 10 or greater,\n'
+          ' or you need to install the PEP 518 requirements in pyproject.toml yourself', file=sys.stderr)
+    raise
+
+print("Scikit-build version:", skbuild.__version__)
+
+
+setup(
+    name="hello-pybind11",
+    version="1.2.3",
+    description="a minimal example package (with pybind11)",
+    author='Pablo Hernandez-Cerdan',
+    license="MIT",
+    packages=['hello'],
+    package_dir={'': 'src'},
+    cmake_install_dir='src/hello'
+)

--- a/tests/samples/hello-pep518/src/hello/__init__.py
+++ b/tests/samples/hello-pep518/src/hello/__init__.py
@@ -1,0 +1,4 @@
+from ._hello import hello, return_two
+
+
+__all__ = ("hello", "return_two")

--- a/tests/samples/hello-pep518/src/hello/hello_py.cpp
+++ b/tests/samples/hello-pep518/src/hello/hello_py.cpp
@@ -1,0 +1,18 @@
+#include <iostream>
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+void hello() {
+    std::cout << "Hello, World!" << std::endl;
+}
+
+int return_two() {
+    return 2;
+}
+
+PYBIND11_MODULE(_hello, m) {
+    m.doc() = "_hello";
+    m.def("hello", &hello, "Prints \"Hello, World!\"");
+    m.def("return_two", &return_two, "Returns 2");
+}

--- a/tests/test_pep518.py
+++ b/tests/test_pep518.py
@@ -1,0 +1,16 @@
+import subprocess
+import sys
+import os
+
+DIR = os.path.dirname(os.path.abspath(__file__))
+HELLO_PEP518 = os.path.join(DIR, "samples/hello-pep518")
+BASE = os.path.dirname(DIR)
+
+
+def test_pep518(pep518):
+    subprocess.check_call([sys.executable, "-m", "build", "--wheel"], cwd=HELLO_PEP518)
+
+
+def test_dual_pep518(pep518):
+    subprocess.check_call([sys.executable, "-m", "build", "--wheel"], cwd=HELLO_PEP518)
+    subprocess.check_call([sys.executable, "-m", "build", "--wheel"], cwd=HELLO_PEP518)


### PR DESCRIPTION
Fixes #628.

~~Builds on / requires #634; must be able to force the version in order to get the tests to pull the local scikit_build wheel.~~

About 95% of the work was in adding the test, the fix was pretty easy. :)