### PR TITLE
Remove usage of deprecated distutils in cmake files

### DIFF
--- a/skbuild/resources/cmake/FindNumPy.cmake
+++ b/skbuild/resources/cmake/FindNumPy.cmake
@@ -20,6 +20,17 @@
 #
 # ``NumPy_INCLUDE_DIR``
 #
+# .. note::
+#
+#     To support NumPy < v0.15.0 where ``from-template`` and ``conv-template`` are not declared as entry points,
+#     the module emulates the behavior of standalone executables by setting the corresponding variables with the
+#     path the the python interpreter and the path to the associated script. For example:
+#     ::
+#
+#         set(NumPy_CONV_TEMPLATE_EXECUTABLE /path/to/python /path/to/site-packages/numpy/distutils/conv_template.py CACHE STRING "Command executing conv-template program" FORCE)
+#
+#         set(NumPy_FROM_TEMPLATE_EXECUTABLE /path/to/python /path/to/site-packages/numpy/distutils/from_template.py CACHE STRING "Command executing from-template program" FORCE)
+#
 
 if(NOT NumPy_FOUND)
   set(_find_extra_args)
@@ -46,6 +57,28 @@ if(NOT NumPy_FOUND)
       OUTPUT_STRIP_TRAILING_WHITESPACE
       ERROR_QUIET
       )
+
+    # XXX This is required to support NumPy < v0.15.0. See note in module documentation above.
+    if(NOT NumPy_CONV_TEMPLATE_EXECUTABLE)
+      execute_process(COMMAND "${PYTHON_EXECUTABLE}"
+        -c "from numpy.distutils import conv_template; print(conv_template.__file__)"
+        OUTPUT_VARIABLE _numpy_conv_template_file
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        )
+      set(NumPy_CONV_TEMPLATE_EXECUTABLE "${PYTHON_EXECUTABLE}" "${_numpy_conv_template_file}" CACHE STRING "Command executing conv-template program" FORCE)
+    endif()
+
+    # XXX This is required to support NumPy < v0.15.0. See note in module documentation above.
+    if(NOT NumPy_FROM_TEMPLATE_EXECUTABLE)
+      execute_process(COMMAND "${PYTHON_EXECUTABLE}"
+        -c "from numpy.distutils import from_template; print(from_template.__file__)"
+        OUTPUT_VARIABLE _numpy_from_template_file
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        )
+      set(NumPy_FROM_TEMPLATE_EXECUTABLE "${PYTHON_EXECUTABLE}" "${_numpy_from_template_file}" CACHE STRING "Command executing from-template program" FORCE)
+    endif()
   endif()
 endif()
 

--- a/skbuild/resources/cmake/FindNumPy.cmake
+++ b/skbuild/resources/cmake/FindNumPy.cmake
@@ -20,17 +20,6 @@
 #
 # ``NumPy_INCLUDE_DIR``
 #
-# .. note::
-#
-#     To support NumPy < v0.15.0 where ``from-template`` and ``conv-template`` are not declared as entry points,
-#     the module emulates the behavior of standalone executables by setting the corresponding variables with the
-#     path the the python interpreter and the path to the associated script. For example:
-#     ::
-#
-#         set(NumPy_CONV_TEMPLATE_EXECUTABLE /path/to/python /path/to/site-packages/numpy/distutils/conv_template.py CACHE STRING "Command executing conv-template program" FORCE)
-#
-#         set(NumPy_FROM_TEMPLATE_EXECUTABLE /path/to/python /path/to/site-packages/numpy/distutils/from_template.py CACHE STRING "Command executing from-template program" FORCE)
-#
 
 if(NOT NumPy_FOUND)
   set(_find_extra_args)
@@ -57,28 +46,6 @@ if(NOT NumPy_FOUND)
       OUTPUT_STRIP_TRAILING_WHITESPACE
       ERROR_QUIET
       )
