### PR TITLE
fix: remove unused var warning

### DIFF
--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -275,6 +275,7 @@ class CMaker:
             cmake_source_dir,
             "-G",
             generator.name,
+            "--no-warn-unused-cli",
             f"-DCMAKE_INSTALL_PREFIX:PATH={cmake_install_prefix}",
             f"-DPYTHON_VERSION_STRING:STRING={python_version_string}",
             "-DSKBUILD:INTERNAL=TRUE",

--- a/tests/test_cmaker.py
+++ b/tests/test_cmaker.py
@@ -187,35 +187,6 @@ def test_make_with_install_target(install_target, capfd):
 def test_configure_with_cmake_args(capfd):
     tmp_dir = _tmpdir("test_configure_with_cmake_args")
     with push_dir(str(tmp_dir)):
-        unused_vars = [
-            "CMAKE_EXPECTED_BAR",
-            "CMAKE_EXPECTED_FOO",
-            "PYTHON_VERSION_STRING",
-            "SKBUILD",
-            "PYTHON_EXECUTABLE",
-            "PYTHON_INCLUDE_DIR",
-            "PYTHON_LIBRARY",
-        ]
-
-        for prefix in ["Python3", "Python"]:
-            unused_vars.extend(
-                [
-                    f"{prefix}_EXECUTABLE",
-                    f"{prefix}_ROOT_DIR",
-                    f"{prefix}_INCLUDE_DIR",
-                    f"{prefix}_FIND_IMPLEMENTATIONS",
-                    f"{prefix}_FIND_REGISTRY",
-                    f"{prefix}_LIBRARY",
-                ]
-            )
-
-            try:
-                import numpy as np  # noqa: F401
-
-                unused_vars.append(prefix + "_NumPy_INCLUDE_DIRS")
-            except ImportError:
-                pass
-
         tmp_dir.join("CMakeLists.txt").write(
             textwrap.dedent(
                 """
@@ -223,12 +194,8 @@ def test_configure_with_cmake_args(capfd):
             project(foobar NONE)
             # Do not complain about missing arguments passed to the main
             # project
-            foreach(unused_var IN ITEMS
-            {}
-              )
-            endforeach()
             """
-            ).format("\n".join(f"  ${{{unused}}}" for unused in unused_vars))
+            )
         )
 
         with push_dir(str(tmp_dir)):

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -100,20 +100,6 @@ def test_too_many_separators():
         assert failed
 
 
-@project_setup_py_test("hello-no-language", ["build", "--", "-DMY_CMAKE_VARIABLE:BOOL=1"], disable_languages_test=True)
-def test_cmake_args(capfd):
-    out, err = capfd.readouterr()
-    assert "Manually-specified variables were not used by the project" in err
-    assert "MY_CMAKE_VARIABLE" in err
-
-
-@project_setup_py_test("hello-no-language", ["-DMY_CMAKE_VARIABLE:BOOL=1", "build"], disable_languages_test=True)
-def test_cmake_cache_entry_as_global_option(capfd):
-    out, err = capfd.readouterr()
-    assert "Manually-specified variables were not used by the project" in err
-    assert "MY_CMAKE_VARIABLE" in err
-
-
 def test_cmake_initial_cache_as_global_option(tmpdir):
     project = "hello-no-language"
     prepare_project(project, tmpdir)


### PR DESCRIPTION
There will always be unused vars, so we could just hide them all. CMAKE_PREFIX_DIRS, in scikit-build-core, is causing this used variable message, and is hard to integrate with the config init method we use there, so experimenting with just removing all of them. Though, there, I do see a mention of "FORCE" in the docs for `-C`, so that's encouraging!
