### PR TITLE
Match setuptools behavior for include_package_data default.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,4 +67,4 @@ repos:
   - id: mypy
     files: ^skbuild
     args: []
-    additional_dependencies: ["types-setuptools", "packaging", "cmake", "ninja"]
+    additional_dependencies: ["types-setuptools", "packaging", "cmake", "ninja", "tomli"]

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -115,7 +115,9 @@ be placed in ``setup.cfg`` as normal.
 
 - ``include_package_data``: If set to ``True``, this tells setuptools to automatically include any data files it finds
   inside your package directories that are specified by your ``MANIFEST.in`` file. For more information, see the setuptools
-  documentation section on `Including Data Files`_.
+  documentation section on `Including Data Files`_. scikit-build matches
+  `the setuptools behavior <https://setuptools.pypa.io/en/latest/history.html#id255>`__ of defaulting this parameter to
+  ``True`` if a pyproject.toml file exists and contains either the ``project`` or ``tool.setuptools`` table.
 
 - ``package_data``: A dictionary mapping package names to lists of glob patterns. For a complete description and examples,
   see the setuptools documentation section on `Including Data Files`_.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -139,7 +139,9 @@ be placed in ``setup.cfg`` as normal.
 - ``entry_points``: A dictionary mapping entry point group names to strings or lists of strings defining the entry points.
   Entry points are used to support dynamic discovery of services or plugins provided by a project.
   See `Dynamic Discovery of Services and Plugins`_ for details and examples of the format of this argument. In addition,
-  this keyword is used to support `Automatic Script Creation`_.
+  this keyword is used to support `Automatic Script Creation`_. Note that if using ``pyproject.toml`` for configuration,
+  the requirement to put ``entry_points`` in ``setup.py`` also requires that the ``project`` section include ``entry_points``
+  in the ``dynamic`` section.
 
 - ``scripts``: List of python script relative paths. If the first line of the script starts with ``#!`` and contains the
   word ``python``, the Distutils will adjust the first line to refer to the current interpreter location.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,12 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "distro",
-    "packaging",
-    "setuptools>=42.0.0",
-    "typing-extensions>=3.7; python_version < \"3.8\"",
-    "wheel>=0.32.0",
+    'distro',
+    'packaging',
+    'setuptools>=42.0.0',
+    'tomli; python_version<"3.11"',
+    'typing-extensions>=3.7; python_version<"3.8"',
+    'wheel>=0.32.0',
 ]
 
 [project.optional-dependencies]
@@ -49,18 +50,18 @@ docs = [
     "sphinxcontrib-moderncmakedomain>=3.19",
 ]
 doctest = [
-    "ubelt >= 0.8.2",
+    "ubelt>=0.8.2",
     "xdoctest>=0.10.0",
 ]
 test = [
-    "build>=0.7",
-    "cython>=0.25.1",
-    "importlib-metadata;python_version<\"3.8\"",
-    "pytest-mock>=1.10.4",
-    "pytest-virtualenv>=1.2.5",
-    "pytest>=6.0.0",
-    "requests",
-    "virtualenv",
+    'build>=0.7',
+    'cython>=0.25.1',
+    'importlib-metadata;python_version<"3.8"',
+    'pytest-mock>=1.10.4',
+    'pytest-virtualenv>=1.2.5',
+    'pytest>=6.0.0',
+    'requests',
+    'virtualenv',
 ]
 
 [project.urls]

--- a/skbuild/_compat/tomllib.py
+++ b/skbuild/_compat/tomllib.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import sys
+
+if sys.version_info >= (3, 11):
+    from tomllib import load
+else:
+    from tomli import load
+
+__all__ = ["load"]

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -674,7 +674,20 @@ def setup(
     )
 
     original_manifestin_data_files = []
-    if kw.get("include_package_data", False):
+
+    def get_default_include_package_data():
+        # Include package data if pyproject.toml contains the project or tool.setuptools table.
+        # https://setuptools.pypa.io/en/latest/history.html#id255
+        # https://github.com/pypa/setuptools/pull/3067
+        pyproject_file = os.path.join(os.getcwd(), "pyproject.toml")
+        if os.path.isfile(pyproject_file):
+            with open(pyproject_file) as f:
+                text = f.read()
+                if "[project]" in text or "[tool.setuptools]" in text:
+                    return True
+        return False
+
+    if kw.get("include_package_data", get_default_include_package_data()):
         original_manifestin_data_files = parse_manifestin(os.path.join(os.getcwd(), "MANIFEST.in"))
         for path in original_manifestin_data_files:
             _classify_file(

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -27,6 +27,7 @@ from packaging.version import parse as parse_version
 from setuptools.dist import Distribution as upstream_Distribution
 
 from . import cmaker
+from ._compat import tomllib
 from .command import (
     bdist,
     bdist_wheel,
@@ -365,6 +366,19 @@ def _load_cmake_spec() -> Any:
     return None
 
 
+def get_default_include_package_data() -> bool:
+    # Include package data if pyproject.toml contains the project or tool.setuptools table.
+    # https://setuptools.pypa.io/en/latest/history.html#id255
+    # https://github.com/pypa/setuptools/pull/3067
+    pyproject_file = os.path.join(os.getcwd(), "pyproject.toml")
+    try:
+        with open(pyproject_file, "rb") as f:
+            pyproject = tomllib.load(f)
+        return "project" in pyproject or "setuptools" in pyproject.get("tool", {})
+    except FileNotFoundError:
+        return False
+
+
 # pylint:disable=too-many-locals, too-many-branches
 def setup(
     *,
@@ -674,18 +688,6 @@ def setup(
     )
 
     original_manifestin_data_files = []
-
-    def get_default_include_package_data() -> bool:
-        # Include package data if pyproject.toml contains the project or tool.setuptools table.
-        # https://setuptools.pypa.io/en/latest/history.html#id255
-        # https://github.com/pypa/setuptools/pull/3067
-        pyproject_file = os.path.join(os.getcwd(), "pyproject.toml")
-        if os.path.isfile(pyproject_file):
-            with open(pyproject_file) as f:
-                text = f.read()
-                if "[project]" in text or "[tool.setuptools]" in text:
-                    return True
-        return False
 
     if kw.get("include_package_data", get_default_include_package_data()):
         original_manifestin_data_files = parse_manifestin(os.path.join(os.getcwd(), "MANIFEST.in"))

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -675,7 +675,7 @@ def setup(
 
     original_manifestin_data_files = []
 
-    def get_default_include_package_data():
+    def get_default_include_package_data() -> bool:
         # Include package data if pyproject.toml contains the project or tool.setuptools table.
         # https://setuptools.pypa.io/en/latest/history.html#id255
         # https://github.com/pypa/setuptools/pull/3067


### PR DESCRIPTION
This PR attempts to match the default behavior of `include_package_data` in setuptools, which is somewhat subtle in that the default is dependent on the existence of certain tables in pyproject.toml.

Resolves #864.