### PR TITLE
Revert "fix: avoid 'not found' warning if libs are not found (#960)"

### DIFF
--- a/skbuild/resources/cmake/FindPythonExtensions.cmake
+++ b/skbuild/resources/cmake/FindPythonExtensions.cmake
@@ -245,10 +245,7 @@
 #=============================================================================
 
 find_package(PythonInterp REQUIRED)
-# Only fill out libs if the Python libs were found by scikit-build
-if(PYTHON_LIBRARY)
-    find_package(PythonLibs)
-endif()
+find_package(PythonLibs)
 include(targetLinkLibrariesWithDynamicLookup)
 
 set(_command "


### PR DESCRIPTION
This reverts commit 8ee16a00986bad2d989fb64d786f949097479a6a.

This was to hide the warning, but `PYTHON_INCLUDE_DIRS` was not getting set from `PYTHON_INCLUDE_DIR`, and it caused breakages when used outside of SKBUILD. Fixes #963.
