### PR TITLE
fix: Don't die on PermissionError during chmod

### DIFF
--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -631,7 +631,8 @@ def setup(
                         executable += ".exe"
                     st = os.stat(executable)
                     permissions = st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
-                    os.chmod(executable, permissions)
+                    with contextlib.suppress(PermissionError):
+                        os.chmod(executable, permissions)
                 cmake_executable = os.path.join(CMAKE_BIN_DIR, "cmake")
                 break
 


### PR DESCRIPTION
The user might not have permissions to change permissions on the executables. Aborting in that case seems premature, since the permissions might be sufficient after all.

Seen on nixpkgs, where the cmake execcutable is immutable.

```pytb
cffsubr> Traceback (most recent call last):
cffsubr>   File "/build/cffsubr-0.3.0/external/afdko/setup.py", line 222, in <module>
cffsubr>     main()
cffsubr>   File "/build/cffsubr-0.3.0/external/afdko/setup.py", line 172, in main
cffsubr>     setup(name="afdko",
cffsubr>   File "/nix/store/dg9b2drwhvdfxp9gmpyiav1isl6hji9d-python3.11-scikit-build-0.17.6/lib/python3.11/site-packages/skbuild/setuptools_wrap.py", line 636, in setup
cffsubr>     os.chmod(executable, permissions)
cffsubr> PermissionError: [Errno 1] Operation not permitted: '/nix/store/vzr2v0mq6sx5vi301xxwf8i4nl9nlhxv-cmake-3.28.3/bin/cmake'
cffsubr> error: running '/nix/store/vhlk4r8ralh744khcy3vy47ijw5rvpw5-python3-3.11.8/bin/python3.11 setup.py build --build-scripts build/bin' command failed
```