### PR TITLE
fix function signature of get_requires_for_build_wheel

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -427,7 +427,7 @@ then you can implement a thin wrapper around ``build_meta`` in the ``_custom_bui
     build_sdist = _orig.build_sdist
     get_requires_for_build_sdist = _orig.get_requires_for_build_sdist
 
-    def get_requires_for_build_wheel(self, config_settings=None):
+    def get_requires_for_build_wheel(config_settings=None):
         from packaging import version
         from skbuild.exceptions import SKBuildError
         from skbuild.cmaker import get_cmake_version


### PR DESCRIPTION
This fixes the function signature of `get_requires_for_build_wheel` to be compliant with pep517 (see https://github.com/pypa/setuptools/pull/3730)