### PR TITLE
fix: avoid 'not found' warning if libs are not found

### DIFF
--- a/skbuild/resources/cmake/FindPythonExtensions.cmake
+++ b/skbuild/resources/cmake/FindPythonExtensions.cmake
@@ -245,7 +245,10 @@
 #=============================================================================
 
 find_package(PythonInterp REQUIRED)
-find_package(PythonLibs)
+# Only fill out libs if the Python libs were found by scikit-build
+if(PYTHON_LIBRARY)
+    find_package(PythonLibs)
+endif()
 include(targetLinkLibrariesWithDynamicLookup)
 
 set(_command "


### PR DESCRIPTION
Fixing one warning that can show up, mentioned in #959, simi-followup to #940.
