### PR TITLE
FindPythonExtensions: Do not override cpp symbols when using gcc on Linux

### DIFF
--- a/skbuild/resources/cmake/FindPythonExtensions.cmake
+++ b/skbuild/resources/cmake/FindPythonExtensions.cmake
@@ -333,14 +333,25 @@ function(_set_python_extension_symbol_visibility _target)
         "/EXPORT:${_modinit_prefix}${_target}"
     )
   elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    # Option to not run version script. See https://github.com/scikit-build/scikit-build/issues/668
+    if(NOT DEFINED SKBUILD_GNU_SKIP_LOCAL_SYMBOL_EXPORT_OVERRIDE)
+       set(SKBUILD_GNU_SKIP_LOCAL_SYMBOL_EXPORT_OVERRIDE FALSE)
+    endif()
     set(_script_path
       ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${_target}-version-script.map
     )
-    file(WRITE ${_script_path}
-               "{global: ${_modinit_prefix}${_target}; local: *; };"
-    )
+    # Export all symbols. See https://github.com/scikit-build/scikit-build/issues/668
+    if(SKBUILD_GNU_SKIP_LOCAL_SYMBOL_EXPORT_OVERRIDE)
+      file(WRITE ${_script_path}
+                 "{global: ${_modinit_prefix}${_target};};"
+      )
+    else()
+      file(WRITE ${_script_path}
+                 "{global: ${_modinit_prefix}${_target}; local: *;};"
+      )
+    endif()
     set_property(TARGET ${_target} APPEND_STRING PROPERTY LINK_FLAGS
-        " -Wl,--version-script=\"${_script_path}\""
+      " -Wl,--version-script=\"${_script_path}\""
     )
   endif()
 endfunction()

--- a/tests/samples/issue-668-symbol-visibility/CMakeLists.txt
+++ b/tests/samples/issue-668-symbol-visibility/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.4...3.22)
+
+project(hello)
+
+find_package(PythonExtensions REQUIRED)
+
+add_library(_hello MODULE hello/_hello.cxx)
+python_extension_module(_hello)
+install(TARGETS _hello LIBRARY DESTINATION hello)

--- a/tests/samples/issue-668-symbol-visibility/hello/__init__.py
+++ b/tests/samples/issue-668-symbol-visibility/hello/__init__.py
@@ -1,0 +1,2 @@
+from ._hello import elevation  # noqa: F401
+from ._hello import hello  # noqa: F401

--- a/tests/samples/issue-668-symbol-visibility/hello/_hello.cxx
+++ b/tests/samples/issue-668-symbol-visibility/hello/_hello.cxx
@@ -1,0 +1,85 @@
+
+// Python includes
+#include <Python.h>
+
+// STD includes
+#include <stdio.h>
+
+// Macros used for defining symbol visibility
+#if (defined(__GNUC__))
+#define _EXPORT __attribute__((visibility("default")))
+#define _HIDDEN __attribute__((visibility("hidden")))
+#else
+#define _EXPORT
+#define _HIDDEN
+#endif
+
+#include <map>
+
+extern "C"
+_EXPORT auto& get_map()
+{
+  static std::map<int,void*> id_to_resource;
+  return id_to_resource;
+}
+
+//-----------------------------------------------------------------------------
+static PyObject *hello_example(PyObject *self, PyObject *args)
+{
+  get_map();
+  // Unpack a string from the arguments
+  const char *strArg;
+  if (!PyArg_ParseTuple(args, "s", &strArg))
+    return NULL;
+
+  // Print message and return None
+  PySys_WriteStdout("Hello, %s!\n", strArg);
+  Py_RETURN_NONE;
+}
+
+//-----------------------------------------------------------------------------
+static PyObject *elevation_example(PyObject *self, PyObject *args)
+{
+  get_map();
+  // Return an integer
+  return PyLong_FromLong(21463L);
+}
+
+//-----------------------------------------------------------------------------
+static PyMethodDef hello_methods[] = {
+  {
+    "hello",
+    hello_example,
+    METH_VARARGS,
+    "Prints back 'Hello <param>', for example example: hello.hello('you')"
+  },
+
+  {
+    "elevation",
+    elevation_example,
+    METH_VARARGS,
+    "Returns elevation of Nevado Sajama."
+  },
+  {NULL, NULL, 0, NULL}        /* Sentinel */
+};
+
+//-----------------------------------------------------------------------------
+#if PY_MAJOR_VERSION < 3
+PyMODINIT_FUNC init_hello(void)
+{
+  (void) Py_InitModule("_hello", hello_methods);
+}
+#else /* PY_MAJOR_VERSION >= 3 */
+static struct PyModuleDef hello_module_def = {
+  PyModuleDef_HEAD_INIT,
+  "_hello",
+  "Internal \"_hello\" module",
+  -1,
+  hello_methods
+};
+
+PyMODINIT_FUNC PyInit__hello(void)
+{
+  return PyModule_Create(&hello_module_def);
+}
+#endif /* PY_MAJOR_VERSION >= 3 */

