### PR TITLE
fix: empty MACOSX variable should be treated as unset

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,7 @@ Bug fixes
 * Fix logic for default generator when cross-compiling for ARM on Windows in :pr:`917` by :user:`dlech`.
 * Use f2py's ``get_include`` if present in :pr:`877`
 * Fix support for cross-compilation exception using ``targetLinkLibrariesWithDynamicLookup`` by :user:`erykoff` in :pr:`901`
+* Treat empty ``MACOSX_DEPLOYMENT_TARGET`` as if it was unset in :pr:`918`.
 
 Testing
 -------

--- a/skbuild/constants.py
+++ b/skbuild/constants.py
@@ -62,7 +62,7 @@ def _default_skbuild_plat_name() -> str:
     # Note that on macOS, distutils.util.get_platform() is not used because
     # it returns the macOS version on which Python was built which may be
     # significantly older than the user's current machine.
-    release = os.environ.get("MACOSX_DEPLOYMENT_TARGET", release)
+    release = os.environ.get("MACOSX_DEPLOYMENT_TARGET", "") or release
     major_macos, minor_macos = release.split(".")[:2]
 
     # On macOS 11+, only the major version matters.


### PR DESCRIPTION
If possible, an empty variable should behave like an unset one. This might help with #911, depending on what caused that.
