### PR TITLE
fix: slightly nicer traceback for failed compiler

### DIFF
--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -637,17 +637,16 @@ class CMaker:
                         bad_installs.append(os.path.join(destination, os.path.basename(match.group(2))))
 
         if bad_installs:
-            raise SKBuildError(
-                "\n".join(
-                    (
-                        "  CMake-installed files must be within the project root.",
-                        "    Project Root:",
-                        "      " + install_dir,
-                        "    Violating Files:",
-                        "\n".join(("      " + _install) for _install in bad_installs),
-                    )
+            msg = "\n".join(
+                (
+                    "  CMake-installed files must be within the project root.",
+                    "    Project Root:",
+                    f"      {install_dir}",
+                    "    Violating Files:",
+                    "\n".join(f"      {_install}" for _install in bad_installs),
                 )
             )
+            raise SKBuildError(msg)
 
     def make(
         self,

--- a/skbuild/platform_specifics/abstract.py
+++ b/skbuild/platform_specifics/abstract.py
@@ -41,7 +41,7 @@ class CMakePlatform:
     @property
     def generator_installation_help(self) -> str:
         """Return message guiding the user for installing a valid toolchain."""
-        raise NotImplementedError  # pragma: no cover
+        raise NotImplementedError()  # pragma: no cover
 
     @staticmethod
     def write_test_cmakelist(languages: Iterable[str]) -> None:
@@ -169,20 +169,18 @@ class CMakePlatform:
             working_generator = self.compile_test_cmakelist(cmake_executable, candidate_generators, cmake_args)
 
         if working_generator is None:
-            raise SKBuildGeneratorNotFoundError(
-                textwrap.dedent(
-                    """
+            line = "*" * 80
+            installation_help = self.generator_installation_help
+            msg = textwrap.dedent(
+                f"""\
                 {line}
                 scikit-build could not get a working generator for your system. Aborting build.
 
                 {installation_help}
 
-                {line}
-                """
-                )
-                .strip()
-                .format(line="*" * 80, installation_help=self.generator_installation_help)
+                {line}"""
             )
+            raise SKBuildGeneratorNotFoundError(msg)
 
         if cleanup:
             CMakePlatform.cleanup_test()


### PR DESCRIPTION
Notice this in #945, we can clean this up a bit.

(Not sure what is happening there, but at least the error message can be simpler).
