### PR TITLE
fix: do byte-compilation in install_lib

### DIFF
--- a/skbuild/command/install_lib.py
+++ b/skbuild/command/install_lib.py
@@ -16,3 +16,4 @@ class install_lib(set_build_base_mixin, new_style(_install_lib)):
             outfiles = super(install_lib, self).install()
         if outfiles is not None:
             distutils_log.info("copied %d files", len(outfiles))
+        return outfiles


### PR DESCRIPTION
`install_lib.run()` in [setuptools](../../../pypa/setuptools/blob/v60.9.3/setuptools/command/install_lib.py#L12) expects that the `outfiles` list is returned from `install_lib.install()`, otherwise byte-compilation is skipped.