### PR TITLE
chore: target-version no longer needed by Black or Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,7 +218,6 @@ select = [
   "NPY",         # NumPy specific rules
 ]
 extend-ignore = ["PLR", "E501", "SIM117"]
-target-version = "py37"
 typing-modules = ["skbuild._compat.typing"]
 line-length = 120
 unfixable = ["T20", "F841"]


### PR DESCRIPTION
See https://github.com/scientific-python/cookie/issues/201.

Committed via https://github.com/asottile/all-repos