### PR TITLE
fix(Cython): support FindPython

### DIFF
--- a/skbuild/resources/cmake/FindCython.cmake
+++ b/skbuild/resources/cmake/FindCython.cmake
@@ -36,9 +36,15 @@
 
 # Use the Cython executable that lives next to the Python executable
 # if it is a local installation.
-find_package(PythonInterp)
-if(PYTHONINTERP_FOUND)
+if(Python_EXECUTABLE)
+  get_filename_component(_python_path ${Python_EXECUTABLE} PATH)
+elseif(Python3_EXECUTABLE)
+  get_filename_component(_python_path ${Python3_EXECUTABLE} PATH)
+elseif(DEFINED PYTHON_EXECUTABLE)
   get_filename_component(_python_path ${PYTHON_EXECUTABLE} PATH)
+endif()
+
+if(DEFINED _python_path)
   find_program(CYTHON_EXECUTABLE
                NAMES cython cython.bat cython3
                HINTS ${_python_path}

--- a/skbuild/resources/cmake/UseCython.cmake
+++ b/skbuild/resources/cmake/UseCython.cmake
@@ -102,8 +102,6 @@ set(CYTHON_FLAGS "" CACHE STRING
     "Extra flags to the cython compiler.")
 mark_as_advanced(CYTHON_ANNOTATE CYTHON_FLAGS)
 
-find_package(PythonLibs REQUIRED)
-
 set(CYTHON_CXX_EXTENSION "cxx")
 set(CYTHON_C_EXTENSION "c")
 
@@ -145,12 +143,6 @@ function(add_cython_target _name)
     message(FATAL_ERROR "Either C or CXX must be enabled to use Cython")
   endif()
 
-  if("${PYTHONLIBS_VERSION_STRING}" MATCHES "^2.")
-    set(_input_syntax "PY2")
-  else()
-    set(_input_syntax "PY3")
-  endif()
-
   if(_args_EMBED_MAIN)
     set(_embed_main TRUE)
   endif()
@@ -162,6 +154,10 @@ function(add_cython_target _name)
   if(_args_CXX)
     set(_output_syntax "CXX")
   endif()
+
+  # Doesn't select an input syntax - Cython
+  # defaults to 2 for Cython 2 and 3 for Cython 3
+  set(_input_syntax "default")
 
   if(_args_PY2)
     set(_input_syntax "PY2")


### PR DESCRIPTION
The language level of Cython depends on Cython version, not the host Python version. Avoiding this avoids requiring FindPythonLibs, which should stop breaking this when using FindPython.

Generalizing FindCython to use an existing discovery of Python and not trigger it's own.

CC @maxbachmann.