### PR TITLE
revert: keep return type string if python lib non-existing for now

### DIFF
--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -600,7 +600,12 @@ class CMaker:
                     python_library = candidate
                     break
 
-        return python_library if python_library and os.path.exists(python_library) else None
+        # Temporary workaround for some libraries (opencv) processing the
+        # string output.  Will return None instead of empty string in future
+        # versions if the library does not exist.
+        if python_library is None:
+            return None
+        return python_library if python_library and os.path.exists(python_library) else ""
 
     @staticmethod
     def check_for_bad_installs() -> None:


### PR DESCRIPTION
Suggested improvement for openCV. I think this should go back to returning None in 0.18, but this would help the perceived regression for OpenCV in 0.17.2. See #940.
