### PR TITLE
fix: make sure include dir is found

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,15 +18,13 @@ and backport changes here.
 Scikit-build 0.17.4
 ===================
 
-Minor release reverting a warning hide change in 0.17.3 (:pr:`960`), since it
-could cause issues when using FindPythonExtensions outside of scikit-build and
-could cause the include directories variable to be unset. The warning is just
-going to be present in cases like manylinux builds.
+A followup fix to the issue 0.17.3 tried to fix. We now have a method to
+manually test downstream packages, too.
 
 Bug fixes
 ---------
 
-* Revert warning suppression :pr:`960` in :pr:`964`.
+* Make sure include dir is found even if the lib is not present in :pr:`974`.
 
 Scikit-build 0.17.3
 ===================

--- a/skbuild/resources/cmake/FindPythonExtensions.cmake
+++ b/skbuild/resources/cmake/FindPythonExtensions.cmake
@@ -168,8 +168,6 @@
 #
 # .. code-block:: cmake
 #
-#    find_package(PythonInterp)
-#    find_package(PythonLibs)
 #    find_package(PythonExtensions)
 #    find_package(Cython)
 #    find_package(Boost COMPONENTS python)
@@ -245,7 +243,14 @@
 #=============================================================================
 
 find_package(PythonInterp REQUIRED)
-find_package(PythonLibs)
+if(SKBUILD AND NOT PYTHON_LIBRARY)
+  set(PYTHON_LIBRARY "no-library-required")
+  find_package(PythonLibs)
+  unset(PYTHON_LIBRARY)
+  unset(PYTHON_LIBRARIES)
+else()
+  find_package(PythonLibs)
+endif()
 include(targetLinkLibrariesWithDynamicLookup)
 
 set(_command "


### PR DESCRIPTION
Adding a way to test downstream projects too.

Closes #957. Added a way to manually test a downstream package. The following work after this change:


```
docker run --rm -v $PWD:/sk -w /sk -t quay.io/pypa/manylinux2014_x86_64:latest pipx run --system-site-packages nox -s downstream -- https://github.com/Blosc/python-blosc2
docker run --rm -v $PWD:/sk -w /sk -t quay.io/pypa/manylinux2014_x86_64:latest pipx run --system-site-packages nox -s downstream -- https://github.com/glotzerlab/freud
```
