### PR TITLE
iOS and Android support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scikit-build"
-dynamic = ["version", "readme"]
+version = "0.17.6"
+dynamic = ["readme"]
 description = "Improved build system generator for Python C/C++/Fortran/Cython extensions"
 requires-python = ">=3.7"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scikit-build"
-version = "0.17.6"
-dynamic = ["readme"]
+dynamic = ["version", "readme"]
 description = "Improved build system generator for Python C/C++/Fortran/Cython extensions"
 requires-python = ">=3.7"
 authors = [

--- a/skbuild/platform_specifics/platform_factory.py
+++ b/skbuild/platform_specifics/platform_factory.py
@@ -30,7 +30,7 @@ def get_platform() -> abstract.CMakePlatform:
 
         return cygwin.CygwinPlatform()
 
-    if this_platform == "darwin":
+    if this_platform in ["darwin", "ios"]:
         from . import osx
 
         return osx.OSXPlatform()

--- a/skbuild/platform_specifics/platform_factory.py
+++ b/skbuild/platform_specifics/platform_factory.py
@@ -20,7 +20,7 @@ def get_platform() -> abstract.CMakePlatform:
         return windows.WindowsPlatform()
 
     # Some flexibility based on what emcripten distros decide to call themselves
-    if this_platform.startswith(("linux", "emscripten", "pyodide")):
+    if this_platform.startswith(("linux", "emscripten", "pyodide", "android")):
         from . import linux
 
         return linux.LinuxPlatform()


### PR DESCRIPTION
This modification enables the execution of scikit-build within a Python crossenv environment, catering to both iOS and Android platforms.