### PR TITLE
fix library dedection for pypy 3.9

### DIFF
--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -482,9 +482,11 @@ class CMaker(object):
 
             candidate_lib_prefixes = ["", "lib"]
 
+            candidate_suffixes = [""]
             candidate_implementations = ["python"]
             if hasattr(sys, "pypy_version_info"):
                 candidate_implementations = ["pypy-c", "pypy3-c", "pypy"]
+                candidate_suffixes.append("-c")
 
             candidate_extensions = [".lib", ".so", ".a"]
             # On pypy + MacOS, the variable WITH_DYLD is not set. It would
@@ -495,9 +497,6 @@ class CMaker(object):
             ld_lib = sysconfig.get_config_var("LDLIBRARY")
             if with_ld or (ld_lib and ld_lib.endswith(".dylib")):
                 candidate_extensions.insert(0, ".dylib")
-            if hasattr(sys, "pypy_version_info"):
-                for ext in list(candidate_extensions):
-                    candidate_extensions.append("-c" + ext)
 
             candidate_versions = [python_version]
             if python_version:
@@ -533,14 +532,15 @@ class CMaker(object):
                 candidate_libdirs.append(libdir)
 
             candidates = (
-                os.path.join(libdir, "".join((pre, impl, ver, abi, ext)))
-                for (libdir, pre, impl, ext, ver, abi) in itertools.product(
+                os.path.join(libdir, "".join((pre, impl, ver, abi, suf, ext)))
+                for (libdir, pre, impl, ext, ver, abi, suf) in itertools.product(
                     candidate_libdirs,
                     candidate_lib_prefixes,
                     candidate_implementations,
                     candidate_extensions,
                     candidate_versions,
                     candidate_abiflags,
+                    candidate_suffixes,
                 )
             )
 

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -474,6 +474,29 @@ class CMaker(object):
             >>> print('python_library = {!r}'.format(python_library))
             python_library = '.../conda/envs/py37/include/python3.7m'
         """
+        # This seems to be the simplest way to detect the library path with
+        # modern python versions that avoids the complicated construct below.
+        # It avoids guessing the library name. Tested with cpython 3.8 and
+        # pypy 3.8 on Ubuntu.
+        libdir = sysconfig.get_config_var("LIBDIR")
+        ldlibrary = sysconfig.get_config_var("LDLIBRARY")
+        if libdir and ldlibrary and os.path.exists(libdir):
+            if sysconfig.get_config_var("MULTIARCH"):
+                masd = sysconfig.get_config_var("multiarchsubdir")
+                if masd:
+                    if masd.startswith(os.sep):
+                        masd = masd[len(os.sep):]
+                    libdir_masd = os.path.join(libdir, masd)
+                    if os.path.exists(libdir_masd):
+                        libdir = libdir_masd
+            libpath = os.path.join(libdir, ldlibrary)
+            if os.path.exists(libpath):
+                return libpath
+
+        return CMaker._guess_python_library(python_version)
+
+    @staticmethod
+    def _guess_python_library(python_version):
         # determine direct path to libpython
         python_library = sysconfig.get_config_var("LIBRARY")
 

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -484,7 +484,7 @@ class CMaker(object):
 
             candidate_implementations = ["python"]
             if hasattr(sys, "pypy_version_info"):
-                candidate_implementations = ["pypy-c", "pypy3-c"]
+                candidate_implementations = ['pypy-c', 'pypy3-c', 'pypy']
 
             candidate_extensions = [".lib", ".so", ".a"]
             # On pypy + MacOS, the variable WITH_DYLD is not set. It would
@@ -495,6 +495,9 @@ class CMaker(object):
             ld_lib = sysconfig.get_config_var("LDLIBRARY")
             if with_ld or (ld_lib and ld_lib.endswith(".dylib")):
                 candidate_extensions.insert(0, ".dylib")
+            if hasattr(sys, "pypy_version_info"):
+                for ext in list(candidate_extensions):
+                    candidate_extensions.append('-c' + ext)
 
             candidate_versions = [python_version]
             if python_version:

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -484,7 +484,7 @@ class CMaker(object):
 
             candidate_implementations = ["python"]
             if hasattr(sys, "pypy_version_info"):
-                candidate_implementations = ['pypy-c', 'pypy3-c', 'pypy']
+                candidate_implementations = ["pypy-c", "pypy3-c", "pypy"]
 
             candidate_extensions = [".lib", ".so", ".a"]
             # On pypy + MacOS, the variable WITH_DYLD is not set. It would
@@ -497,7 +497,7 @@ class CMaker(object):
                 candidate_extensions.insert(0, ".dylib")
             if hasattr(sys, "pypy_version_info"):
                 for ext in list(candidate_extensions):
-                    candidate_extensions.append('-c' + ext)
+                    candidate_extensions.append("-c" + ext)
 
             candidate_versions = [python_version]
             if python_version:

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -485,7 +485,7 @@ class CMaker(object):
                 masd = sysconfig.get_config_var("multiarchsubdir")
                 if masd:
                     if masd.startswith(os.sep):
-                        masd = masd[len(os.sep):]
+                        masd = masd[len(os.sep) :]
                     libdir_masd = os.path.join(libdir, masd)
                     if os.path.exists(libdir_masd):
                         libdir = libdir_masd


### PR DESCRIPTION
The library name in pypy 3.9 has changed. The '-c' moved to the end. This PR patches the candidate matrix to "make it work". It doesn't really fit nicely in the current matrix, though.