### PR TITLE
remove redundant `wheel` dependency

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -44,7 +44,6 @@ Then, add a ``pyproject.toml`` to list the build system requirements::
     [build-system]
     requires = [
       "setuptools>=42",
-      "wheel",
       "scikit-build",
       "cmake",
       "ninja; platform_system!='Windows'"

--- a/tests/samples/hello-numpy/pyproject.toml
+++ b/tests/samples/hello-numpy/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "setuptools>=42",
-    "wheel",
     "scikit-build",
     "cmake>=3.18",
     "ninja",

--- a/tests/samples/hello-pep518/pyproject.toml
+++ b/tests/samples/hello-pep518/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "setuptools",
-    "wheel",
     "scikit-build",
     "cmake",
     "ninja",


### PR DESCRIPTION
wheels is automatically installed by PEP 517 front ends, when building wheels. This was a documentation mistake in setuptools: https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a