### PR TITLE
Ensure that each package has a separate list of data elements.

### DIFF
--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -510,7 +510,10 @@ def setup(*args, **kw):  # noqa: C901
 
     packages = kw.get("packages", [])
     package_dir = kw.get("package_dir", {})
-    package_data = copy.deepcopy(kw.get("package_data", {}))
+    package_data = {
+        k: v.copy()
+        for k, v in kw.get("package_data", {}).items()
+    }
 
     py_modules = kw.get("py_modules", [])
     new_py_modules = {py_module: False for py_module in py_modules}

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -5,6 +5,7 @@ from distutils and setuptools.
 from __future__ import print_function
 
 import argparse
+import copy
 import json
 import os
 import os.path
@@ -509,7 +510,7 @@ def setup(*args, **kw):  # noqa: C901
 
     packages = kw.get("packages", [])
     package_dir = kw.get("package_dir", {})
-    package_data = {k: v.copy() for k, v in kw.get("package_data", {}).items()}
+    package_data = {k: copy.copy(v) for k, v in kw.get("package_data", {}).items()}
 
     py_modules = kw.get("py_modules", [])
     new_py_modules = {py_module: False for py_module in py_modules}

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -5,7 +5,6 @@ from distutils and setuptools.
 from __future__ import print_function
 
 import argparse
-import copy
 import json
 import os
 import os.path

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -509,10 +509,7 @@ def setup(*args, **kw):  # noqa: C901
 
     packages = kw.get("packages", [])
     package_dir = kw.get("package_dir", {})
-    package_data = {
-        k: v.copy()
-        for k, v in kw.get("package_data", {}).items()
-    }
+    package_data = {k: v.copy() for k, v in kw.get("package_data", {}).items()}
 
     py_modules = kw.get("py_modules", [])
     new_py_modules = {py_module: False for py_module in py_modules}


### PR DESCRIPTION
Currently when scikit-build copies files from the source tree to the build tree (files that do not need to be compiled, e.g. pure Python files or Cython headers) it uses the `package_data` dict as a way to keep track of these files since data files are subject to the same requirements at this stage. `skbuild` assumes that modifying the `package_data` dict in place is safe [here](https://github.com/scikit-build/scikit-build/blob/master/skbuild%2Fsetuptools_wrap.py#L978) because it deep copies the `package_data` parameter passed to setup.py [here](https://github.com/scikit-build/scikit-build/blob/master/skbuild%2Fsetuptools_wrap.py#L513). However, deep copying is not sufficient in the scenario where the calling code constructs the input dict such that all values are actually references to the same dictionary, e.g.
```
files = ['foo', 'bar']
...
setup(..., package_data={package: files for package in packages},...)
```
or 
```
setup(..., package_data=dict.fromkeys(packages, ['foo', 'bar']), ...)
```
`setuptools.setup` appears to have no problem with these inputs, so `scikit-build` should support them as well. The safer approach here is to use a dict comprehension that explicitly copies each list. The lists will not be nested, so this approach is sufficient to guarantee that each list is unique and can be safely modified.