### PR TITLE
fix: Don't set Python_LIBRARY when using venv

### DIFF
--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -504,6 +504,12 @@ class CMaker:
                 minor = sys.version_info[1]
                 return str(Path(result) / f"python3{minor}.lib")
 
+        # If we are in a virtualenv, then the library path won't be available.
+        # The virtualenv overrides config vars like LIBDIR so this check needs
+        # to be before the checks below.
+        if os.environ.get("VIRTUAL_ENV"):
+            return None
+
         # This seems to be the simplest way to detect the library path with
         # modern python versions that avoids the complicated construct below.
         # It avoids guessing the library name. Tested with cpython 3.8 and


### PR DESCRIPTION
If scikit-build is running in a virtual environment, then the path to libpython is not available. The virtual environment does not copy this file and it overrides sysconfig variables so we can no longer find the original location of the library.

Fixes: https://github.com/scikit-build/scikit-build/issues/940