-
-    # XXX This is required to support NumPy < v0.15.0. See note in module documentation above.
-    if(NOT NumPy_CONV_TEMPLATE_EXECUTABLE)
-      execute_process(COMMAND "${PYTHON_EXECUTABLE}"
-        -c "from numpy.distutils import conv_template; print(conv_template.__file__)"
-        OUTPUT_VARIABLE _numpy_conv_template_file
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET
-        )
-      set(NumPy_CONV_TEMPLATE_EXECUTABLE "${PYTHON_EXECUTABLE}" "${_numpy_conv_template_file}" CACHE STRING "Command executing conv-template program" FORCE)
-    endif()
-
-    # XXX This is required to support NumPy < v0.15.0. See note in module documentation above.
-    if(NOT NumPy_FROM_TEMPLATE_EXECUTABLE)
-      execute_process(COMMAND "${PYTHON_EXECUTABLE}"
-        -c "from numpy.distutils import from_template; print(from_template.__file__)"
-        OUTPUT_VARIABLE _numpy_from_template_file
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET
-        )
-      set(NumPy_FROM_TEMPLATE_EXECUTABLE "${PYTHON_EXECUTABLE}" "${_numpy_from_template_file}" CACHE STRING "Command executing from-template program" FORCE)
-    endif()
   endif()
 endif()
 

--- a/skbuild/resources/cmake/FindPythonExtensions.cmake
+++ b/skbuild/resources/cmake/FindPythonExtensions.cmake
@@ -254,19 +254,27 @@ endif()
 include(targetLinkLibrariesWithDynamicLookup)
 
 set(_command "
-import distutils.sysconfig
+import sys
+at_least_python_3_10 = sys.version_info[:2] >= (3, 10)
+if at_least_python_3_10:
+    import sysconfig
+else:
+    import distutils.sysconfig
+
 import itertools
 import os
 import os.path
 import site
-import sys
 
 result = None
 rel_result = None
 candidate_lists = []
 
 try:
-    candidate_lists.append((distutils.sysconfig.get_python_lib(),))
+    if at_least_python_3_10:
+        candidate_lists.append((sysconfig.get_paths()['purelib'],))
+    else:
+        candidate_lists.append((distutils.sysconfig.get_python_lib(),))
 except AttributeError: pass
 
 try:
@@ -287,13 +295,17 @@ for candidate in candidates:
         rel_result = rel_candidate
         break
 
+if at_least_python_3_10:
+    ext_suffix = sysconfig.get_config_var('EXT_SUFFIX')
+else:
+    ext_suffix = distutils.sysconfig.get_config_var('EXT_SUFFIX')
 sys.stdout.write(\";\".join((
     os.sep,
     os.pathsep,
     sys.prefix,
     result,
     rel_result,
-    distutils.sysconfig.get_config_var('EXT_SUFFIX')
+    ext_suffix,
 )))
 ")
 

--- a/skbuild/resources/cmake/FindPythonExtensions.cmake
+++ b/skbuild/resources/cmake/FindPythonExtensions.cmake
@@ -255,8 +255,7 @@ include(targetLinkLibrariesWithDynamicLookup)
 
 set(_command "
 import sys
-at_least_python_3_10 = sys.version_info[:2] >= (3, 10)
-if at_least_python_3_10:
+if sys.version_info >= (3, 10):
     import sysconfig
 else:
     import distutils.sysconfig
@@ -271,7 +270,7 @@ rel_result = None
 candidate_lists = []
 
 try:
-    if at_least_python_3_10:
+    if sys.version_info >= (3, 10):
         candidate_lists.append((sysconfig.get_paths()['purelib'],))
     else:
         candidate_lists.append((distutils.sysconfig.get_python_lib(),))
@@ -295,7 +294,7 @@ for candidate in candidates:
         rel_result = rel_candidate
         break
 
-if at_least_python_3_10:
+if sys.version_info >= (3, 10):
     ext_suffix = sysconfig.get_config_var('EXT_SUFFIX')
 else:
     ext_suffix = distutils.sysconfig.get_config_var('EXT_SUFFIX')


### PR DESCRIPTION
I didn't have a chance to go through the whole repo, but I made this PR upstream to `zfpy` which vendors some files

https://github.com/LLNL/zfp/pull/217

If you want to monitor if this "works", please check build logs in https://github.com/conda-forge/zfpy-feedstock/pull/35

goodluck modernizing this.

There seems to be only a finite number of occurrences of distutils 

```
grep "(from|import) distutils" . -RE
``` 