--- a/tests/samples/issue-668-symbol-visibility/pyproject.toml
+++ b/tests/samples/issue-668-symbol-visibility/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "scikit-build>=0.13",
+    "cmake>=3.18",
+    "ninja",
+]
+build-backend = "setuptools.build_meta"

--- a/tests/samples/issue-668-symbol-visibility/setup.py
+++ b/tests/samples/issue-668-symbol-visibility/setup.py
@@ -1,0 +1,11 @@
+from skbuild import setup
+
+setup(
+    name="hello-cpp",
+    version="1.2.3",
+    description="a minimal example package (cpp version)",
+    author="The scikit-build team",
+    license="MIT",
+    packages=["hello"],
+    python_requires=">=3.7",
+)

--- a/tests/test_issue668_symbol_visibility.py
+++ b/tests/test_issue668_symbol_visibility.py
@@ -1,0 +1,68 @@
+import glob
+import platform
+import shutil
+import subprocess
+
+import pytest
+
+from skbuild.constants import CMAKE_BUILD_DIR
+
+from . import (
+    _tmpdir,
+    execute_setup_py,
+    initialize_git_repo_and_commit,
+    prepare_project,
+    push_dir,
+)
+
+
+@pytest.mark.skipif(
+    platform.system().lower() not in ["linux"], reason="Executable and Linkable Format (ELF) is specific to Linux"
+)
+@pytest.mark.parametrize("skip_override", ["ON", "OFF"])
+def test_symbol_visibility(skip_override):
+    with push_dir():
+
+        tmp_dir = _tmpdir("test_issue668_symbol_visibility")
+        project = "issue-668-symbol-visibility"
+        prepare_project(project, tmp_dir)
+        initialize_git_repo_and_commit(tmp_dir, verbose=True)
+
+        with execute_setup_py(
+            tmp_dir, ["build", f"-DSKBUILD_GNU_SKIP_LOCAL_SYMBOL_EXPORT_OVERRIDE:BOOL={skip_override}"]
+        ):
+            pass
+
+        print(f"Running test with SKBUILD_GNU_SKIP_LOCAL_SYMBOL_EXPORT_OVERRIDE:BOOL={skip_override}")
+
+        lib_dir = str(tmp_dir) + "/" + CMAKE_BUILD_DIR()
+        libs = glob.glob(lib_dir + "/*.so")
+        assert libs
+        print(f"Examining the library file: {libs[0]}")
+
+        readelf = shutil.which("readelf")
+        assert readelf
+
+        cppfilt = shutil.which("c++filt")
+        assert cppfilt
+
+        result = subprocess.Popen([readelf, "-s", "--wide", libs[0]], stdout=subprocess.PIPE)
+        output = str(subprocess.check_output((cppfilt), stdin=result.stdout), "UTF-8")
+        result.wait()
+        result.stdout.close()
+
+        for line in output.splitlines():
+            # Looking for entries associated with get_map
+            # ex.     62: 0000000000001260   164 FUNC    GLOBAL DEFAULT   14 get_map\n
+            # NOTE: We want to ignore get_map::id_to_resourse entries
+            if "get_map" in line and "get_map::" not in line:
+                print(line)
+                if skip_override == "ON":
+                    assert "GLOBAL" in line
+                else:
+                    assert "LOCAL" in line
+            # Looking for the PyInit_ entries
+            # These should always be GLOBAL
+            if "PyInit_" in line:
+                print(line)
+                assert "GLOBAL" in line


### PR DESCRIPTION
This partially reverts f6ea5d0af (FindPythonExtensions: Set symbol visibility
to export only module init function) to ensure all local symbols are externally
visible.

This change is required to ensure library can resolve against
symbols other than the CPython module entrypoint (`PyInit_<moduleName>`
or `init<moduleName>`).

Since selectively listing additional symbols is not scalable (see [1]), this
commit ensures all symbols are visible.

[1] https://gcc.gnu.org/wiki/Visibility

Questions

* Is the issue fixed by this commit also a problem on windows ?

Additional required changes:
* [x] Add sample project and associated test
* [x] Evaluate unanticipated side effects and consider integration of an option for opt-in instead of changing the default behavior.
