### PR TITLE
fix: cmake 3.5+ requirement

### DIFF
--- a/skbuild/platform_specifics/unix.py
+++ b/skbuild/platform_specifics/unix.py
@@ -18,7 +18,7 @@ class UnixPlatform(abstract.CMakePlatform):
             import ninja  # pylint: disable=import-outside-toplevel
 
             ninja_executable_path = os.path.join(ninja.BIN_DIR, "ninja")
-            ninja_args = ["-DCMAKE_MAKE_PROGRAM:FILEPATH=" + ninja_executable_path]
+            ninja_args = [f"-DCMAKE_MAKE_PROGRAM:FILEPATH={ninja_executable_path}"]
         except ImportError:
             ninja_args = []
 

--- a/skbuild/platform_specifics/windows.py
+++ b/skbuild/platform_specifics/windows.py
@@ -70,7 +70,7 @@ n
             import ninja  # pylint: disable=import-outside-toplevel
 
             ninja_executable_path = os.path.join(ninja.BIN_DIR, "ninja")
-            ninja_args = ["-DCMAKE_MAKE_PROGRAM:FILEPATH=" + ninja_executable_path]
+            ninja_args = [f"-DCMAKE_MAKE_PROGRAM:FILEPATH={ninja_executable_path}"]
         except ImportError:
             ninja_args = []
 

--- a/skbuild/resources/cmake/targetLinkLibrariesWithDynamicLookup.cmake
+++ b/skbuild/resources/cmake/targetLinkLibrariesWithDynamicLookup.cmake
@@ -398,7 +398,7 @@ function(_test_weak_link_project
     ")
 
     set(_rpath_arg)
-    if(APPLE AND ${CMAKE_VERSION} VERSION_GREATER 2.8.11)
+    if(APPLE)
       set(_rpath_arg "-DCMAKE_MACOSX_RPATH='${CMAKE_MACOSX_RPATH}'")
     endif()
 

--- a/tests/samples/issue-668-symbol-visibility/CMakeLists.txt
+++ b/tests/samples/issue-668-symbol-visibility/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4...3.22)
+cmake_minimum_required(VERSION 3.5...3.22)
 
 project(hello)
 

--- a/tests/samples/test-filter-manifest/CMakeLists.txt
+++ b/tests/samples/test-filter-manifest/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 project(hello NONE)
 


### PR DESCRIPTION
Fix https://github.com/scikit-build/scikit-build/issues/1066 by requiring CMake 3.5+. This was already done in some areas to stop warnings, but this applies it to the search for `cmake` vs. `cmake3`, with `cmake` now preferred, but cmake < 3.5 is ignored. This is more inline with scikit-build-core, which required 3.15+ and makes this user selectable.
