### PR TITLE
Provide more useful error if user provides CMAKE_INSTALL_PREFIX

### DIFF
--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -18,7 +18,6 @@ import shlex
 import subprocess
 import sys
 import sysconfig
-import warnings
 from pathlib import Path
 from shlex import quote
 from typing import Mapping, Sequence, overload
@@ -317,15 +316,8 @@ class CMaker:
             if any("CMAKE_INSTALL_PREFIX" in arg for arg in env_cmake_args):
                 raise ValueError("CMAKE_INSTALL_PREFIX may not be passed via SKBUILD_CONFIGURE_OPTIONS.")
         else:
-            env_cmake_args_filtered = list(filter(None, shlex.split(os.environ.get("CMAKE_ARGS", ""))))
+            env_cmake_args_filtered = filter(None, shlex.split(os.environ.get("CMAKE_ARGS", "")))
             env_cmake_args = [s for s in env_cmake_args_filtered if "CMAKE_INSTALL_PREFIX" not in s]
-            # Don't error, only warn in this instance because CMAKE_ARGS may be out of
-            # the project's control (e.g. when provided by conda builds).
-            if len(env_cmake_args) < len(env_cmake_args_filtered):
-                warnings.warn(
-                    "CMAKE_INSTALL_PREFIX was passed via CMAKE_ARGS and ignored. This "
-                    "cmake option is ignored and should be removed."
-                )
 
         cmd.extend(env_cmake_args)
 

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -315,9 +315,7 @@ class CMaker:
         if "SKBUILD_CONFIGURE_OPTIONS" in os.environ:
             env_cmake_args = list(filter(None, shlex.split(os.environ["SKBUILD_CONFIGURE_OPTIONS"])))
             if any("CMAKE_INSTALL_PREFIX" in arg for arg in env_cmake_args):
-                raise ValueError(
-                    "CMAKE_INSTALL_PREFIX may not be passed via SKBUILD_CONFIGURE_OPTIONS."
-                )
+                raise ValueError("CMAKE_INSTALL_PREFIX may not be passed via SKBUILD_CONFIGURE_OPTIONS.")
         else:
             env_cmake_args_filtered = list(filter(None, shlex.split(os.environ.get("CMAKE_ARGS", ""))))
             env_cmake_args = [s for s in env_cmake_args_filtered if "CMAKE_INSTALL_PREFIX" not in s]

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -18,6 +18,7 @@ import shlex
 import subprocess
 import sys
 import sysconfig
+import warnings
 from pathlib import Path
 from shlex import quote
 from typing import Mapping, Sequence, overload
@@ -313,9 +314,20 @@ class CMaker:
         # Parse CMAKE_ARGS only if SKBUILD_CONFIGURE_OPTIONS is not present
         if "SKBUILD_CONFIGURE_OPTIONS" in os.environ:
             env_cmake_args = list(filter(None, shlex.split(os.environ["SKBUILD_CONFIGURE_OPTIONS"])))
+            if any("CMAKE_INSTALL_PREFIX" in arg for arg in env_cmake_args):
+                raise ValueError(
+                    "CMAKE_INSTALL_PREFIX may not be passed via SKBUILD_CONFIGURE_OPTIONS."
+                )
         else:
-            env_cmake_args_filtered = filter(None, shlex.split(os.environ.get("CMAKE_ARGS", "")))
+            env_cmake_args_filtered = list(filter(None, shlex.split(os.environ.get("CMAKE_ARGS", ""))))
             env_cmake_args = [s for s in env_cmake_args_filtered if "CMAKE_INSTALL_PREFIX" not in s]
+            # Don't error, only warn in this instance because CMAKE_ARGS may be out of
+            # the project's control (e.g. when provided by conda builds).
+            if len(env_cmake_args) < len(env_cmake_args_filtered):
+                warnings.warn(
+                    "CMAKE_INSTALL_PREFIX was passed via CMAKE_ARGS and ignored. This "
+                    "cmake option is ignored and should be removed."
+                )
 
         cmd.extend(env_cmake_args)
 

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -399,6 +399,14 @@ def setup(
                 kw["package_dir"][package] = prefix[:-1]
 
     sys.argv, cmake_executable, skip_generator_test, cmake_args_from_args, make_args = parse_args()
+    if any("CMAKE_INSTALL_PREFIX" in arg for arg in cmake_args_from_args):
+        raise ValueError(
+            "CMAKE_INSTALL_PREFIX may not be passed to the scikit-build CLI."
+        )
+    if any("CMAKE_INSTALL_PREFIX" in arg for arg in cmake_args):
+        raise ValueError(
+            "CMAKE_INSTALL_PREFIX may not be passed via cmake_args to setup."
+        )
 
     # work around https://bugs.python.org/issue1011113
     # (patches provided, but no updates since 2014)
@@ -419,7 +427,6 @@ def setup(
     )
     cmdclass["test"] = cmdclass.get("test", test.test)
     kw["cmdclass"] = cmdclass
-    breakpoint()
 
     # Extract setup keywords specific to scikit-build and remove them from kw.
     # Removing the keyword from kw need to be done here otherwise, the

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -400,13 +400,9 @@ def setup(
 
     sys.argv, cmake_executable, skip_generator_test, cmake_args_from_args, make_args = parse_args()
     if any("CMAKE_INSTALL_PREFIX" in arg for arg in cmake_args_from_args):
-        raise ValueError(
-            "CMAKE_INSTALL_PREFIX may not be passed to the scikit-build CLI."
-        )
+        raise ValueError("CMAKE_INSTALL_PREFIX may not be passed to the scikit-build CLI.")
     if any("CMAKE_INSTALL_PREFIX" in arg for arg in cmake_args):
-        raise ValueError(
-            "CMAKE_INSTALL_PREFIX may not be passed via cmake_args to setup."
-        )
+        raise ValueError("CMAKE_INSTALL_PREFIX may not be passed via cmake_args to setup.")
 
     # work around https://bugs.python.org/issue1011113
     # (patches provided, but no updates since 2014)

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -419,6 +419,7 @@ def setup(
     )
     cmdclass["test"] = cmdclass.get("test", test.test)
     kw["cmdclass"] = cmdclass
+    breakpoint()
 
     # Extract setup keywords specific to scikit-build and remove them from kw.
     # Removing the keyword from kw need to be done here otherwise, the


### PR DESCRIPTION
Resolves #721. I did not bother to add testing since this is just a helping the user understand an invalid edge case (and given the overall thrust towards scikit-build-core migration anyway).