### PR TITLE
chore: prepare for 0.16

### DIFF
--- a/.github/actions/setup-nox/action.yml
+++ b/.github/actions/setup-nox/action.yml
@@ -29,13 +29,8 @@ runs:
       with:
         python-version: "3.10"
     - uses: actions/setup-python@v4
-      if: runner.os != 'macOS'
       with:
         python-version: "3.11"
-    - uses: actions/setup-python@v4
-      if: runner.os == 'macOS'
-      with:
-        python-version: "3.11-dev"
     - name: "Install nox"
       run: pipx install nox
       shell: bash

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,8 @@ Bug fixes
 
 * FindPython mode uses a new path specification, should help make it usable. :pr:`774`
 
+* Better flushing and output streams for more consistent output ordering. :pr:`781`
+
 Scikit-build 0.15.0
 ===================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ Scikit-build 0.16.0
 This release adds support for Python 3.11 and removes support for Python 2.7
 and 3.5 (:pr:`688`). Testing and static checking improved, including being
 fully statically typed internally (though setuptools is not fully typed, so
-it's of limited use).
+it is of limited use).
 
 All deprecated setuptools/distutils features are also deprecated in
 scikit-build, like the ``test`` command, ``easy_install``, etc. Editable mode

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,36 @@ Release Notes
 This is the list of changes to scikit-build between each release. For full
 details, see the commit logs at http://github.com/scikit-build/scikit-build
 
+
+Scikit-build 0.16.0
+===================
+
+This release adds support for Python 3.11 and removes support for Python 2.7
+and 3.5 (:pr:`688`). Testing and static checking improved, including being
+fully statically typed internally (though setuptools is not fully typed, so
+it's of limited use).
+
+All deprecated setuptools/distutils features are also deprecated in
+scikit-build, like the ``test`` command, ``easy_install``, etc. Editable mode
+is still unsupported.  Python 3.6 support is deprecated. Older versions of
+CMake (<3.15) are not recommended; a future version will remove support for older
+CMake's (along with providing a better mechanism for ensuring a proper CMake is
+available). If you need any of these features, please open or find an issue
+explaining what and why you need something.
+
+
+New Features
+------------
+
+* Cython module now supports FindPython mode. :pr:`743`
+
+* PyPy is discovered without extra settings in FindPython mode :pr:`744`
+
+Bug fixes
+---------
+
+* FindPython mode uses a new path specification, should help make it usable. :pr:`774`
+
 Scikit-build 0.15.0
 ===================
 

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,16 @@
 scikit-build
 ===============================
 
+.. image:: https://github.com/scikit-build/scikit-build/actions/workflows/ci.yml/badge.svg
+    :target: https://github.com/scikit-build/scikit-build/actions/workflows/ci.yml
+
+.. image:: https://dev.azure.com/scikit-build/scikit-build/_apis/build/status/scikit-build.scikit-build?branchName=master
+   :target: https://dev.azure.com/scikit-build/scikit-build/_build/latest?definitionId=1&branchName=master
+
+.. image:: https://codecov.io/gh/scikit-build/scikit-build/branch/master/graph/badge.svg
+    :target: https://codecov.io/gh/scikit-build/scikit-build
+    :alt: Code coverage status
+
 Improved build system generator for CPython C/C++/Fortran/Cython extensions.
 
 Better support is available for additional compilers, build systems, cross
@@ -30,27 +40,35 @@ Latest Release
   +-----------------------------------------------------------------------------+-------------------------------------------------------------------------------+
 
 
-Build Status
+
+Known Issues
 ------------
 
-.. table::
+These issues are likely to be addressed in upcoming releases.
 
-  +--------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------+
-  | GitHub Actions                                                                             | Azure                                                                                                                     |
-  +============================================================================================+===========================================================================================================================+
-  | .. image:: https://github.com/scikit-build/scikit-build/actions/workflows/ci.yml/badge.svg | .. image:: https://dev.azure.com/scikit-build/scikit-build/_apis/build/status/scikit-build.scikit-build?branchName=master |
-  |     :target: https://github.com/scikit-build/scikit-build/actions/workflows/ci.yml         |     :target: https://dev.azure.com/scikit-build/scikit-build/_build/latest?definitionId=1&branchName=master               |
-  +--------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------+
+* Editable installs do not work with the latest versions of Setuptools (and had
+  issues with older versions, too).
+* Configuration scikit-build cares about _must_ be specified in ``setup()``
+  currently.
+* The cache directory (``_skbuild``) may need to be deleted between builds in
+  some cases (like rebuilding with a different Python interpreter).
 
-Overall Health
---------------
+We are also working on improving scikit-build, so there are some upcoming
+changes and deprecations:
 
-.. image:: https://requires.io/github/scikit-build/scikit-build/requirements.svg?branch=master
-    :target: https://requires.io/github/scikit-build/scikit-build/requirements/?branch=master
-    :alt: Requirements Status
 
-.. image:: https://codecov.io/gh/scikit-build/scikit-build/branch/master/graph/badge.svg
-    :target: https://codecov.io/gh/scikit-build/scikit-build
+* All deprecated setuptools/distutils features are also deprecated in
+  scikit-build, like the ``test`` command, ``easy_install``, etc.
+* Python 3.6
+  support is deprecated, as setuptools, pytest, and everything else we use has
+  dropped it already.
+* Older versions of CMake (<3.15) are not recommended; a future version will
+  remove support for older CMake's (along with providing a better mechanism for
+  ensuring a proper CMake is available).
+* Our primary branch will change to ``main``
+
+If you need any of these features, please open or find an issue explaining what
+and why you need something.
 
 Miscellaneous
 -------------
@@ -59,3 +77,6 @@ Miscellaneous
 * Documentation: http://scikit-build.readthedocs.org
 * Source code: https://github.com/scikit-build/scikit-build
 * Mailing list: https://groups.google.com/forum/#!forum/scikit-build
+
+
+Support for this work was provided by NSF cooperative agreement `OAC-2209877 <https://www.nsf.gov/awardsearch/showAward?AWD_ID=2209877>`_.

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
         "Mailing List": "https://groups.google.com/forum/#!forum/scikit-build",
         "Examples": "https://github.com/scikit-build/scikit-build-sample-projects",
     },
-    package_data={"skbuild": ["resources"]},
+    package_data={"skbuild": ["resources", "py.typed"]},
     install_requires=requirements,
     license="MIT",
     zip_safe=False,
@@ -53,6 +53,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Typing :: Typed",
     ],
     extras_require={"test": dev_requirements, "docs": doc_requirements},
 )


### PR DESCRIPTION
@jcfr, @thewtex, this has messaging about the future of Scikit-build, worth verifying it's reasonable before approving! I'd like to get this out fairly soon, as it seems to be needed for Python 3.11. There are other known bugs, but it's better to get some known fixes out (especially 3.11 support!) than wait for perfection.

Closes #777.