### PR TITLE
chore: enable basic mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,10 +81,10 @@ repos:
 
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: "v0.971"
+  rev: "v0.981"
   hooks:
   - id: mypy
     files: ^skbuild
     args: []
-    additional_dependencies: ["types-setuptools", "packaging"]
+    additional_dependencies: ["types-setuptools", "packaging", "cmake", "ninja"]
     stages: [manual]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,5 +86,5 @@ repos:
   - id: mypy
     files: ^skbuild
     args: []
-    additional_dependencies: ["types-setuptools"]
+    additional_dependencies: ["types-setuptools", "packaging"]
     stages: [manual]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,7 +79,6 @@ repos:
     stages: [manual]
     additional_dependencies: ["setuptools_scm[toml]"]
 
-
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: "v0.981"
   hooks:
@@ -87,4 +86,3 @@ repos:
     files: ^skbuild
     args: []
     additional_dependencies: ["types-setuptools", "packaging", "cmake", "ninja"]
-    stages: [manual]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,9 +41,8 @@ module = [
   "wheel.*",
   "setuptools.logging",
   "setuptools.command.*",
-  "ninja",
-  "cmake",
   "numpy",
+  "distro",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,20 @@ warn_unused_configs = true
 check_untyped_defs = true
 show_error_codes = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
+strict_equality = true
+strict_concatenate = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+no_implicit_reexport = true
+disallow_any_generics = true
+disallow_incomplete_defs = true
+
+# disallow_subclassing_any = true 4
+# warn_return_any = true 5
+# disallow_untyped_calls = true 39
+# disallow_untyped_defs = true 61
 
 [[tool.mypy.overrides]]
 module = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ warn_unused_configs = true
 check_untyped_defs = true
 show_error_codes = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
-warn_unreachable = true
 
 [[tool.mypy.overrides]]
 module = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ profile = "black"
 known_third_party = ["distutils"]
 force_to_top = ["setuptools"]
 
+
 [tool.mypy]
 files = ["skbuild"]
 python_version = "3.6"
@@ -35,6 +36,16 @@ show_error_codes = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 warn_unreachable = true
 
+[[tool.mypy.overrides]]
+module = [
+  "wheel.*",
+  "setuptools.logging",
+  "setuptools.command.*",
+  "ninja",
+  "cmake",
+  "numpy",
+]
+ignore_missing_imports = true
 
 [tool.pylint]
 master.py-version = "3.6"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 distro
 packaging
 setuptools>=42.0.0
+typing-extensions>=3.7; python_version < "3.8"
 wheel>=0.32.0

--- a/skbuild/_version.pyi
+++ b/skbuild/_version.pyi
@@ -1,0 +1,4 @@
+__version__: str
+version: str
+__version_tuple__: tuple[int, int, int, str, str] | tuple[int, int, int]
+version_tuple: tuple[int, int, int, str, str] | tuple[int, int, int]

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -15,7 +15,7 @@ import subprocess
 import sys
 import sysconfig
 from shlex import quote
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, overload
 
 import distutils.sysconfig as du_sysconfig
 
@@ -31,9 +31,17 @@ from .platform_specifics import get_platform
 RE_FILE_INSTALL = re.compile(r"""[ \t]*file\(INSTALL DESTINATION "([^"]+)".*"([^"]+)"\).*""")
 
 
-def pop_arg(
-    arg: str, args: Union[Tuple[()], List[str]], default: Optional[str] = None
-) -> Union[Tuple[List[Any], str], Tuple[List[str], None], Tuple[List[str], str], Tuple[List[Any], None]]:
+@overload
+def pop_arg(arg: str, args: Iterable[str], default: None = None) -> Tuple[List[str], Optional[str]]:
+    ...
+
+
+@overload
+def pop_arg(arg: str, args: Iterable[str], default: str) -> Tuple[List[str], str]:
+    ...
+
+
+def pop_arg(arg: str, args: Iterable[str], default: Optional[str] = None) -> Tuple[List[str], Optional[str]]:
     """Pops an argument ``arg`` from an argument list ``args`` and returns the
     new list and the value of the argument if present and a default otherwise.
     """

--- a/skbuild/command/__init__.py
+++ b/skbuild/command/__init__.py
@@ -2,13 +2,30 @@
 distutils and setuptools commands.
 """
 
+from typing import List, Optional
+
 from .. import cmaker
+from ..typing import Protocol
+from ..utils import Distribution
+
+
+class CommandMixinProtocol(Protocol):
+    """Protocol for commands that use CMake."""
+
+    build_base: str
+    distribution: Distribution
+    outfiles: List[str]
+    install_lib: Optional[str]
+    install_platlib: str
+
+    def finalize_options(self, *args, **kwargs) -> None:
+        ...
 
 
 class set_build_base_mixin:
     """Mixin allowing to override distutils and setuptools commands."""
 
-    def finalize_options(self, *args, **kwargs):
+    def finalize_options(self: CommandMixinProtocol, *args, **kwargs):
         """Override built-in function and set a new `build_base`."""
         try:
             if not self.build_base or self.build_base == "build":
@@ -16,4 +33,4 @@ class set_build_base_mixin:
         except AttributeError:
             pass
 
-        super().finalize_options(*args, **kwargs)
+        super().finalize_options(*args, **kwargs)  # type: ignore[misc]

--- a/skbuild/command/__init__.py
+++ b/skbuild/command/__init__.py
@@ -2,9 +2,9 @@
 distutils and setuptools commands.
 """
 
-from typing import List, Optional
+from typing import Any, List, Optional
 
-from .. import cmaker
+from ..constants import SETUPTOOLS_INSTALL_DIR
 from ..typing import Protocol
 from ..utils import Distribution
 
@@ -18,18 +18,18 @@ class CommandMixinProtocol(Protocol):
     install_lib: Optional[str]
     install_platlib: str
 
-    def finalize_options(self, *args, **kwargs) -> None:
+    def finalize_options(self, *args: Any, **kwargs: Any) -> None:
         ...
 
 
 class set_build_base_mixin:
     """Mixin allowing to override distutils and setuptools commands."""
 
-    def finalize_options(self: CommandMixinProtocol, *args, **kwargs):
+    def finalize_options(self: CommandMixinProtocol, *args: Any, **kwargs: Any) -> None:
         """Override built-in function and set a new `build_base`."""
         try:
             if not self.build_base or self.build_base == "build":
-                self.build_base = cmaker.SETUPTOOLS_INSTALL_DIR()
+                self.build_base = SETUPTOOLS_INSTALL_DIR()
         except AttributeError:
             pass
 

--- a/skbuild/command/build_ext.py
+++ b/skbuild/command/build_ext.py
@@ -7,7 +7,7 @@ from distutils.file_util import copy_file
 try:
     from setuptools.command.build_ext import build_ext as _build_ext
 except ImportError:
-    from distutils.command.build_ext import build_ext as _build_ext
+    from distutils.command.build_ext import build_ext as _build_ext  # type: ignore[misc]
 
 from ..constants import CMAKE_INSTALL_DIR
 from . import set_build_base_mixin
@@ -28,7 +28,7 @@ class build_ext(set_build_base_mixin, _build_ext):
             filename = self.get_ext_filename(fullname)
             modpath = fullname.split(".")
             package = ".".join(modpath[:-1])
-            package_dir = build_py.get_package_dir(package)
+            package_dir = build_py.get_package_dir(package)  # type: ignore[attr-defined]
             # skbuild: strip install dir for inplace build
             package_dir = package_dir[len(CMAKE_INSTALL_DIR()) + 1 :]
             dest_filename = os.path.join(package_dir, os.path.basename(filename))
@@ -37,6 +37,6 @@ class build_ext(set_build_base_mixin, _build_ext):
             # Always copy, even if source is older than destination, to ensure
             # that the right extensions for the current Python/platform are
             # used.
-            copy_file(src_filename, dest_filename, verbose=self.verbose, dry_run=self.dry_run)
+            copy_file(src_filename, dest_filename, verbose=self.verbose, dry_run=self.dry_run)  # type: ignore[attr-defined]
             if ext._needs_stub:
                 self.write_stub(package_dir or os.curdir, ext, True)

--- a/skbuild/command/build_py.py
+++ b/skbuild/command/build_py.py
@@ -2,6 +2,7 @@
 command."""
 
 import os
+from typing import Dict, List, Tuple
 
 from setuptools.command.build_py import build_py as _build_py
 
@@ -54,10 +55,10 @@ class build_py(set_build_base_mixin, _build_py):
         #   this package
         # checked - true if we have checked that the package directory
         #   is valid (exists, contains __init__.py, ... ?)
-        packages = {}
+        packages: Dict[str, Tuple[str, bool]] = {}
 
         # List of (package, module, filename) tuples to return
-        modules = []
+        modules: List[Tuple[str, str, str]] = []
 
         # We treat modules-in-packages almost the same as toplevel modules,
         # just the "package" for a toplevel is empty (either an empty
@@ -72,11 +73,11 @@ class build_py(set_build_base_mixin, _build_py):
                 (package_dir, checked) = packages[package]
             except KeyError:
                 package_dir = self.get_package_dir(package)
-                checked = 0
+                checked = False
 
             if not checked:
                 init_py = self.check_package(package, package_dir)
-                packages[package] = (package_dir, 1)
+                packages[package] = (package_dir, True)
                 if init_py:
                     modules.append((package, "__init__", init_py))
 

--- a/skbuild/command/egg_info.py
+++ b/skbuild/command/egg_info.py
@@ -16,13 +16,13 @@ class egg_info(set_build_base_mixin, _egg_info):
 
     def finalize_options(self, *args, **kwargs):
         if self.egg_base is None:
-            if self.distribution.package_dir is not None and len(self.distribution.package_dir) == 1:
+            if self.distribution.package_dir is not None and len(self.distribution.package_dir) == 1:  # type: ignore[attr-defined]
                 # Recover directory specified in setup() function
                 # using `package_dir={'':<egg_base>}`
                 # This is required to successfully update the python path when
                 # running the test command.
-                package_name = list(self.distribution.package_dir.keys())[0]
-                egg_base = to_unix_path(list(self.distribution.package_dir.values())[0])
+                package_name = list(self.distribution.package_dir.keys())[0]  # type: ignore[attr-defined]
+                egg_base = to_unix_path(list(self.distribution.package_dir.values())[0])  # type: ignore[attr-defined]
                 cmake_install_dir = to_unix_path(CMAKE_INSTALL_DIR())
                 if egg_base.startswith(cmake_install_dir):
                     egg_base = egg_base[len(cmake_install_dir) + 1 :]
@@ -33,9 +33,9 @@ class egg_info(set_build_base_mixin, _egg_info):
                 # pylint:disable=attribute-defined-outside-init
                 self.egg_base = egg_base
         else:
-            script_path = os.path.abspath(self.distribution.script_name)
+            script_path = os.path.abspath(self.distribution.script_name)  # type: ignore[attr-defined]
             script_dir = os.path.dirname(script_path)
             # pylint:disable=attribute-defined-outside-init
             self.egg_base = os.path.join(script_dir, self.egg_base)
 
-        super().finalize_options(*args, **kwargs)
+        super().finalize_options(*args, **kwargs)  # type: ignore[misc]

--- a/skbuild/command/install.py
+++ b/skbuild/command/install.py
@@ -3,21 +3,21 @@ command."""
 
 from setuptools.command.install import install as _install
 
-from . import set_build_base_mixin
+from . import CommandMixinProtocol, set_build_base_mixin
 
 
 class install(set_build_base_mixin, _install):
     """Custom implementation of ``install`` setuptools command."""
 
-    def finalize_options(self, *args, **kwargs):
+    def finalize_options(self: CommandMixinProtocol, *args, **kwargs):
         """Ensure that if the distribution is non-pure, all modules
         are installed in ``self.install_platlib``.
 
         .. note:: `setuptools.dist.Distribution.has_ext_modules()`
            is overridden in :func:`..setuptools_wrap.setup()`.
         """
-        if self.install_lib is None and self.distribution.has_ext_modules():
+        if self.install_lib is None and self.distribution.has_ext_modules():  # type: ignore[attr-defined]
             # pylint:disable=attribute-defined-outside-init
             self.install_lib = self.install_platlib
 
-        super().finalize_options(*args, **kwargs)
+        super().finalize_options(*args, **kwargs)  # type: ignore[misc]

--- a/skbuild/command/install.py
+++ b/skbuild/command/install.py
@@ -1,6 +1,8 @@
 """This module defines custom implementation of ``install`` setuptools
 command."""
 
+from typing import Any
+
 from setuptools.command.install import install as _install
 
 from . import CommandMixinProtocol, set_build_base_mixin
@@ -9,7 +11,7 @@ from . import CommandMixinProtocol, set_build_base_mixin
 class install(set_build_base_mixin, _install):
     """Custom implementation of ``install`` setuptools command."""
 
-    def finalize_options(self: CommandMixinProtocol, *args, **kwargs):
+    def finalize_options(self: CommandMixinProtocol, *args: Any, **kwargs: Any) -> None:
         """Ensure that if the distribution is non-pure, all modules
         are installed in ``self.install_platlib``.
 

--- a/skbuild/command/install_lib.py
+++ b/skbuild/command/install_lib.py
@@ -1,19 +1,21 @@
 """This module defines custom implementation of ``install_lib`` setuptools
 command."""
 
+from typing import List
+
 from setuptools.command.install_lib import install_lib as _install_lib
 
 from ..utils import distribution_hide_listing, distutils_log
-from . import set_build_base_mixin
+from . import CommandMixinProtocol, set_build_base_mixin
 
 
 class install_lib(set_build_base_mixin, _install_lib):
     """Custom implementation of ``install_lib`` setuptools command."""
 
-    def install(self):
+    def install(self: CommandMixinProtocol) -> List[str]:
         """Handle --hide-listing option."""
         with distribution_hide_listing(self.distribution):
-            outfiles = super().install()
+            outfiles = super().install()  # type: ignore[misc]
         if outfiles is not None:
             distutils_log.info("copied %d files", len(outfiles))
         return outfiles

--- a/skbuild/command/install_scripts.py
+++ b/skbuild/command/install_scripts.py
@@ -4,14 +4,14 @@ command."""
 from setuptools.command.install_scripts import install_scripts as _install_scripts
 
 from ..utils import distribution_hide_listing, distutils_log
-from . import set_build_base_mixin
+from . import CommandMixinProtocol, set_build_base_mixin
 
 
 class install_scripts(set_build_base_mixin, _install_scripts):
     """Custom implementation of ``install_scripts`` setuptools command."""
 
-    def run(self, *args, **kwargs):
+    def run(self: CommandMixinProtocol, *args, **kwargs):
         """Handle --hide-listing option."""
         with distribution_hide_listing(self.distribution):
-            super().run(*args, **kwargs)
+            super().run(*args, **kwargs)  # type: ignore[misc]
         distutils_log.info("copied %d files", len(self.outfiles))

--- a/skbuild/command/install_scripts.py
+++ b/skbuild/command/install_scripts.py
@@ -1,6 +1,8 @@
 """This module defines custom implementation of ``install_scripts`` setuptools
 command."""
 
+from typing import Any
+
 from setuptools.command.install_scripts import install_scripts as _install_scripts
 
 from ..utils import distribution_hide_listing, distutils_log
@@ -10,7 +12,7 @@ from . import CommandMixinProtocol, set_build_base_mixin
 class install_scripts(set_build_base_mixin, _install_scripts):
     """Custom implementation of ``install_scripts`` setuptools command."""
 
-    def run(self: CommandMixinProtocol, *args, **kwargs):
+    def run(self: CommandMixinProtocol, *args: Any, **kwargs: Any) -> None:
         """Handle --hide-listing option."""
         with distribution_hide_listing(self.distribution):
             super().run(*args, **kwargs)  # type: ignore[misc]

--- a/skbuild/command/sdist.py
+++ b/skbuild/command/sdist.py
@@ -1,5 +1,7 @@
 """This module defines custom implementation of ``sdist`` setuptools command."""
 
+from typing import Sequence
+
 from setuptools.command.sdist import sdist as _sdist
 
 from ..utils import distribution_hide_listing, distutils_log
@@ -9,7 +11,7 @@ from . import CommandMixinProtocol, set_build_base_mixin
 class sdist(set_build_base_mixin, _sdist):
     """Custom implementation of ``sdist`` setuptools command."""
 
-    def make_release_tree(self: CommandMixinProtocol, base_dir, files):
+    def make_release_tree(self: CommandMixinProtocol, base_dir: str, files: Sequence[str]) -> None:
         """Handle --hide-listing option."""
         with distribution_hide_listing(self.distribution):
             super().make_release_tree(base_dir, files)  # type: ignore[misc]

--- a/skbuild/command/sdist.py
+++ b/skbuild/command/sdist.py
@@ -3,22 +3,22 @@
 from setuptools.command.sdist import sdist as _sdist
 
 from ..utils import distribution_hide_listing, distutils_log
-from . import set_build_base_mixin
+from . import CommandMixinProtocol, set_build_base_mixin
 
 
 class sdist(set_build_base_mixin, _sdist):
     """Custom implementation of ``sdist`` setuptools command."""
 
-    def make_release_tree(self, base_dir, files):
+    def make_release_tree(self: CommandMixinProtocol, base_dir, files):
         """Handle --hide-listing option."""
         with distribution_hide_listing(self.distribution):
-            super().make_release_tree(base_dir, files)
+            super().make_release_tree(base_dir, files)  # type: ignore[misc]
         distutils_log.info("copied %d files", len(files))
 
     def make_archive(self, base_name, _format, root_dir=None, base_dir=None, owner=None, group=None):
         """Handle --hide-listing option."""
         distutils_log.info("creating '%s' %s archive and adding '%s' to it", base_name, _format, base_dir)
-        with distribution_hide_listing(self.distribution):
+        with distribution_hide_listing(self.distribution):  # type: ignore[attr-defined]
             super().make_archive(base_name, _format, root_dir, base_dir)
 
     def run(self, *args, **kwargs):

--- a/skbuild/constants.py
+++ b/skbuild/constants.py
@@ -12,7 +12,7 @@ CMAKE_DEFAULT_EXECUTABLE = "cmake"
 """Default path to CMake executable."""
 
 
-def _default_skbuild_plat_name():
+def _default_skbuild_plat_name() -> str:
     """Get default platform name.
 
     On linux and windows, it corresponds to :func:`distutils.util.get_platform()`.
@@ -65,7 +65,7 @@ def _default_skbuild_plat_name():
 _SKBUILD_PLAT_NAME = _default_skbuild_plat_name()
 
 
-def set_skbuild_plat_name(plat_name):
+def set_skbuild_plat_name(plat_name: str) -> None:
     """Set platform name associated with scikit-build functions returning a path:
 
     * :func:`SKBUILD_DIR()`
@@ -79,7 +79,7 @@ def set_skbuild_plat_name(plat_name):
     _SKBUILD_PLAT_NAME = plat_name
 
 
-def skbuild_plat_name():
+def skbuild_plat_name() -> str:
     """Get platform name formatted as `<operating_system>[-<operating_system_version>]-<machine_architecture>`.
 
     Default value corresponds to :func:`_default_skbuild_plat_name()` and can be overridden
@@ -90,34 +90,34 @@ def skbuild_plat_name():
     return _SKBUILD_PLAT_NAME
 
 
-def SKBUILD_DIR():
+def SKBUILD_DIR() -> str:
     """Top-level directory where setuptools and CMake directories are generated."""
     version_str = ".".join(map(str, sys.version_info[:2]))
     return os.path.join("_skbuild", f"{_SKBUILD_PLAT_NAME}-{version_str}")
 
 
-def SKBUILD_MARKER_FILE():
+def SKBUILD_MARKER_FILE() -> str:
     """Marker file used by :func:`skbuild.command.generate_source_manifest.generate_source_manifest.run()`."""
     return os.path.join(SKBUILD_DIR(), "_skbuild_MANIFEST")
 
 
-def CMAKE_BUILD_DIR():
+def CMAKE_BUILD_DIR() -> str:
     """CMake build directory."""
     return os.path.join(SKBUILD_DIR(), "cmake-build")
 
 
-def CMAKE_INSTALL_DIR():
+def CMAKE_INSTALL_DIR() -> str:
     """CMake install directory."""
     return os.path.join(SKBUILD_DIR(), "cmake-install")
 
 
-def CMAKE_SPEC_FILE():
+def CMAKE_SPEC_FILE() -> str:
     """CMake specification file storing CMake version, CMake configuration arguments and
     environment variables ``PYTHONNOUSERSITE`` and ``PYTHONPATH``.
     """
     return os.path.join(CMAKE_BUILD_DIR(), "CMakeSpec.json")
 
 
-def SETUPTOOLS_INSTALL_DIR():
+def SETUPTOOLS_INSTALL_DIR() -> str:
     """Setuptools install directory."""
     return os.path.join(SKBUILD_DIR(), "setuptools")

--- a/skbuild/platform_specifics/windows.py
+++ b/skbuild/platform_specifics/windows.py
@@ -7,7 +7,9 @@ import re
 import subprocess
 import sys
 import textwrap
+from typing import Dict
 
+from ..typing import TypedDict
 from . import abstract
 from .abstract import CMakeGenerator
 
@@ -28,6 +30,12 @@ VS_YEAR_TO_MSC_VER = {
     "2019": "1920",  # VS 2019 - can be +9
     "2022": "1930",  # VS 2022 - can be +9
 }
+
+
+class CachedEnv(TypedDict):
+    PATH: str
+    INCLUDE: str
+    LIB: str
 
 
 class WindowsPlatform(abstract.CMakePlatform):
@@ -182,7 +190,7 @@ def find_visual_studio(vs_version):
 
 # To avoid multiple slow calls to ``subprocess.check_output()`` (either directly or
 # indirectly through ``query_vcvarsall``), results of previous calls are cached.
-__get_msvc_compiler_env_cache = {}
+__get_msvc_compiler_env_cache: Dict[str, CachedEnv] = {}
 
 
 def _get_msvc_compiler_env(vs_version, vs_toolset=None):
@@ -240,7 +248,7 @@ def _get_msvc_compiler_env(vs_version, vs_toolset=None):
             key.lower(): value for key, _, value in (line.partition("=") for line in out.splitlines()) if key and value
         }
 
-        cached_env = {
+        cached_env: CachedEnv = {
             "PATH": vc_env.get("path", ""),
             "INCLUDE": vc_env.get("include", ""),
             "LIB": vc_env.get("lib", ""),

--- a/skbuild/platform_specifics/windows.py
+++ b/skbuild/platform_specifics/windows.py
@@ -229,12 +229,12 @@ def _get_msvc_compiler_env(vs_version, vs_toolset=None):
             vcvars_ver = f"-vcvars_ver={match_str}"
 
     try:
-        out = subprocess.check_output(
+        out_bytes = subprocess.check_output(
             f'cmd /u /c "{vcvarsall}" {arch} {vcvars_ver} && set',
             stderr=subprocess.STDOUT,
             shell=sys.platform.startswith("cygwin"),
         )
-        out = out.decode("utf-16le", errors="replace")
+        out = out_bytes.decode("utf-16le", errors="replace")
 
         vc_env = {
             key.lower(): value for key, _, value in (line.partition("=") for line in out.splitlines()) if key and value

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -386,7 +386,7 @@ def _load_cmake_spec() -> Optional[Dict[str, Any]]:
 
 
 # pylint:disable=too-many-locals, too-many-branches
-def setup(*args, **kw) -> None:  # noqa: C901
+def setup(*args: Any, **kw: Any) -> None:  # noqa: C901
     """This function wraps setup() so that we can run cmake, make,
     CMake build, then proceed as usual with setuptools, appending the
     CMake-generated output as necessary.

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -146,9 +146,9 @@ def parse_args() -> Tuple[List[str], Optional[str], bool, List[str], List[str]]:
     """This function parses the command-line arguments ``sys.argv`` and returns
     the tuple ``(setuptools_args, cmake_executable, skip_generator_test, cmake_args, build_tool_args)``
     where each ``*_args`` element corresponds to a set of arguments separated by ``--``."""
-    dutils = []
-    cmake = []
-    make = []
+    dutils: List[str] = []
+    cmake: List[str] = []
+    make: List[str] = []
     argsets = [dutils, cmake, make]
     i = 0
     separator = "--"
@@ -220,7 +220,7 @@ def _parse_setuptools_arguments(
 
     # Update class attribute to also ensure the argument is processed
     # when ``setuptools.setup`` is called.
-    upstream_Distribution.global_options.extend(
+    upstream_Distribution.global_options.extend(  # type: ignore[attr-defined]
         [
             ("hide-listing", None, "do not display list of files being included in the distribution"),
             ("force-cmake", None, "always run CMake"),
@@ -237,19 +237,20 @@ def _parse_setuptools_arguments(
     # SystemExit to suppress tracebacks.
 
     with _capture_output():
-        result = dist.parse_command_line()
+        result = dist.parse_command_line()  # type: ignore[attr-defined]
         display_only = not result
         if not hasattr(dist, "hide_listing"):
-            dist.hide_listing = False
+            dist.hide_listing = False  # type: ignore[attr-defined]
         if not hasattr(dist, "force_cmake"):
-            dist.force_cmake = False
+            dist.force_cmake = False  # type: ignore[attr-defined]
         if not hasattr(dist, "skip_cmake"):
-            dist.skip_cmake = False
+            dist.skip_cmake = False  # type: ignore[attr-defined]
 
     plat_names = set()
-    for cmd in [dist.get_command_obj(command) for command in dist.commands]:
-        if getattr(cmd, "plat_name", None) is not None:
-            plat_names.add(cmd.plat_name)
+    for cmd in [dist.get_command_obj(command) for command in dist.commands]:  # type: ignore[attr-defined]
+        plat_name = getattr(cmd, "plat_name", None)
+        if plat_name is not None:
+            plat_names.add(plat_name)
     if not plat_names:
         plat_names.add(None)
     elif len(plat_names) > 1:
@@ -258,15 +259,16 @@ def _parse_setuptools_arguments(
         raise SKBuildError(msg)
     plat_name = list(plat_names)[0]
 
-    build_ext_inplace = dist.get_command_obj("build_ext").inplace
+    build_ext_cmd = dist.get_command_obj("build_ext")
+    build_ext_inplace: bool = getattr(build_ext_cmd, "inplace", False)
 
     return (
         display_only,
-        dist.help_commands,
-        dist.commands,
-        dist.hide_listing,
-        dist.force_cmake,
-        dist.skip_cmake,
+        dist.help_commands,  # type: ignore[attr-defined]
+        dist.commands,  # type: ignore[attr-defined]
+        dist.hide_listing,  # type: ignore[attr-defined]
+        dist.force_cmake,  # type: ignore[attr-defined]
+        dist.skip_cmake,  # type: ignore[attr-defined]
         plat_name,
         build_ext_inplace,
     )
@@ -470,7 +472,7 @@ def setup(*args, **kw) -> None:  # noqa: C901
     # * no CMakeLists.txt if found
     display_only = has_invalid_arguments = help_commands = False
     force_cmake = skip_cmake = False
-    commands = []
+    commands: List[str] = []
     try:
         (
             display_only,

--- a/skbuild/typing.py
+++ b/skbuild/typing.py
@@ -1,8 +1,8 @@
 import sys
 
 if sys.version_info >= (3, 8):
-    from typing import Protocol, TypedDict, Final, Literal
+    from typing import Final, Literal, Protocol, TypedDict
 else:
-    from typing_extensions import Protocol, TypedDict, Final, Literal
+    from typing_extensions import Final, Literal, Protocol, TypedDict
 
 __all__ = ["Protocol", "TypedDict", "Final", "Literal"]

--- a/skbuild/typing.py
+++ b/skbuild/typing.py
@@ -1,0 +1,8 @@
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import Protocol, TypedDict, Final, Literal
+else:
+    from typing_extensions import Protocol, TypedDict, Final, Literal
+
+__all__ = ["Protocol", "TypedDict", "Final", "Literal"]

--- a/skbuild/utils/__init__.py
+++ b/skbuild/utils/__init__.py
@@ -6,6 +6,7 @@ import os
 from contextlib import contextmanager
 from typing import (
     Any,
+    Iterable,
     Iterator,
     List,
     Mapping,
@@ -135,7 +136,7 @@ class PythonModuleFinder(distutils_build_py):
         with push_dir(project_dir):
             return super().find_all_modules()
 
-    def find_package_modules(self, package: str, package_dir: str) -> map:
+    def find_package_modules(self, package: str, package_dir: str) -> Iterable[Tuple[str, str, str]]:
         """Temporally prepend the ``alternative_build_base`` to ``module_file``.
         Doing so will ensure modules can also be found in other location
         (e.g ``skbuild.constants.CMAKE_INSTALL_DIR``).
@@ -146,7 +147,7 @@ class PythonModuleFinder(distutils_build_py):
         modules = super().find_package_modules(package, package_dir)
 
         # Strip the alternative base from module_file
-        def _strip_directory(entry):
+        def _strip_directory(entry: Tuple[str, str, str]) -> Tuple[str, str, str]:
             module_file = entry[2]
             if self.alternative_build_base is not None and module_file.startswith(self.alternative_build_base):
                 module_file = module_file[len(self.alternative_build_base) + 1 :]

--- a/skbuild/utils/__init__.py
+++ b/skbuild/utils/__init__.py
@@ -2,8 +2,7 @@
 
 import contextlib
 import os
-from collections import namedtuple
-from contextlib import ContextDecorator, contextmanager
+from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import (
     Any,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,12 +1,10 @@
+from types import SimpleNamespace
+
 import pytest
 
 from skbuild.utils import distribution_hide_listing, distutils_log
 
 setuptools_logging = pytest.importorskip("setuptools.logging")
-
-
-class SimpleNamespace:
-    pass
 
 
 def test_hide_listing(caplog):


### PR DESCRIPTION
This was sitting around, let's go ahead and see what the diff looks like. I was playing with monkeytype.

- chore: update mypy settings a bit
- chore: run monkeytype, update old workarounds

Looks like monkey type was too specific, some need generalization. :)

Edit: Worked on the added types, and got mypy running by default.

A few notes:

* There are several type ignores due to https://github.com/python/mypy/issues/12344
* I didn't work out all the details of Distribution, so there are lots of type ignores there
* There are a few minor cleanups noticed by mypy, like random trailing commas