### PR TITLE
fix: detect python library on Focal Fossa

### DIFF
--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -494,7 +494,7 @@ class CMaker(object):
                     if masd:
                         if masd.startswith(os.sep):
                             masd = masd[len(os.sep):]
-                        libdir = os.path.join(libdir, masd)
+                        candidate_libdirs.append(os.path.join(libdir, masd))
                 candidate_libdirs.append(libdir)
 
             candidates = (


### PR DESCRIPTION
This fixes an issue in cmaker.py which doesn't detect the libpython shared lib because sysconfig.get_config_var('LIBDIR') already contains the multiarch subdir.