### PR TITLE
FindF2PY: ensure generic f2py executable is looked up first

### DIFF
--- a/skbuild/resources/cmake/FindF2PY.cmake
+++ b/skbuild/resources/cmake/FindF2PY.cmake
@@ -66,7 +66,7 @@
 #   case, CMake is not used to find the compiler and configure the associated build system.
 #
 
-find_program(F2PY_EXECUTABLE NAMES f2py${PYTHON_VERSION_MAJOR} f2py)
+find_program(F2PY_EXECUTABLE NAMES f2py f2py${PYTHON_VERSION_MAJOR} )
 
 # XXX This is required to support NumPy < v0.15.0. See note in module documentation above.
 if(NOT F2PY_EXECUTABLE)


### PR DESCRIPTION
In issue #449  a change was made to the resolution of F2py to support python2 builds and prefer the versioned `f2py` over an unversioned. 

https://github.com/scikit-build/scikit-build/blob/5b20908709070e6329348aabbb889bacc25ca892/skbuild/resources/cmake/FindF2PY.cmake#L69

This made sense at the time, but with the now final deprecation of python2, and numpy dropping `f2py3` in version [1.26](https://github.com/numpy/numpy/pull/24235) this change has come to bite us. 

Now if using a virtual environment with a version of `numpy>1.26`, but an OS/system that has a python with `numpy<1.26`, cmake will prefer the `f2py3` of the OS, leading to hard-to-diagnose problems. 

With `numpy>=2.0`  [C-API changes](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#c-api-changes),  code compiled with the systems f2py will not run in the environment. 