### PR TITLE
fix: Rpm spec

### DIFF
--- a/.distro/scikit-build.spec
+++ b/.distro/scikit-build.spec
@@ -1,3 +1,5 @@
+%global pypi_name scikit_build
+
 Name:           python-scikit-build
 Version:        0.0.0
 Release:        %{autorelease}
@@ -8,7 +10,8 @@ Summary:        Improved build system generator for Python C/C++/Fortran/Cython 
 # All bundled(cmake()) files listed are Apache-2.0 licensed.
 License:        MIT AND BSD-2-Clause-Views AND Apache-2.0
 URL:            https://github.com/scikit-build/scikit-build
-Source:         %{pypi_source scikit-build}
+Source0:        %{pypi_source %{pypi_name}}
+Source1:        %{name}.rpmlintrc
 
 BuildArch:      noarch
 BuildRequires:  python3-devel
@@ -52,7 +55,7 @@ Provides:       bundled(cmake(UsePythonExtensions))
 
 
 %prep
-%autosetup -p1 -n scikit-build-%{version}
+%autosetup -n %{pypi_name}-%{version}
 
 
 %generate_buildrequires

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -44,8 +44,11 @@ jobs:
   - job: propose_downstream
     trigger: release
     dist_git_branches:
-      - fedora-development
-      - fedora-latest
+      # TODO: Switch to fedora-development and fedora-latest
+      # There is an issue that the commits diverge on different PRs. In the meantime will create PRs on branched fedora
+      # manually
+      # https://github.com/packit/packit/issues/1724
+      - fedora-rawhide
   - job: koji_build
     trigger: commit
     dist_git_branches:


### PR DESCRIPTION
%pypi_name was incorrect

Caught this because it failed to make a PR downstream. I will edit downstream as well, so no need for a new release for this.