### PR TITLE
fix: handle logging changes in setuptools 65.6+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,6 @@ jobs:
       env:
         TMP: /tmp
         TEMP: /tmp
-        SETUPTOOLS_SCM_PRETEND_VERSION: "0.15"
       run: python3.9 -m nox -s tests-3.9
 
 
@@ -144,3 +143,10 @@ jobs:
 
     - name: Check metadata
       run: pipx run twine check dist/*
+
+
+  pass:
+    needs: [tests, tests-pypy, dist]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All jobs passed"

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ skbuild/_cmake_test_compile/*
 
 .coverage*
 skbuild/_version.py
+
+/*env*/

--- a/noxfile.py
+++ b/noxfile.py
@@ -38,6 +38,8 @@ def tests(session):
             contained = "1" if version in known_MSVC else "0"
             env[f"SKBUILD_TEST_FIND_VS{version}_INSTALLATION_EXPECTED"] = contained
 
+    # Latest versions may break things, so grab them for testing!
+    session.install("-U", "setuptools", "wheel")
     session.install("-e", ".[test]")
     session.run("pytest", *posargs, env=env)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,5 +91,6 @@ filterwarnings = [
 ]
 log_cli_level = "info"
 markers = [
-  "fortran: fortran testing",
+  "fortran: Fortran testing",
+  "deprecated: These tests deprecated setuptools features",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ codecov>=2.0.5
 coverage>=4.2
 cython>=0.25.1
 flake8>=3.0.4
+importlib-metadata;python_version<"3.8"
 path.py>=11.5.0
 pytest>=6.0.0
 pytest-cov>=2.7.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@ coverage>=4.2
 cython>=0.25.1
 flake8>=3.0.4
 importlib-metadata;python_version<"3.8"
-path.py>=11.5.0
 pytest>=6.0.0
 pytest-cov>=2.7.1
 pytest-mock>=1.10.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,12 @@ import sys
 
 import pytest
 
+if sys.version_info < (3, 8):
+    import importlib_metadata as metadata
+else:
+    from importlib import metadata
+
+
 DIR = os.path.dirname(os.path.abspath(__file__))
 BASE = os.path.dirname(DIR)
 
@@ -43,3 +49,26 @@ def pep518(pep518_wheelhouse, monkeypatch):
     monkeypatch.setenv("PIP_FIND_LINKS", pep518_wheelhouse)
     monkeypatch.setenv("PIP_NO_INDEX", "true")
     return pep518_wheelhouse
+
+
+def pytest_report_header() -> str:
+    interesting_packages = {
+        "build",
+        "distro",
+        "packaging",
+        "pip",
+        "setuptools",
+        "virtualenv",
+        "wheel",
+    }
+    valid = []
+    for package in interesting_packages:
+        try:
+            version = metadata.version(package)  # type: ignore[no-untyped-call]
+        except ModuleNotFoundError:
+            continue
+        valid.append(f"{package}=={version}")
+    reqs = " ".join(sorted(valid))
+    pkg_line = f"installed packages of interest: {reqs}"
+
+    return "\n".join([pkg_line])

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -1,11 +1,11 @@
-import os
+from pathlib import Path
 
 import pytest
-from path import Path
 
 from . import initialize_git_repo_and_commit, prepare_project
 
-DIST_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../dist"))
+DIR = Path(__file__).parent.resolve()
+DIST_DIR = DIR.parent / "dist"
 
 # Test if package can be imported to allow testing on
 # conda-forge where ``pytest-virtualenv`` is not available.
@@ -13,7 +13,7 @@ pytest.importorskip("pytest_virtualenv", reason="pytest_virtualenv not available
 
 
 def test_source_distribution(virtualenv):
-    sdists = Path(DIST_DIR).files(match="*.tar.gz") if Path(DIST_DIR).exists() else []
+    sdists = DIST_DIR.glob("*.tar.gz") if DIST_DIR.exists() else []
     if not sdists:
         pytest.skip("no source distribution available")
     assert len(sdists) == 1
@@ -28,7 +28,7 @@ def test_source_distribution(virtualenv):
 
 
 def test_wheel(virtualenv):
-    wheels = Path(DIST_DIR).files(match="*.whl") if Path(DIST_DIR).exists() else []
+    wheels = DIST_DIR.glob("*.whl") if DIST_DIR.exists() else []
     if not wheels:
         pytest.skip("no wheel available")
     assert len(wheels) == 1

--- a/tests/test_hello_cpp.py
+++ b/tests/test_hello_cpp.py
@@ -11,7 +11,7 @@ import os
 
 import pytest
 
-from skbuild.constants import CMAKE_BUILD_DIR, CMAKE_INSTALL_DIR, SKBUILD_DIR
+from skbuild.constants import CMAKE_BUILD_DIR, SKBUILD_DIR
 from skbuild.utils import push_dir
 
 from . import SAMPLES_DIR, _copy_dir, _tmpdir, get_ext_suffix, project_setup_py_test
@@ -163,23 +163,19 @@ def test_hello_cleans(capfd, caplog):
 
         # Check that a project can be cleaned twice in a row
         run_build()
-        print("<<-->>")
+        capfd.readouterr()
+        caplog.clear()
+
         run_clean()
-        print("<<-->>")
+        txt1 = caplog.text
+        msg = capfd.readouterr().out + txt1
+        assert "running clean" in msg
+        caplog.clear()
+
         run_clean()
-
-    _, clean1_out, clean2_out = capfd.readouterr()[0].split("<<-->>")
-
-    clean1_out = clean1_out.strip()
-    clean2_out = clean2_out.strip()
-
-    assert "running clean" == clean1_out.splitlines()[0]
-    if caplog.text.count("removing") != 3:
-        assert f"removing '{CMAKE_INSTALL_DIR()}'" == clean1_out.splitlines()[1]
-        assert f"removing '{CMAKE_BUILD_DIR()}'" == clean1_out.splitlines()[2]
-        assert f"removing '{SKBUILD_DIR()}'" == clean1_out.splitlines()[3]
-
-    assert "running clean" == clean2_out
+        txt2 = caplog.text
+        msg = capfd.readouterr().out + txt2
+        assert "running clean" in msg
 
 
 @project_setup_py_test("hello-cpp", ["develop"])

--- a/tests/test_hello_cpp.py
+++ b/tests/test_hello_cpp.py
@@ -178,6 +178,7 @@ def test_hello_cleans(capfd, caplog):
         assert "running clean" in msg
 
 
+@pytest.mark.deprecated
 @project_setup_py_test("hello-cpp", ["develop"])
 def test_hello_develop():
     for expected_file in [

--- a/tests/test_issue274_support_default_package_dir.py
+++ b/tests/test_issue274_support_default_package_dir.py
@@ -1,3 +1,5 @@
+import pytest
+
 from . import (
     _tmpdir,
     execute_setup_py,
@@ -8,11 +10,13 @@ from . import (
 )
 
 
+@pytest.mark.deprecated
 @project_setup_py_test("issue-274-support-default-package-dir", ["install"], disable_languages_test=True)
 def test_install_command():
     pass
 
 
+@pytest.mark.deprecated
 def test_test_command():
     with push_dir():
 

--- a/tests/test_issue274_support_one_package_without_package_dir.py
+++ b/tests/test_issue274_support_one_package_without_package_dir.py
@@ -1,3 +1,5 @@
+import pytest
+
 from . import (
     _tmpdir,
     execute_setup_py,
@@ -8,11 +10,13 @@ from . import (
 )
 
 
+@pytest.mark.deprecated
 @project_setup_py_test("issue-274-support-one-package-without-package-dir", ["install"], disable_languages_test=True)
 def test_install_command():
     pass
 
 
+@pytest.mark.deprecated
 def test_test_command():
     with push_dir():
 

--- a/tests/test_issue334_configure_cmakelists_non_cp1252_encoding.py
+++ b/tests/test_issue334_configure_cmakelists_non_cp1252_encoding.py
@@ -1,6 +1,9 @@
+import pytest
+
 from . import project_setup_py_test
 
 
+@pytest.mark.deprecated
 @project_setup_py_test("issue-334-configure-cmakelist-non-cp1252-encoding", ["install"], disable_languages_test=True)
 def test_install_command():
     pass

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -321,6 +321,7 @@ def test_cmake_minimum_required_version_keyword():
         assert "CMake version 99.98.97 or higher is required." in message
 
 
+@pytest.mark.deprecated
 @pytest.mark.filterwarnings("ignore:setuptools.installer is deprecated:Warning")
 @pytest.mark.skipif(
     os.environ.get("CONDA_BUILD", "0") == "1",

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -146,7 +146,7 @@ def test_cmake_args_keyword(cmake_args, capfd):
         ("banana", False, str),
     ),
 )
-def test_cmake_install_dir_keyword(cmake_install_dir, expected_failed, error_code_type, capsys):
+def test_cmake_install_dir_keyword(cmake_install_dir, expected_failed, error_code_type, capsys, caplog):
 
     # -------------------------------------------------------------------------
     # "SOURCE" tree layout:
@@ -220,6 +220,7 @@ def test_cmake_install_dir_keyword(cmake_install_dir, expected_failed, error_cod
         message = str(e)
 
     out, _ = capsys.readouterr()
+    out += caplog.text
 
     assert failed == expected_failed
     if failed:
@@ -379,7 +380,7 @@ def test_setup_requires_keyword_include_cmake(mocker, capsys):
 
 
 @pytest.mark.parametrize("distribution_type", ("pure", "skbuild"))
-def test_script_keyword(distribution_type, capsys):
+def test_script_keyword(distribution_type, capsys, caplog):
 
     # -------------------------------------------------------------------------
     #
@@ -458,12 +459,13 @@ def test_script_keyword(distribution_type, capsys):
         pass
 
     out, _ = capsys.readouterr()
+    out += caplog.text
     for message in messages:
         assert to_platform_path(message) in out
 
 
 @pytest.mark.parametrize("distribution_type", ("pure", "skbuild"))
-def test_py_modules_keyword(distribution_type, capsys):
+def test_py_modules_keyword(distribution_type, capsys, caplog):
 
     # -------------------------------------------------------------------------
     #
@@ -539,6 +541,7 @@ def test_py_modules_keyword(distribution_type, capsys):
         pass
 
     out, _ = capsys.readouterr()
+    out += caplog.text
     for message in messages:
         assert to_platform_path(message) in out
 
@@ -943,7 +946,7 @@ def test_setup_inputs(
 
 
 @pytest.mark.parametrize("with_cmake_source_dir", [0, 1])
-def test_cmake_install_into_pure_package(with_cmake_source_dir, capsys):
+def test_cmake_install_into_pure_package(with_cmake_source_dir, capsys, caplog):
 
     # -------------------------------------------------------------------------
     # "SOURCE" tree layout:
@@ -1056,6 +1059,7 @@ def test_cmake_install_into_pure_package(with_cmake_source_dir, capsys):
     ]
 
     out, _ = capsys.readouterr()
+    out += caplog.text
     for message in messages:
         assert to_platform_path(message) in out
 


### PR DESCRIPTION
- tests: include printout of installed packages of interest
- tests: remove usage of raw "path"
- chore: ignore venv dirs
- fix: handle logging changes in setuptools 65.6+
- tests: mark some tests deprecated
- ci: pass job

This also ensures we are using the latest setuptools and wheel in the tests, which should help us see issues before (too many) users see them.