### PR TITLE
Ignore distutils deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ filterwarnings = [
   "ignore:Config variable 'Py_DEBUG' is unset:RuntimeWarning",
   "ignore:Config variable 'WITH_PYMALLOC' is unset, Python ABI tag may be incorrect:RuntimeWarning",
   'ignore:\s*Installing .* as data is deprecated:Warning',
-  "ignore:shell/Perl-style substitions are deprecated:DeprecationWarning",
+  "ignore:shell/Perl-style subs.* are deprecated:DeprecationWarning",
 ]
 log_cli_level = "info"
 markers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ filterwarnings = [
   "ignore:Config variable 'Py_DEBUG' is unset:RuntimeWarning",
   "ignore:Config variable 'WITH_PYMALLOC' is unset, Python ABI tag may be incorrect:RuntimeWarning",
   'ignore:\s*Installing .* as data is deprecated:Warning',
+  "ignore:shell/Perl-style substitions are deprecated:DeprecationWarning",
 ]
 log_cli_level = "info"
 markers = [


### PR DESCRIPTION
The distutils vendored in setuptools throws this error in a couple of tests:

```
[   37s] ______________________________ test_test_command _______________________________
[   37s] 
[   37s]     def test_test_command():
[   37s]         with push_dir():
[   37s]     
[   37s]             tmp_dir = _tmpdir("test_test_command")
[   37s]             project = "issue-274-support-one-package-without-package-dir"
[   37s]             prepare_project(project, tmp_dir)
[   37s]             initialize_git_repo_and_commit(tmp_dir, verbose=True)
[   37s]     
[   37s]             try:
[   37s] >               with execute_setup_py(tmp_dir, ["test"], disable_languages_test=True):
[   37s] 
[   37s] project    = 'issue-274-support-one-package-without-package-dir'
[   37s] tmp_dir    = local('/tmp/pytest-of-abuild/pytest-2488/test_test_command0')
[   37s] 
[   37s] tests/test_issue274_support_one_package_without_package_dir.py:25: 
...
[   37s] /usr/lib/python3.8/site-packages/setuptools/__init__.py:87: in setup
[   37s]     return distutils.core.setup(**attrs)
[   37s]         attrs      = {'author': 'The scikit-build team', 'cmdclass': {'bdist': <class 'skbuild.command.bdist.bdist'>, 'bdist_wheel': <class...<class 'skbuild.command.build_ext.build_ext'>, ...}, 'data_files': [], 'description': 'a minimal example package', ...}
[   37s] /usr/lib/python3.8/site-packages/setuptools/_distutils/core.py:185: in setup
[   37s]     return run_commands(dist)
[   37s]         attrs      = {'author': 'The scikit-build team', 'cmdclass': {'bdist': <class 'skbuild.command.bdist.bdist'>, 'bdist_wheel': <class...<class 'skbuild.command.build_ext.build_ext'>, ...}, 'data_files': [], 'description': 'a minimal example package', ...}
[   37s]         dist       = <skbuild.setuptools_wrap.setup.<locals>.BinaryDistribution object at 0x7ff77c327d60>
[   37s]         klass      = <class 'skbuild.setuptools_wrap.setup.<locals>.BinaryDistribution'>
[   37s]         ok         = True
[   37s] /usr/lib/python3.8/site-packages/setuptools/_distutils/core.py:201: in run_commands
[   37s]     dist.run_commands()
[   37s]         dist       = <skbuild.setuptools_wrap.setup.<locals>.BinaryDistribution object at 0x7ff77c327d60>
[   37s] /usr/lib/python3.8/site-packages/setuptools/_distutils/dist.py:968: in run_commands
[   37s]     self.run_command(cmd)
[   37s]         cmd        = 'test'
[   37s]         self       = <skbuild.setuptools_wrap.setup.<locals>.BinaryDistribution object at 0x7ff77c327d60>
[   37s] /usr/lib/python3.8/site-packages/setuptools/dist.py:1217: in run_command
[   37s]     super().run_command(command)
[   37s]         __class__  = <class 'setuptools.dist.Distribution'>
[   37s]         command    = 'test'
[   37s]         self       = <skbuild.setuptools_wrap.setup.<locals>.BinaryDistribution object at 0x7ff77c327d60>
[   37s] /usr/lib/python3.8/site-packages/setuptools/_distutils/dist.py:987: in run_command
[   37s]     cmd_obj.run()
[   37s]         cmd_obj    = <skbuild.command.test.test object at 0x7ff77c40aa30>
[   37s]         command    = 'test'
[   37s]         self       = <skbuild.setuptools_wrap.setup.<locals>.BinaryDistribution object at 0x7ff77c327d60>
[   37s] skbuild/command/test.py:13: in run
[   37s]     self.run_command("develop")
[   37s]         __class__  = <class 'skbuild.command.test.test'>
[   37s]         args       = ()
[   37s]         kwargs     = {}
[   37s]         self       = <skbuild.command.test.test object at 0x7ff77c40aa30>
[   37s] /usr/lib/python3.8/site-packages/setuptools/_distutils/cmd.py:319: in run_command
[   37s]     self.distribution.run_command(command)
[   37s]         command    = 'develop'
[   37s]         self       = <skbuild.command.test.test object at 0x7ff77c40aa30>
[   37s] /usr/lib/python3.8/site-packages/setuptools/dist.py:1217: in run_command
[   37s]     super().run_command(command)
[   37s]         __class__  = <class 'setuptools.dist.Distribution'>
[   37s]         command    = 'develop'
[   37s]         self       = <skbuild.setuptools_wrap.setup.<locals>.BinaryDistribution object at 0x7ff77c327d60>
[   37s] /usr/lib/python3.8/site-packages/setuptools/_distutils/dist.py:986: in run_command
[   37s]     cmd_obj.ensure_finalized()
[   37s]         cmd_obj    = <setuptools.command.develop.develop object at 0x7ff77c1cb6d0>
[   37s]         command    = 'develop'
[   37s]         self       = <skbuild.setuptools_wrap.setup.<locals>.BinaryDistribution object at 0x7ff77c327d60>
[   37s] /usr/lib/python3.8/site-packages/setuptools/_distutils/cmd.py:109: in ensure_finalized
[   37s]     self.finalize_options()
[   37s]         self       = <setuptools.command.develop.develop object at 0x7ff77c1cb6d0>
[   37s] /usr/lib/python3.8/site-packages/setuptools/command/develop.py:52: in finalize_options
[   37s]     easy_install.finalize_options(self)
[   37s]         ei         = <skbuild.command.egg_info.egg_info object at 0x7ff77c1cb490>
[   37s]         self       = <setuptools.command.develop.develop object at 0x7ff77c1cb6d0>
[   37s] /usr/lib/python3.8/site-packages/setuptools/command/easy_install.py:262: in finalize_options
[   37s]     self._expand(
[   37s]         py_version = '3.8.15'
[   37s]         self       = <setuptools.command.develop.develop object at 0x7ff77c1cb6d0>
[   37s] /usr/lib/python3.8/site-packages/setuptools/command/easy_install.py:1366: in _expand
[   37s]     val = subst_vars(val, config_vars)
[   37s]         attr       = 'install_dir'
[   37s]         attrs      = ('install_dir', 'script_dir', 'build_directory', 'site_dirs')
[   37s]         config_vars = {'ABIFLAGS': '', 'AC_APPLE_UNIVERSAL_BUILD': 0, 'AIX_GENUINE_CPLUSPLUS': 0, 'ALT_SOABI': 0, ...}
[   37s]         scheme     = {'install_dir': '$base/lib/python$py_version_short/site-packages', 'script_dir': '$base/bin'}
[   37s]         self       = <setuptools.command.develop.develop object at 0x7ff77c1cb6d0>
[   37s]         subst_vars = <function subst_vars at 0x7ff77e1b10d0>
[   37s]         val        = '$base/lib/python$py_version_short/site-packages'
[   37s] /usr/lib/python3.8/site-packages/setuptools/_distutils/util.py:212: in subst_vars
[   37s]     return _subst_compat(s).format_map(lookup)
[   37s]         local_vars = {'ABIFLAGS': '', 'AC_APPLE_UNIVERSAL_BUILD': 0, 'AIX_GENUINE_CPLUSPLUS': 0, 'ALT_SOABI': 0, ...}
[   37s]         lookup     = {'ABIFLAGS': '', 'AC_APPLE_UNIVERSAL_BUILD': '0', 'AIX_GENUINE_CPLUSPLUS': '0', 'ALT_SOABI': '0', ...}
[   37s]         s          = '$base/lib/python$py_version_short/site-packages'
[   37s] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[   37s] 
[   37s] s = '$base/lib/python$py_version_short/site-packages'
[   37s] 
[   37s]     def _subst_compat(s):
[   37s]         """
[   37s]         Replace shell/Perl-style variable substitution with
[   37s]         format-style. For compatibility.
[   37s]         """
[   37s]     
[   37s]         def _subst(match):
[   37s]             return f'{{{match.group(1)}}}'
[   37s]     
[   37s]         repl = re.sub(r'\$([a-zA-Z_][a-zA-Z_0-9]*)', _subst, s)
[   37s]         if repl != s:
[   37s]             import warnings
[   37s]     
[   37s] >           warnings.warn(
[   37s]                 "shell/Perl-style substitions are deprecated",
[   37s]                 DeprecationWarning,
[   37s]             )
[   37s] E           DeprecationWarning: shell/Perl-style substitions are deprecated
[   37s] 
[   37s] _subst     = <function _subst_compat.<locals>._subst at 0x7ff77c3fedc0>
[   37s] repl       = '{base}/lib/python{py_version_short}/site-packages'
[   37s] s          = '$base/lib/python$py_version_short/site-packages'
[   37s] warnings   = <module 'warnings' from '/usr/lib64/python3.8/warnings.py'>
[   37s] 
[   37s] /usr/lib/python3.8/site-packages/setuptools/_distutils/util.py:230: DeprecationWarning
...
[   37s] FAILED tests/test_hello_cpp.py::test_hello_develop - DeprecationWarning: shel...
[   37s] FAILED tests/test_issue274_support_default_package_dir.py::test_test_command
[   37s] FAILED tests/test_issue274_support_one_package_without_package_dir.py::test_test_command
```