### PR TITLE
feat: drop Python 3.7

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -111,7 +111,7 @@ Before you submit a pull request, check that it meets these guidelines:
    your new functionality into a function with a docstring, and add the
    feature to the list in ``README.rst``.
 
-3. The pull request should work for Python 3.7+ and PyPy.  Make sure that
+3. The pull request should work for Python 3.8+ and PyPy.  Make sure that
    the tests pass for all supported Python versions in CI on your PR.
 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,10 +11,10 @@ jobs:
       matrix:
         Python37:
           python.arch: 'x86'
-          python.version: '3.7'
+          python.version: '3.8'
         Python37-x64:
           python.arch: 'x64'
-          python.version: '3.7'
+          python.version: '3.8'
       maxParallel: 2
 
     steps:

--- a/docs/generators.rst
+++ b/docs/generators.rst
@@ -123,7 +123,7 @@ Visual Studio IDE
     +-------------------+------------------------+-----------------------------+
     | CPython Version   | x86 (32-bit)           | x64 (64-bit)                |
     +===================+========================+=============================+
-    | **3.7 and above** | Visual Studio 17 2022  | Visual Studio 17 2022 Win64 |
+    | **3.8 and above** | Visual Studio 17 2022  | Visual Studio 17 2022 Win64 |
     |                   | Visual Studio 16 2019  | Visual Studio 16 2019 Win64 |
     |                   | Visual Studio 15 2017  | Visual Studio 15 2017 Win64 |
     +-------------------+------------------------+-----------------------------+
@@ -216,7 +216,7 @@ MacOSX wheels will allow them to work on ``System CPython``, the ``Official CPyt
     |                      +-------------------------+--------------+--------------------------------+
     |                      | 3.8                     | 11           | macosx-11.0-universal2         |
     |                      +-------------------------+--------------+--------------------------------+
-    |                      | 3.7, 3.8, 3.9, 3.10     | 10.9         | macosx-10.9-x86_64             |
+    |                      | 3.8, 3.9, 3.10          | 10.9         | macosx-10.9-x86_64             |
     +----------------------+-------------------------+--------------+--------------------------------+
     | Macports CPython     | 3.x                     | Current      | Depends on current macOS       |
     +----------------------+-------------------------+--------------+ version.                       |
@@ -347,7 +347,7 @@ this next table references links for installing alternative environments:
     +-------------------+-------------------------------------------------+
     | CPython version   | Download links for Windows SDK or Visual Studio |
     +===================+=================================================+
-    | **3.7 and above** | - `Visual C++ Build Tools`_                     |
+    | **3.8 and above** | - `Visual C++ Build Tools`_                     |
     |                   |                                                 |
     |                   | or                                              |
     |                   |                                                 |

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -33,7 +33,7 @@ Make a fold name my_project as your project root folder, place the following in 
         author='The scikit-build team',
         license="MIT",
         packages=['hello'],
-        python_requires=">=3.7",
+        python_requires=">=3.8",
     )
 
 Your project now uses scikit-build instead of setuptools.

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,7 +12,7 @@ nox.needs_version = ">=2024.3.2"
 nox.options.default_venv_backend = "uv|virtualenv"
 nox.options.sessions = ["lint", "tests"]
 
-PYTHON_ALL_VERSIONS = ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.7", "pypy3.8", "pypy3.9", "pypy3.10"]
+PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.8", "pypy3.9", "pypy3.10"]
 MSVC_ALL_VERSIONS = {"2017", "2019", "2022"}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "scikit-build"
 dynamic = ["version", "readme"]
 description = "Improved build system generator for Python C/C++/Fortran/Cython extensions"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "The scikit-build team" },
 ]
@@ -19,7 +19,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -33,7 +32,6 @@ dependencies = [
     'packaging',
     'setuptools>=42.0.0',
     'tomli; python_version<"3.11"',
-    'typing-extensions>=3.7; python_version<"3.8"',
     'wheel>=0.32.0',
 ]
 
