### PR TITLE
fix: support CPython 3.13 with windows lib finding fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-20.04, macos-13, windows-2019, windows-2022]
+        runs-on: [ubuntu-22.04, macos-13, windows-2019, windows-2022]
 
     name: Tests on ${{ matrix.runs-on }}
     steps:
@@ -63,7 +63,7 @@ jobs:
     - name: Setup nox
       uses: wntrblm/nox@2024.04.15
       with:
-        python-versions: "3.7,3.8,3.9,3.10,3.11,3.12"
+        python-versions: "3.7,3.8,3.9,3.10,3.11,3.12,3.13"
 
     # We check all Python's on Linux, because it's fast.
     # We check minimum Python and maximum Python on all OS's.
@@ -86,6 +86,8 @@ jobs:
     - name: Test on 🐍 3.12
       run: nox -s tests-3.12 -- --cov --cov-report=xml --cov-report=term --cov-append --durations=20
       if: runner.os == 'Linux'
+    - name: Test on 🐍 3.13
+      run: nox -s tests-3.13 -- --cov --cov-report=xml --cov-report=term --cov-append --durations=20
 
     - name: Upload coverage report
       uses: codecov/codecov-action@v4

--- a/noxfile.py
+++ b/noxfile.py
@@ -42,7 +42,7 @@ def tests(session: nox.Session) -> None:
             contained = "1" if version in known_MSVC else "0"
             env[f"SKBUILD_TEST_FIND_VS{version}_INSTALLATION_EXPECTED"] = contained
 
-    numpy = [] if "pypy" in session.python or "3.12" in session.python else ["numpy"]
+    numpy = [] if "pypy" in session.python or "3.13" in session.python else ["numpy"]
     install_spec = "-e.[test,cov,doctest]" if "--cov" in posargs else ".[test,doctest]"
     if "--cov" in posargs:
         posargs.append("--cov-config=pyproject.toml")

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,7 +12,7 @@ nox.needs_version = ">=2024.3.2"
 nox.options.default_venv_backend = "uv|virtualenv"
 nox.options.sessions = ["lint", "tests"]
 
-PYTHON_ALL_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.7", "pypy3.8", "pypy3.9"]
+PYTHON_ALL_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.7", "pypy3.8", "pypy3.9", "pypy3.10"]
 MSVC_ALL_VERSIONS = {"2017", "2019", "2022"}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Typing :: Typed",
 ]
 dependencies = [

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -515,9 +515,11 @@ class CMaker:
                     libdir_masd = os.path.join(libdir, masd)
                     if os.path.exists(libdir_masd):
                         libdir = libdir_masd
-            libpath = os.path.join(libdir, ldlibrary)
-            if libpath and os.path.exists(libpath):
-                return libpath
+            libpath = Path(libdir) / ldlibrary
+            if sys.platform.startswith("win") and libpath.suffix == ".dll":
+                libpath = libpath.with_suffix(".lib")
+            if libpath.is_file():
+                return str(libpath)
 
         return CMaker._guess_python_library(python_version)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ pytest.register_assert_rewrite("tests.pytest_helpers")
 
 @pytest.fixture(scope="session")
 def pep518_wheelhouse(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    numpy = ["numpy"] if sys.version_info < (3, 12) else []
+    numpy = ["numpy"] if sys.version_info < (3, 13) else []
     wheelhouse = tmp_path_factory.mktemp("wheelhouse")
     subprocess.run(
         [


### PR DESCRIPTION
Adding 3.13.

Windows 3.13 is producing `LINK : fatal error LNK1104: cannot open file 'python313.lib' [C:\Users\runneradmin\AppData\Local\Temp\pytest-of-runneradmin\pytest-340\test_build0\_skbuild\win-amd64-3.13\cmake-build\_hello.vcxproj]`.