### PR TITLE
tests: fix match for get_map symbol

### DIFF
--- a/tests/test_issue668_symbol_visibility.py
+++ b/tests/test_issue668_symbol_visibility.py
@@ -57,7 +57,7 @@ def test_symbol_visibility(skip_override):
             # Looking for entries associated with get_map
             # ex.     62: 0000000000001260   164 FUNC    GLOBAL DEFAULT   14 get_map\n
             # NOTE: We want to ignore get_map::id_to_resourse entries
-            if "get_map" in line and "get_map::" not in line:
+            if "get_map" in line.split():
                 print(line)
                 if skip_override == "ON":
                     assert "GLOBAL" in line


### PR DESCRIPTION
Wrong line could be matched by mistake, e.g.
    45: 0000000000010160     0 NOTYPE  LOCAL  DEFAULT   10 0000001a.plt_call.get_map