### PR TITLE
Update setuptools_wrap.py

### DIFF
--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -13,6 +13,7 @@ import platform
 import stat
 import sys
 import warnings
+import functools
 from contextlib import contextmanager
 
 # pylint: disable-next=wrong-import-order
@@ -957,9 +958,7 @@ def _consolidate_package_modules(cmake_source_dir, packages, package_dir, py_mod
 
         # Copy missing module file
         if os.path.exists(src_module_file):
-            dest_module_file = os.path.join(
-                [CMAKE_INSTALL_DIR()] + package.split(".") + [os.path.basename(src_module_file)]
-            )
+            dest_module_file = functools.reduce(os.path.join, [CMAKE_INSTALL_DIR()] + package.split(".") + [os.path.basename(src_module_file)])
             _copy_file(src_module_file, dest_module_file, hide_listing)
 
         # Since the mapping in package_data expects the package to be associated

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -957,7 +957,7 @@ def _consolidate_package_modules(cmake_source_dir, packages, package_dir, py_mod
 
         # Copy missing module file
         if os.path.exists(src_module_file):
-            dest_module_file = os.path.join(CMAKE_INSTALL_DIR(), *package.split("."), os.path.basename(src_module_file))
+            dest_module_file = os.path.join( [CMAKE_INSTALL_DIR()] + package.split(".") + [os.path.basename(src_module_file)])
             _copy_file(src_module_file, dest_module_file, hide_listing)
 
         # Since the mapping in package_data expects the package to be associated

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -957,7 +957,7 @@ def _consolidate_package_modules(cmake_source_dir, packages, package_dir, py_mod
 
         # Copy missing module file
         if os.path.exists(src_module_file):
-            dest_module_file = os.path.join(CMAKE_INSTALL_DIR(), *package.split('.'), os.path.basename(src_module_file))
+            dest_module_file = os.path.join(CMAKE_INSTALL_DIR(), *package.split("."), os.path.basename(src_module_file))
             _copy_file(src_module_file, dest_module_file, hide_listing)
 
         # Since the mapping in package_data expects the package to be associated

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 
 import argparse
 import copy
+import functools
 import json
 import os
 import os.path
@@ -13,7 +14,6 @@ import platform
 import stat
 import sys
 import warnings
-import functools
 from contextlib import contextmanager
 
 # pylint: disable-next=wrong-import-order
@@ -958,7 +958,9 @@ def _consolidate_package_modules(cmake_source_dir, packages, package_dir, py_mod
 
         # Copy missing module file
         if os.path.exists(src_module_file):
-            dest_module_file = functools.reduce(os.path.join, [CMAKE_INSTALL_DIR()] + package.split(".") + [os.path.basename(src_module_file)])
+            dest_module_file = functools.reduce(
+                os.path.join, [CMAKE_INSTALL_DIR()] + package.split(".") + [os.path.basename(src_module_file)]
+            )
             _copy_file(src_module_file, dest_module_file, hide_listing)
 
         # Since the mapping in package_data expects the package to be associated

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -957,7 +957,7 @@ def _consolidate_package_modules(cmake_source_dir, packages, package_dir, py_mod
 
         # Copy missing module file
         if os.path.exists(src_module_file):
-            dest_module_file = os.path.join(CMAKE_INSTALL_DIR(), src_module_file)
+            dest_module_file = os.path.join(CMAKE_INSTALL_DIR(), *package.split('.'), os.path.basename(src_module_file))
             _copy_file(src_module_file, dest_module_file, hide_listing)
 
         # Since the mapping in package_data expects the package to be associated

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -957,7 +957,9 @@ def _consolidate_package_modules(cmake_source_dir, packages, package_dir, py_mod
 
         # Copy missing module file
         if os.path.exists(src_module_file):
-            dest_module_file = os.path.join( [CMAKE_INSTALL_DIR()] + package.split(".") + [os.path.basename(src_module_file)])
+            dest_module_file = os.path.join(
+                [CMAKE_INSTALL_DIR()] + package.split(".") + [os.path.basename(src_module_file)]
+            )
             _copy_file(src_module_file, dest_module_file, hide_listing)
 
         # Since the mapping in package_data expects the package to be associated


### PR DESCRIPTION
Candidate fix for https://github.com/scikit-build/scikit-build/issues/358 - The issue is that 'package_dir' in setup.py may result in 'package' being substantially different from the directory prefix of 'src_module_file'. To fix this, instead of using all of 'src_module_file', instead just retain the base .py file, but also prefix with the expected package path.