### PR TITLE
test: remove test directives

### DIFF
--- a/tests/samples/issue-274-support-default-package-dir/setup.py
+++ b/tests/samples/issue-274-support-default-package-dir/setup.py
@@ -10,5 +10,4 @@ setup(
     license="MIT",
     packages=["hello"],
     package_dir={"": "src"},
-    test_suite="hello_tests",
 )

--- a/tests/samples/issue-274-support-one-package-without-package-dir/setup.py
+++ b/tests/samples/issue-274-support-one-package-without-package-dir/setup.py
@@ -9,5 +9,4 @@ setup(
     author="The scikit-build team",
     license="MIT",
     packages=["hello"],
-    test_suite="hello_tests",
 )

--- a/tests/samples/issue-335-support-cmake-source-dir/wrapping/python/setup.py
+++ b/tests/samples/issue-335-support-cmake-source-dir/wrapping/python/setup.py
@@ -9,7 +9,6 @@ setup(
     author="The scikit-build team",
     license="MIT",
     packages=["hello"],
-    tests_require=[],
     setup_requires=[],
     cmake_source_dir="../../",
 )

--- a/tests/samples/test-filter-manifest/wrapping/python/setup.py
+++ b/tests/samples/test-filter-manifest/wrapping/python/setup.py
@@ -14,7 +14,6 @@ setup(
     author="The scikit-build team",
     license="MIT",
     packages=["hello"],
-    tests_require=[],
     setup_requires=[],
     cmake_source_dir="../../",
     cmake_process_manifest_hook=exclude_dev_files,


### PR DESCRIPTION
setuptools 72 and above now raise warnings for test_suite and tests_require directives in setup.py as support for setup.py test is preparing to be removed. These directives have been deprecated for quite some time, so just remove them from the sample setup.py files.