### PR TITLE
ci: assorted fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     - master
     - main
 
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   FORCE_COLOR: "3"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         echo "SKBUILD_TEST_FIND_VS2022_INSTALLATION_EXPECTED=0" >> $GITHUB_ENV
 
     - name: Set environment for available GHA MSVCs
-      if: matrix.runs-on == 'windows-latest'
+      if: matrix.runs-on == 'windows-2022'
       run: |
         echo "SKBUILD_TEST_FIND_VS2019_INSTALLATION_EXPECTED=1" >> $GITHUB_ENV
         echo "SKBUILD_TEST_FIND_VS2022_INSTALLATION_EXPECTED=1" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,22 +131,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, macos-latest, windows-2016, windows-latest]
+        runs-on: [ubuntu-latest, macos-latest]
     name: Tests on 🐍 PyPy • ${{ matrix.runs-on }}
 
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-
-    - name: Set environment for available GHA MSVCs
-      run: |
-        echo "SKBUILD_TEST_FIND_VS2008_INSTALLATION_EXPECTED=0" >> $GITHUB_ENV
-        echo "SKBUILD_TEST_FIND_VS2010_INSTALLATION_EXPECTED=0" >> $GITHUB_ENV
-        echo "SKBUILD_TEST_FIND_VS2012_INSTALLATION_EXPECTED=0" >> $GITHUB_ENV
-        echo "SKBUILD_TEST_FIND_VS2015_INSTALLATION_EXPECTED=1" >> $GITHUB_ENV
-        echo "SKBUILD_TEST_FIND_VS2017_INSTALLATION_EXPECTED=1" >> $GITHUB_ENV
-        echo "SKBUILD_TEST_FIND_VS2019_INSTALLATION_EXPECTED=1" >> $GITHUB_ENV
 
     - name: Set min macOS version
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     - master
     - main
 
+env:
+  FORCE_COLOR: "3"
+
 jobs:
   lint:
     name: Lint
@@ -72,23 +75,23 @@ jobs:
 
     - name: Test on 🐍 2.7
       if: runner.os != 'Windows'
-      run: nox --forcecolor -s tests-2.7
+      run: nox --error-on-missing-interpreters -s tests-2.7
     - name: Test on 🐍 3.5
       if: matrix.runs-on != 'windows-2022'
-      run: nox --forcecolor -s tests-3.5
+      run: nox --error-on-missing-interpreters -s tests-3.5
     - name: Test on 🐍 3.6
       if: runner.os == 'Linux'
-      run: nox --forcecolor -s tests-3.6
+      run: nox --error-on-missing-interpreters -s tests-3.6
     - name: Test on 🐍 3.7
       if: runner.os == 'Linux' || matrix.runs-on == 'windows-2022'
-      run: nox --forcecolor -s tests-3.7
+      run: nox --error-on-missing-interpreters -s tests-3.7
     - name: Test on 🐍 3.8
       if: runner.os == 'Linux'
-      run: nox --forcecolor -s tests-3.8
+      run: nox --error-on-missing-interpreters -s tests-3.8
     - name: Test on 🐍 3.9
-      run: nox --forcecolor -s tests-3.9
+      run: nox --error-on-missing-interpreters -s tests-3.9
     - name: Test on 🐍 3.10
-      run: nox --forcecolor -s tests-3.10
+      run: nox --error-on-missing-interpreters -s tests-3.10
 
   # Split out due to a bug in our test suite requiring a clean run for Windows Ninja
   tests-win-extra:
@@ -115,7 +118,7 @@ jobs:
       uses: excitedleigh/setup-nox@v2.0.0
 
     - name: Test on 🐍 3.5
-      run: nox --forcecolor -s tests-3.5
+      run: nox --error-on-missing-interpreters -s tests-3.5
 
 
   tests-pypy:
@@ -150,10 +153,10 @@ jobs:
 
     - uses: actions/setup-python@v2
       with:
-        python_version: pypy3.7
+        python-version: pypy-3.7
 
     - name: Test on 🐍 PyPy 3.7
-      run: nox --forcecolor -s tests-pypy3.7
+      run: nox --error-on-missing-interpreters -s tests-pypy3.7
 
 
   dist:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,26 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Include PDF and ePub
+formats: all
+
+# Set the version of Python
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+  - method: pip
+    path: .
+    extra_requirements:
+    - docs

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,10 +1,6 @@
-include AUTHORS.rst
-include CONTRIBUTING.rst
-include HISTORY.rst
+include *.rst
 include LICENSE
-include README.rst
-include requirements.txt
-include requirements-dev.txt
+include requirements*.txt
 include skbuild/resources/cmake/*.cmake
 
 recursive-include tests *

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[wheel]
+[bdist_wheel]
 universal = 1
 
 [versioneer]

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ with open('requirements.txt', 'r') as fp:
 with open('requirements-dev.txt', 'r') as fp:
     dev_requirements = list(filter(bool, (line.strip() for line in fp)))
 
+with open('requirements-docs.txt', 'r') as fp:
+    doc_requirements = list(filter(bool, (line.strip() for line in fp)))
+
 setup(
     name='scikit-build',
     version=versioneer.get_version(),
@@ -68,5 +71,5 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
     ],
-    extras_require={"test": dev_requirements},
+    extras_require={"test": dev_requirements, "docs": doc_requirements},
 )


### PR DESCRIPTION
Pulling out the fixes from #634 and #631 that were unrelated and are easy to merge.

Two non-CI changes: There's now a `[docs]` extra (so the readthedocs is better), and an old warning about `[wheel]` being replaced by `[bdist_wheel]` has been fixed.

- ci: fix old if
- ci: fix PyPy not found on win/macOS
- ci: cancel in-progress on repeated pushes
- tests: Windows Nox doesn't find PyPy
- docs: add docs config file
- fix: warning produced about bdist_wheel
