### PR TITLE
fix: conda-forge uses -DCMAKE_SYSTEM_PROCESSOR, so respect that too

### DIFF
--- a/skbuild/constants.py
+++ b/skbuild/constants.py
@@ -69,7 +69,8 @@ def _default_skbuild_plat_name() -> str:
 
     # Use CMAKE_OSX_ARCHITECTURES if that is set, otherwise use ARCHFLAGS,
     # which is the variable used by Setuptools. Fall back to the machine arch
-    # if neither of those is given.
+    # if neither of those is given. Not that -D flags like CMAKE_SYSTEM_PROCESSOR
+    # will override this by setting it later.
 
     archflags = os.environ.get("ARCHFLAGS")
     if archflags is not None:

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -564,6 +564,10 @@ def setup(  # noqa: C901
                 machine = cmake_arg.split("=")[1]
                 if set(machine.split(";")) == {"x86_64", "arm64"}:
                     machine = "universal2"
+            elif "CMAKE_SYSTEM_PROCESSOR" in cmake_arg:
+                machine = cmake_arg.split("=")[1]
+
+        assert machine in {"x86_64", "arm64", "universal2"}, f"macOS arch {machine} not understood"
 
         set_skbuild_plat_name(f"macosx-{version}-{machine}")
 

--- a/tests/test_issue342_cmake_osx_args_in_setup.py
+++ b/tests/test_issue342_cmake_osx_args_in_setup.py
@@ -135,6 +135,7 @@ def test_cmake_args_keyword_osx_default(
     cli_cmake_args,
     expected_cmake_osx_deployment_target,
     mocker,
+    monkeypatch,
 ):
 
     tmp_dir = _tmpdir("cmake_args_keyword_osx_default")
@@ -166,28 +167,15 @@ def test_cmake_args_keyword_osx_default(
 
     mock_configure = mocker.patch("skbuild.cmaker.CMaker.configure", side_effect=RuntimeError("exit skbuild"))
 
-    try:
-        # allow to run the test on any platform
-        saved_platform = sys.platform
-        sys.platform = "darwin"
+    monkeypatch.setattr(platform, "mac_ver", lambda: ("10.9", None, "x84_64"))
+    monkeypatch.setattr(platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(sys, "platform", "darwin")
 
-        def mock_mac_ver():
-            return "10.9", None, "x84_64"
-
-        saved_mac_ver = platform.mac_ver
-        platform.mac_ver = mock_mac_ver
-
-        saved_SKBUILD_PLAT_NAME = skbuild.constants._SKBUILD_PLAT_NAME
-
-        with push_env(MACOSX_DEPLOYMENT_TARGET=osx_deployment_target_env_var):
-            skbuild.constants._SKBUILD_PLAT_NAME = skbuild.constants._default_skbuild_plat_name()
-            with pytest.raises(RuntimeError, match="exit skbuild"):
-                with execute_setup_py(tmp_dir, ["build"] + cli_setup_args + ["--"] + cli_cmake_args):
-                    pass
-    finally:
-        sys.platform = saved_platform
-        platform.mac_ver = saved_mac_ver
-        skbuild.constants._SKBUILD_PLAT_NAME = saved_SKBUILD_PLAT_NAME
+    with push_env(MACOSX_DEPLOYMENT_TARGET=osx_deployment_target_env_var):
+        monkeypatch.setattr(skbuild.constants, "_SKBUILD_PLAT_NAME", skbuild.constants._default_skbuild_plat_name())
+        with pytest.raises(RuntimeError, match="exit skbuild"):
+            with execute_setup_py(tmp_dir, ["build"] + cli_setup_args + ["--"] + cli_cmake_args):
+                pass
 
     assert mock_configure.call_count == 1
 


### PR DESCRIPTION
Should fix https://github.com/conda-forge/frictionqpotspringblock-feedstock/pull/51 hopefully. Hard to test without deploying it or applying this as a patch to the scikit-build feedstock.
