### PR TITLE
fix: only add Python_LIBRARY on Windows

### DIFF
--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -297,9 +297,7 @@ class CMaker:
             )
             if python_include_dir:
                 cmd.append(f"{prefix}_INCLUDE_DIR:PATH={python_include_dir}")
-            if python_library and (
-                sys.platform.startswith("win") or tuple(int(x) for x in self.cmake_version.split(".")[:2]) >= (3, 24)
-            ):
+            if python_library and sys.platform.startswith("win"):
                 cmd.append(f"{prefix}_LIBRARY:PATH={python_library}")
             if sys.implementation.name == "pypy":
                 cmd.append(f"{prefix}_FIND_IMPLEMENTATIONS:STRING=PyPy")


### PR DESCRIPTION
Pretty sure this is needed also given https://github.com/scikit-build/scikit-build-core/issues/283. Ideally this needs to be fixed upstream.