### PR TITLE
fix: generator args were missing for actual compile

### DIFF
--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -275,6 +275,7 @@ class CMaker:
             cmake_source_dir,
             "-G",
             generator.name,
+            *generator.args,
             "--no-warn-unused-cli",
             f"-DCMAKE_INSTALL_PREFIX:PATH={cmake_install_prefix}",
             f"-DPYTHON_VERSION_STRING:STRING={python_version_string}",


### PR DESCRIPTION
Fix last part of https://github.com/scikit-build/scikit-build/issues/755 - generator args were not propagated.
