### PR TITLE
Fix cross-compiling Windows ARM64

### DIFF
--- a/skbuild/platform_specifics/windows.py
+++ b/skbuild/platform_specifics/windows.py
@@ -140,12 +140,7 @@ class CMakeVisualStudioIDEGenerator(CMakeGenerator):
         """
         vs_version = VS_YEAR_TO_VERSION[year]
         vs_base = f"Visual Studio {vs_version} {year}"
-        if platform.machine() == "ARM64":
-            vs_arch = "ARM64"
-        elif platform.architecture()[0] == "64bit":
-            vs_arch = "x64"
-        else:
-            vs_arch = "Win32"
+        vs_arch = _compute_arch()
         super().__init__(vs_base, toolset=toolset, arch=vs_arch)
 
 


### PR DESCRIPTION
The code that creates the `default_generators` for Visual Studio generators was using the host architecture instead of the target architecture when cross-compiling so finding the compiler would fail.

This reuses the existing helper function to get the architecture for the candidate generators.