### PR TITLE
chore: move isort to using Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,16 +34,11 @@ repos:
     additional_dependencies:
     - black==23.1.0 # keep in sync with black hook
 
-- repo: https://github.com/PyCQA/isort
-  rev: "5.12.0"
-  hooks:
-  - id: isort
-
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.0.246
+  rev: v0.0.248
   hooks:
   - id: ruff
-    args: ["--fix"]
+    args: ["--fix", "--show-fixes"]
 
 - repo: https://github.com/codespell-project/codespell
   rev: "v2.2.2"
@@ -67,7 +62,7 @@ repos:
     additional_dependencies: ["setuptools_scm[toml]"]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: "v1.0.0"
+  rev: "v1.0.1"
   hooks:
   - id: mypy
     files: ^skbuild

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,6 @@ ignore = [
 line-length = 120
 
 
-[tool.isort]
-profile = "black"
-known_third_party = ["distutils"]
-force_to_top = ["setuptools"]
-
-
 [tool.mypy]
 files = ["skbuild"]
 python_version = "3.6"
@@ -126,6 +120,8 @@ src = ["src"]
 unfixable = ["T20", "F841"]
 exclude = []
 flake8-unused-arguments.ignore-variadic-names = true
+isort.known-third-party = ["distutils"]
+isort.force-to-top = ["setuptools"]
 
 [tool.ruff.per-file-ignores]
 "tests/**" = ["T20"]


### PR DESCRIPTION
Ruff now supports `force-to-top`.
