### PR TITLE
fix: validate value before returning library path

### DIFF
--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -602,10 +602,7 @@ class CMaker:
                     python_library = candidate
                     break
 
-        if python_library and not os.path.exists(python_library):
-            return None
-
-        return python_library
+        return python_library if os.path.exists(python_library) else None
 
     @staticmethod
     def check_for_bad_installs() -> None:

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -602,7 +602,8 @@ class CMaker:
                     python_library = candidate
                     break
 
-        # TODO(opadron): what happens if we don't find a libpython?
+        if python_library and not os.path.exists(python_library):
+            return None
 
         return python_library
 

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -602,7 +602,7 @@ class CMaker:
                     python_library = candidate
                     break
 
-        return python_library if os.path.exists(python_library) else None
+        return python_library if python_library and os.path.exists(python_library) else None
 
     @staticmethod
     def check_for_bad_installs() -> None:


### PR DESCRIPTION
In CMaker._guess_python_library(), there is a path where python_library can be set to a file name without a path. For example, this happens when using a venv in a MinGW envronment on Windows. This gets passed to CMake via Python_LIBRARY which causes CMake to fail.

To fix it, we validate that the path exists on disk before returning the value or return None if it does not exist.
