### PR TITLE
fix: FindNumPy should call FindPythonLibs

### DIFF
--- a/skbuild/resources/cmake/FindNumPy.cmake
+++ b/skbuild/resources/cmake/FindNumPy.cmake
@@ -40,8 +40,6 @@ if(NOT NumPy_FOUND)
   if(NumPy_FIND_QUIET)
     list(APPEND _find_extra_args QUIET)
   endif()
-  find_package(PythonInterp ${_find_extra_args})
-  find_package(PythonLibs ${_find_extra_args})
 
   find_program(NumPy_CONV_TEMPLATE_EXECUTABLE NAMES conv-template)
   find_program(NumPy_FROM_TEMPLATE_EXECUTABLE NAMES from-template)


### PR DESCRIPTION
This should not be necessary. It should already be found, and even if not, PYTHON_EXECUTABLE is set and PYTHON_INCLUDE_DIR isn't important. I think this is causing #957, since you can't run FindPythonLibs REQUIRED on manylinux.