### PR TITLE
tests: update for setuptools explicit package listing requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,6 @@ filterwarnings = [
   'ignore:.*ends with a trailing slash, which is not supported by setuptools:FutureWarning',
   "ignore:Config variable 'Py_DEBUG' is unset:RuntimeWarning",
   "ignore:Config variable 'WITH_PYMALLOC' is unset, Python ABI tag may be incorrect:RuntimeWarning",
-  'default:\s*Installing .* as data is deprecated:Warning',
   'default:shell/Perl-style subs.* are deprecated:DeprecationWarning',
   'default:subprocess .* is still running:ResourceWarning',
   'ignore: pkg_resources is deprecated as an API:DeprecationWarning',

--- a/tests/samples/test-include-exclude-data-with-base/setup.py
+++ b/tests/samples/test-include-exclude-data-with-base/setup.py
@@ -6,13 +6,17 @@ setup(
     name="test_include_exclude_data_with_base",
     version="0.1.0",
     cmake_languages=(),
-    packages=["hello", "hello2"],
+    packages=["hello", "hello2", "hello.data.subdata", "hello2.data2.subdata2"],
     package_dir={"": "src"},
     include_package_data=True,
     exclude_package_data={
-        "": [
-            "*/*/*_data4_include_from_manifest_and_exclude_from_setup.txt",
-            "*/*/*_data4_cmake_generated_and_exclude_from_setup.txt",
-        ]
+        "hello.data.subdata": [
+            "*_data4_cmake_generated_and_exclude_from_setup.txt",
+            "*data4_include_from_manifest_and_exclude_from_setup.txt",
+        ],
+        "hello2.data2.subdata2": [
+            "*_data4_cmake_generated_and_exclude_from_setup.txt",
+            "*_data4_include_from_manifest_and_exclude_from_setup.txt",
+        ],
     },
 )

--- a/tests/samples/test-include-exclude-data/setup.py
+++ b/tests/samples/test-include-exclude-data/setup.py
@@ -6,12 +6,16 @@ setup(
     name="test_include_exclude_data",
     version="0.1.0",
     cmake_languages=(),
-    packages=["hello", "hello2"],
+    packages=["hello", "hello2", "hello.data.subdata", "hello2.data2.subdata2"],
     include_package_data=True,
     exclude_package_data={
-        "": [
-            "*/*/*_data4_include_from_manifest_and_exclude_from_setup.txt",
-            "*/*/*_data4_cmake_generated_and_exclude_from_setup.txt",
-        ]
+        "hello.data.subdata": [
+            "*_data4_cmake_generated_and_exclude_from_setup.txt",
+            "*data4_include_from_manifest_and_exclude_from_setup.txt",
+        ],
+        "hello2.data2.subdata2": [
+            "*_data4_cmake_generated_and_exclude_from_setup.txt",
+            "*_data4_include_from_manifest_and_exclude_from_setup.txt",
+        ],
     },
 )


### PR DESCRIPTION
Removes one warning (seen in our tests & #753), previously just ignored.