@@ -56,7 +54,6 @@ doctest = [
 test = [
     'build>=0.7',
     'cython>=0.25.1',
-    'importlib-metadata;python_version<"3.8"',
     'pip',
     'pytest-mock>=1.10.4',
     'pytest>=6.0.0',
@@ -135,7 +132,7 @@ ignore_missing_imports = true
 
 
 [tool.pylint]
-py-version = "3.7"
+py-version = "3.8"
 jobs = "0"
 reports.output-format = "colorized"
 similarities.ignore-imports = "yes"

--- a/skbuild/__init__.py
+++ b/skbuild/__init__.py
@@ -16,6 +16,6 @@ __email__ = "scikit-build@googlegroups.com"
 __all__ = ["setup", "__version__"]
 
 
-# Cleaner Python 3.7 command line completion
+# Cleaner Python 3.7+ command line completion
 def __dir__() -> list[str]:
     return __all__

--- a/skbuild/_compat/typing.py
+++ b/skbuild/_compat/typing.py
@@ -1,10 +1,5 @@
 from __future__ import annotations
 
-import sys
-
-if sys.version_info >= (3, 8):
-    from typing import Final, Literal, Protocol, TypedDict
-else:
-    from typing_extensions import Final, Literal, Protocol, TypedDict
+from typing import Final, Literal, Protocol, TypedDict
 
 __all__ = ["Protocol", "TypedDict", "Final", "Literal"]

--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -369,7 +369,7 @@ class CMaker:
             >>> from skbuild.cmaker import CMaker
             >>> python_version = CMaker.get_python_version()
             >>> print('python_version = {!r}'.format(python_version))
-            python_version = '3.7'
+            python_version = '3.8'
         """
         python_version = sysconfig.get_config_var("VERSION")
 
@@ -402,7 +402,7 @@ class CMaker:
             >>> python_version = CMaker.get_python_version()
             >>> python_include_dir = CMaker.get_python_include_dir(python_version)
             >>> print('python_include_dir = {!r}'.format(python_include_dir))
-            python_include_dir = '.../conda/envs/py37/include/python3.7m'
+            python_include_dir = '.../conda/envs/py38/include/python3.8m'
         """
         # determine python include dir
         python_include_dir: str | None = sysconfig.get_config_var("INCLUDEPY")

--- a/skbuild/platform_specifics/windows.py
+++ b/skbuild/platform_specifics/windows.py
@@ -63,7 +63,7 @@ n
             """
         ).strip()
 
-        # For Python 3.7 and above: VS2022, VS2019, VS2017
+        # For Python 3.8 and above: VS2022, VS2019, VS2017
         supported_vs_years = [("2022", "v144"), ("2022", "v143"), ("2019", "v142"), ("2017", "v141")]
 
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,17 +6,12 @@ import shutil
 import subprocess
 import sys
 from collections.abc import Generator
+from importlib import metadata
 from pathlib import Path
+from typing import Literal, overload
 
 import pytest
 import virtualenv as _virtualenv
-
-if sys.version_info < (3, 8):
-    import importlib_metadata as metadata
-    from typing_extensions import Literal, overload
-else:
-    from importlib import metadata
-    from typing import Literal, overload
 
 HAS_SETUPTOOLS_SCM = importlib.util.find_spec("setuptools_scm") is not None
 

--- a/tests/pytest_helpers.py
+++ b/tests/pytest_helpers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 import tarfile
+from importlib import metadata
 from zipfile import ZipFile
 
 from packaging.version import Version
@@ -9,11 +10,6 @@ from packaging.version import Version
 from skbuild import __version__ as skbuild_version
 
 from . import list_ancestors
-
-if sys.version_info < (3, 8):
-    import importlib_metadata as metadata
-else:
-    from importlib import metadata
 
 
 def check_sdist_content(sdist_archive, expected_distribution_name, expected_content, package_dir=""):

--- a/tests/samples/issue-668-symbol-visibility/setup.py
+++ b/tests/samples/issue-668-symbol-visibility/setup.py
@@ -9,5 +9,5 @@ setup(
     author="The scikit-build team",
     license="MIT",
     packages=["hello"],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
 )

--- a/tests/samples/issue-707-nested-packages/setup.py
+++ b/tests/samples/issue-707-nested-packages/setup.py
@@ -9,5 +9,5 @@ setup(
     author="The scikit-build team",
     license="MIT",
     packages=["hello_nested", "hello_nested.goodbye_nested"],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
 )


### PR DESCRIPTION
We've had to disable most of our Python 3.7 tests in CI, so let's go ahead and drop it.
