### PR TITLE
fix: only add Python_LIBRARY on Windows MSVC

### DIFF
--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -297,7 +297,7 @@ class CMaker:
             )
             if python_include_dir:
                 cmd.append(f"{prefix}_INCLUDE_DIR:PATH={python_include_dir}")
-            if python_library and sys.platform.startswith("win"):
+            if python_library and sysconfig.get_platform().startswith("win"):
                 cmd.append(f"{prefix}_LIBRARY:PATH={python_library}")
             if sys.implementation.name == "pypy":
                 cmd.append(f"{prefix}_FIND_IMPLEMENTATIONS:STRING=PyPy")

--- a/skbuild/constants.py
+++ b/skbuild/constants.py
@@ -43,7 +43,7 @@ def _default_skbuild_plat_name() -> str:
 
     On macOS, it corresponds to the version and machine associated with :func:`platform.mac_ver()`.
     """
-    if sys.platform != "darwin":
+    if not sys.platform.startswith("darwin"):
         return get_platform()
 
     supported_macos_architectures = {"x86_64", "arm64"}


### PR DESCRIPTION
I think this will fix #940.
