### PR TITLE
Finer exceptions and hopes for editable installs.

### DIFF
--- a/skbuild/exceptions.py
+++ b/skbuild/exceptions.py
@@ -8,9 +8,10 @@ class SKBuildError(RuntimeError):
     project.
     """
 
+
 class SKBuildInvalidFileInstallationError(SKBuildError):
-    """Exception raised when a file is being installed into an invalid location.
-    """
+    """Exception raised when a file is being installed into an invalid location."""
+
 
 class SKBuildGeneratorNotFoundError(SKBuildError):
     """Exception raised when no suitable generator is found for the current

--- a/skbuild/exceptions.py
+++ b/skbuild/exceptions.py
@@ -8,6 +8,9 @@ class SKBuildError(RuntimeError):
     project.
     """
 
+class SKBuildInvalidFileInstallationError(SKBuildError):
+    """Exception raised when a file is being installed into an invalid location.
+    """
 
 class SKBuildGeneratorNotFoundError(SKBuildError):
     """Exception raised when no suitable generator is found for the current

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -46,7 +46,7 @@ from .constants import (
     set_skbuild_plat_name,
     skbuild_plat_name,
 )
-from .exceptions import SKBuildError, SKBuildGeneratorNotFoundError
+from .exceptions import SKBuildError, SKBuildInvalidFileInstallationError, SKBuildGeneratorNotFoundError
 from .utils import (
     PythonModuleFinder,
     mkdir_p,
@@ -793,7 +793,7 @@ def _classify_installed_files(
                 f"    Project Root  : {install_root}\n"
                 f"    Violating File: {to_platform_path(path)}\n"
             )
-            raise SKBuildError(msg)
+            raise SKBuildInvalidFileInstallationError(msg)
 
         # peel off the 'skbuild' prefix
         path = to_unix_path(os.path.relpath(path, CMAKE_INSTALL_DIR()))

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -46,7 +46,11 @@ from .constants import (
     set_skbuild_plat_name,
     skbuild_plat_name,
 )
-from .exceptions import SKBuildError, SKBuildInvalidFileInstallationError, SKBuildGeneratorNotFoundError
+from .exceptions import (
+    SKBuildError,
+    SKBuildGeneratorNotFoundError,
+    SKBuildInvalidFileInstallationError,
+)
 from .utils import (
     PythonModuleFinder,
     mkdir_p,


### PR DESCRIPTION
There does not seem to be a robust solution for editable installs (#370, #436, #546, #579, #697). The closest I've been able to get raises from `_classify_installed_files`, even though everything looks exactly as one might expect for an editable install. The only thing added here is a new exception class that gets raised in this situation so that the exception can be safely singled out and permitted, without catching every `SKBuildError`. Its not an ideal solution to the editable installation problem, but having more detailed exceptions sounds like an all-around plus.