### PR TITLE
`setuptools_wrap.py`: parse `CMAKE_ARGS` with `shlex.split` like elsewhere

### DIFF
--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -316,13 +316,15 @@ class CMaker:
 
         # Parse CMAKE_ARGS only if SKBUILD_CONFIGURE_OPTIONS is not present
         if "SKBUILD_CONFIGURE_OPTIONS" in os.environ:
-            env_cmake_args = list(filter(None, shlex.split(os.environ["SKBUILD_CONFIGURE_OPTIONS"])))
+            env_cmake_args = shlex.split(os.environ["SKBUILD_CONFIGURE_OPTIONS"])
             if any("CMAKE_INSTALL_PREFIX" in arg for arg in env_cmake_args):
                 msg = "CMAKE_INSTALL_PREFIX may not be passed via SKBUILD_CONFIGURE_OPTIONS."
                 raise ValueError(msg)
+        elif "CMAKE_ARGS" in os.environ:
+            env_cmake_args = shlex.split(os.environ["CMAKE_ARGS"])
+            env_cmake_args = [s for s in env_cmake_args if "CMAKE_INSTALL_PREFIX" not in s]
         else:
-            env_cmake_args_filtered = filter(None, shlex.split(os.environ.get("CMAKE_ARGS", "")))
-            env_cmake_args = [s for s in env_cmake_args_filtered if "CMAKE_INSTALL_PREFIX" not in s]
+            env_cmake_args = []
 
         cmd.extend(env_cmake_args)
 

--- a/skbuild/setuptools_wrap.py
+++ b/skbuild/setuptools_wrap.py
@@ -13,6 +13,7 @@ import json
 import os
 import os.path
 import platform
+import shlex
 import shutil
 import stat
 import sys
@@ -535,8 +536,11 @@ def setup(
         cmake_install_target = cmake_install_target_from_setup
 
     # Parse CMAKE_ARGS
-    env_cmake_args = os.environ["CMAKE_ARGS"].split() if "CMAKE_ARGS" in os.environ else []
-    env_cmake_args = [s for s in env_cmake_args if "CMAKE_INSTALL_PREFIX" not in s]
+    if "CMAKE_ARGS" in os.environ:
+        env_cmake_args = shlex.split(os.environ["CMAKE_ARGS"])
+        env_cmake_args = [s for s in env_cmake_args if "CMAKE_INSTALL_PREFIX" not in s]
+    else:
+        env_cmake_args = []
 
     # Since CMake arguments provided through the command line have more weight
     # and when CMake is given multiple times a argument, only the last one is


### PR DESCRIPTION
* Fix a bug where `CMAKE_ARGS` was not parsed with `shlex.split`, which was breaking with e.g. `CMAKE_ARGS` set to `-G "Unix Makefiles"`.
* Remove redundant `list(filter(None, ...))`

I wish I could just pass the CMake arguments as command line arguments. Apparently calling `setup.py` is the only way to do so, but deprecated (?). What's left is patching toml files (not great), or setting this env variable (ugly).