### PR TITLE
fix: codecov ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,21 +67,28 @@ jobs:
     # We check minimum Python and maximum Python on all OS's.
 
     - name: Test on 🐍 3.7
-      run: nox -s tests-3.7
+      run: nox -s tests-3.7 -- --cov --cov-report=xml --cov-report=term
     - name: Test on 🐍 3.8
       if: runner.os == 'Linux'
-      run: nox -s tests-3.8
+      run: nox -s tests-3.8 -- --cov --cov-report=xml --cov-report=term --cov-append
     - name: Test on 🐍 3.9
       if: runner.os == 'Linux'
-      run: nox -s tests-3.9
+      run: nox -s tests-3.9 -- --cov --cov-report=xml --cov-report=term --cov-append
     - name: Test on 🐍 3.10
-      run: nox -s tests-3.10
       if: runner.os == 'Linux'
+      run: nox -s tests-3.10 -- --cov --cov-report=xml --cov-report=term --cov-append
     - name: Test on 🐍 3.11
-      run: nox -s tests-3.11
+      run: nox -s tests-3.11 -- --cov --cov-report=xml --cov-report=term --cov-append
     - name: Test on 🐍 3.12
-      run: nox -s tests-3.12
+      run: nox -s tests-3.12 -- --cov --cov-report=xml --cov-report=term --cov-append
       if: runner.os == 'Linux'
+
+    - name: Upload coverage report
+      uses: codecov/codecov-action@v3
+      with:
+        name: ${{ matrix.runs-on }}-any
+        verbose: true
+
 
   cygwin:
     name: Tests on 🐍 3.9 • cygwin
@@ -136,7 +143,7 @@ jobs:
         python-version: pypy-${{ matrix.pypy-version }}
 
     - name: Test on 🐍 PyPy ${{ matrix.pypy-version }}
-      run: nox -s tests-pypy${{ matrix.pypy-version }}
+      run: nox -s tests-pypy${{ matrix.pypy-version }} -- --cov --cov-report=xml --cov-report=term
 
     - name: Upload coverage report
       uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,12 @@ jobs:
     - name: Test on 🐍 PyPy ${{ matrix.pypy-version }}
       run: nox -s tests-pypy${{ matrix.pypy-version }}
 
+    - name: Upload coverage report
+      uses: codecov/codecov-action@v3
+      with:
+        name: ${{ runner.os }}-${{ matrix.pypy-version }}
+        verbose: true
+
 
   dist:
     name: Distribution

--- a/noxfile.py
+++ b/noxfile.py
@@ -28,7 +28,7 @@ def tests(session: nox.Session) -> None:
     """
     Run the tests.
     """
-    posargs = list(session.posargs) or ["--cov", "--cov-report=xml"]
+    posargs = list(session.posargs)
     env = os.environ.copy()
 
     # This should be handled via markers or some other pytest mechanism, but for now, this is usable.
@@ -41,10 +41,11 @@ def tests(session: nox.Session) -> None:
             env[f"SKBUILD_TEST_FIND_VS{version}_INSTALLATION_EXPECTED"] = contained
 
     numpy = [] if "pypy" in session.python or "3.12" in session.python else ["numpy"]
+    install_spec = ".[test,cov,doctest]" if "--cov" in posargs else ".[test,doctest]"
 
     # Latest versions may break things, so grab them for testing!
     session.install("-U", "setuptools", "wheel")
-    session.install("-e", ".[test,cov,doctest]", *numpy)
+    session.install("-e", install_spec, *numpy)
     session.run("pytest", *posargs, env=env)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
 
 [project.optional-dependencies]
 cov = [
-    "codecov>=2.0.5",
     "coverage>=4.2",
     "pytest-cov>=2.7.1",
 ]


### PR DESCRIPTION
Codecov package has been [removed](https://github.com/codecov/codecov-python), use github action instead. Please fix the CI as needed.
- There are no coverage for `main` because the default branch changed :shrug:
- Should the tests be tagged according to the os and python version?