### PR TITLE
Avoid `PythonLibs` and `PythonInterp` due to CMP0148

### DIFF
--- a/skbuild/resources/cmake/FindPythonExtensions.cmake
+++ b/skbuild/resources/cmake/FindPythonExtensions.cmake
@@ -242,14 +242,14 @@
 # limitations under the License.
 #=============================================================================
 
-find_package(PythonInterp REQUIRED)
+find_package(Python COMPONENTS Interpreter)
 if(SKBUILD AND NOT PYTHON_LIBRARY)
   set(PYTHON_LIBRARY "no-library-required")
-  find_package(PythonLibs)
+  find_package(Python COMPONENTS Development)
   unset(PYTHON_LIBRARY)
   unset(PYTHON_LIBRARIES)
 else()
-  find_package(PythonLibs)
+  find_package(Python COMPONENTS Development)
 endif()
 include(targetLinkLibrariesWithDynamicLookup)
 
@@ -297,7 +297,7 @@ sys.stdout.write(\";\".join((
 )))
 ")
 
-execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c "${_command}"
+execute_process(COMMAND "${Python_EXECUTABLE}" -c "${_command}"
                 OUTPUT_VARIABLE _list
                 RESULT_VARIABLE _result)
 


### PR DESCRIPTION
This PR aims to avoid the use of `PythonLibs` and `PythonInterp` due to [CMP0148](https://cmake.org/cmake/help/latest/policy/CMP0148.html), which was introduced in CMake 3.27.

Closes #1018.