### PR TITLE
feat: support Visual Studio 18 2026

### DIFF
--- a/docs/generators.rst
+++ b/docs/generators.rst
@@ -123,7 +123,8 @@ Visual Studio IDE
     +-------------------+------------------------+-----------------------------+
     | CPython Version   | x86 (32-bit)           | x64 (64-bit)                |
     +===================+========================+=============================+
-    | **3.8 and above** | Visual Studio 17 2022  | Visual Studio 17 2022 Win64 |
+    | **3.8 and above** | Visual Studio 18 2026  | Visual Studio 18 2026 Win64 |
+    |                   | Visual Studio 17 2022  | Visual Studio 17 2022 Win64 |
     |                   | Visual Studio 16 2019  | Visual Studio 16 2019 Win64 |
     |                   | Visual Studio 15 2017  | Visual Studio 15 2017 Win64 |
     +-------------------+------------------------+-----------------------------+

--- a/skbuild/platform_specifics/windows.py
+++ b/skbuild/platform_specifics/windows.py
@@ -20,6 +20,7 @@ VS_YEAR_TO_VERSION = {
     "2017": 15,
     "2019": 16,
     "2022": 17,
+    "2026": 18,
 }
 """Describes the version of `Visual Studio` supported by
 :class:`CMakeVisualStudioIDEGenerator` and
@@ -32,6 +33,7 @@ VS_YEAR_TO_MSC_VER = {
     "2017": "1910",  # VS 2017 - can be +9
     "2019": "1920",  # VS 2019 - can be +9
     "2022": "1930",  # VS 2022 - can be +19
+    "2026": "1950",  # VS 2026
 }
 
 ARCH_TO_MSVC_ARCH = {
@@ -63,8 +65,14 @@ n
             """
         ).strip()
 
-        # For Python 3.8 and above: VS2022, VS2019, VS2017
-        supported_vs_years = [("2022", "v144"), ("2022", "v143"), ("2019", "v142"), ("2017", "v141")]
+        # For Python 3.8 and above: VS2026, VS2022, VS2019, VS2017
+        supported_vs_years = [
+            ("2026", "v145"),
+            ("2022", "v144"),
+            ("2022", "v143"),
+            ("2019", "v142"),
+            ("2017", "v141"),
+        ]
 
         try:
             import ninja  # noqa: PLC0415

--- a/tests/test_skbuild.py
+++ b/tests/test_skbuild.py
@@ -41,6 +41,7 @@ def test_generator_selection():
         has_vs_2017 = find_visual_studio(vs_version=VS_YEAR_TO_VERSION["2017"])
         has_vs_2019 = find_visual_studio(vs_version=VS_YEAR_TO_VERSION["2019"])
         has_vs_2022 = find_visual_studio(vs_version=VS_YEAR_TO_VERSION["2022"])
+        has_vs_2026 = find_visual_studio(vs_version=VS_YEAR_TO_VERSION["2026"])
 
         # As of Dec 2016, this is available only for VS 9.0
         has_vs_for_python_vcvars = any(
@@ -60,7 +61,7 @@ def test_generator_selection():
             # Early versions of 2017 may not ship with Ninja (TODO: check)
             assert get_best_generator().name in {"Ninja", vs_generator}
 
-        elif has_vs_2019 or has_vs_2022:
+        elif has_vs_2019 or has_vs_2022 or has_vs_2026:
             # ninja is provided by the CMake extension bundled with Visual Studio 2017
             # C:/Program Files (x86)/Microsoft Visual Studio/2017/Professional/Common7/IDE/CommonExtensions/Microsoft/CMake/Ninja/ninja.exe
             assert get_best_generator().name == "Ninja"
@@ -123,7 +124,7 @@ def test_invalid_generator(generator_args, project_setup_py_test):
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Requires Windows")
-@pytest.mark.parametrize("vs_year", ["2017", "2019", "2022"])
+@pytest.mark.parametrize("vs_year", ["2017", "2019", "2022", "2026"])
 def test_platform_windows_find_visual_studio(vs_year, capsys):
     """If the environment variable ``SKBUILD_TEST_FIND_VS<vs_year>_INSTALLATION_EXPECTED`` is set,
     this test asserts the value returned by :func:`skbuild.platforms.windows.find_visual_studio()`.


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Closes #1177.

## What

Adds support for the **Visual Studio 18 2026** CMake generator, so scikit-build can find a working generator on machines where VS 2026 is the only Visual Studio installed.

## Changes

- `skbuild/platform_specifics/windows.py`:
  - `VS_YEAR_TO_VERSION`: `"2026": 18` → generator name `Visual Studio 18 2026`
  - `VS_YEAR_TO_MSC_VER`: `"2026": "1950"` (MSVC 14.5x → `_MSC_VER` 1950, used for `_SKBUILD_FORCE_MSVC`)
  - Prepend `("2026", "v145")` to `supported_vs_years` so the VS 2026 / toolset v145 generators (Ninja, IDE, NMake) are tried before VS 2022.
- `tests/test_skbuild.py`: add `2026` to the `find_visual_studio` parametrize and a `has_vs_2026` detection branch.
- `docs/generators.rst`: add the VS 18 2026 row to the generator table.

## Notes

The VS 18 2026 generator was [introduced in CMake 4.2](https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2018%202026.html), and the [v145 toolset ships with VS 2026 18.x](https://devblogs.microsoft.com/cppblog/whats-new-for-cpp-developers-in-visual-studio-2026-version-18-0/). Users hitting #1177 will also need **CMake 4.2+** for this generator to be recognized.

Verified locally: the new generators now lead the priority list, and `prek -a` passes clean. The Windows-specific tests can only exercise the real toolchain in CI / on Windows.