### PR TITLE
docs: prepare for 0.17.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,3 @@ skbuild/_version.py
 
 # pyenv
 .python-version
-
-# Scratch
-/tmp

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,9 @@ skbuild/_version.py
 /.distro/main.fmf
 /.distro/plans/main.fmf
 /.distro/tests/main.fmf
+
+# pyenv
+.python-version
+
+# Scratch
+/tmp

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,31 @@ and backport changes here.
 .. START-BRIEF-CHANGELOG
 
 
+Scikit-build 0.17.6
+===================
+
+A small fix release with some new platforms and better testing, including CPython 3.12.0b1.
+
+Bug fixes
+---------
+
+* Support added for SunOS by :user:`mtelka` in :pr:`983`.
+* Support added for AIX (with recent CMake) by :user:`bhuntsman` in :pr:`988`.
+
+Testing
+-------
+
+* Tests now pass on CPython 3.12.0b1 in :pr:`879`.
+* Tests no longer use ``pytest-virtualenv`` in :pr:`879`.
+* ``isolated`` marker now includes ``test_distribution`` tests in :pr:`879`.
+* Tests avoid incorrect ``get_map`` match by :user:`keszybz` in :pr:`990`.
+* Fedora testing fix by :user:`LecrisUT` in :pr:`986` and :pr:`938`.
+
+Miscellaneous
+-------------
+
+* Docs improvements in :pr:`979`.
+
 Scikit-build 0.17.5
 ===================
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -70,7 +70,7 @@ def docs(session):
     Build the docs. Use "-R" to rebuild faster. Check options with "-- -h".
     """
 
-    parser = argparse.ArgumentParser(prog=f"{os.path.basename(sys.argv[0])} -s docs")
+    parser = argparse.ArgumentParser(prog=f"{Path(sys.argv[0]).name} -s docs")
     parser.add_argument("--serve", action="store_true", help="Serve the docs")
     args = parser.parse_args(session.posargs)
 
@@ -125,12 +125,14 @@ def downstream(session: nox.Session) -> None:
     #       pipx run --system-site-packages nox -s downstream -- https://github.com/...
     # (requires tomli, so allowing access to system-site-packages)
 
+    parser = argparse.ArgumentParser(prog=f"{Path(sys.argv[0]).name} -s downstream")
+    parser.add_argument("path", help="Location to git clone from")
+    args, remaining = parser.parse_known_args(session.posargs)
+
     if sys.version_info < (3, 11):
         import tomli as tomllib
     else:
         import tomllib
-
-    assert session.posargs, "Must pass the downstream project to build"
 
     tmp_dir = Path(session.create_tmp())
     proj_dir = tmp_dir / "git"
@@ -142,7 +144,7 @@ def downstream(session: nox.Session) -> None:
         session.chdir(proj_dir)
         session.run("git", "pull", external=True)
     else:
-        session.run("git", "clone", *session.posargs, proj_dir, "--recurse-submodules", external=True)
+        session.run("git", "clone", args.path, *remaining, proj_dir, "--recurse-submodules", external=True)
         session.chdir(proj_dir)
 
     # Read and strip requirements


### PR DESCRIPTION
Main feature is 3.12.0b1 classifier, but also some new supported platforms.


- chore: nox nicer downstream
- chore: pyenv in gitignore
- docs: add changelog for 0.17.6
