### PR TITLE
ci: Fedora: Fix rsync filter rule

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -15,8 +15,8 @@ files_to_sync:
   - src: .distro/plans/
     dest: plans/
     filters:
-      - "- .distro/plans/main.fmf.dist-git"
-      - "- .distro/plans/rpmlint.fmf"
+      - "- main.fmf.dist-git"
+      - "- rpmlint.fmf"
   - src: .distro/plans/main.fmf.dist-git
     dest: plans/main.fmf
 upstream_package_name: scikit-build


### PR DESCRIPTION
Small hotfix