### PR TITLE
fix: detect PyPy library correctly on Windows (#701)

### DIFF
--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -528,8 +528,8 @@ class CMaker:
 
             candidate_suffixes = [""]
             candidate_implementations = ["python"]
-            if hasattr(sys, "pypy_version_info"):
-                candidate_implementations += ["pypy-c", "pypy3-c", "pypy"]
+            if sys.implementation.name == "pypy":
+                candidate_implementations[:0] = ["pypy-c", "pypy3-c", "pypy"]
                 candidate_suffixes.append("-c")
 
             candidate_extensions = [".lib", ".so", ".a"]

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -529,7 +529,7 @@ class CMaker:
             candidate_suffixes = [""]
             candidate_implementations = ["python"]
             if hasattr(sys, "pypy_version_info"):
-                candidate_implementations = ["pypy-c", "pypy3-c", "pypy"]
+                candidate_implementations += ["pypy-c", "pypy3-c", "pypy"]
                 candidate_suffixes.append("-c")
 
             candidate_extensions = [".lib", ".so", ".a"]


### PR DESCRIPTION
On Windows the name of the PyPy import library is pythonXY.lib. For some reason (Linux?) existing code overwrote 'python' stem guess with ["pypy-c", "pypy3-c", "pypy"] instead of appending.

Testing: existing tests **already cover this** in `tests/test_cmaker.py::test_get_python_library`. However PyPy tests aren't run on Windows on Github, only on Linux. I assume this is why this issue wasn't detected by tests.

To test "install" PyPy (e.g. unpack it) on Windows in folder of your choice and then do

```cmd
nox -s tests --force-python c:\<path_where_you_unpacked_pypy>\python3.exe -- -k test_get_python_library
```

resolves #701