### PR TITLE
fix: correctness bugs found in code review

### DIFF
--- a/skbuild/cmaker.py
+++ b/skbuild/cmaker.py
@@ -78,7 +78,7 @@ def has_cmake_cache_arg(cmake_args: list[str], arg_name: str, arg_value: str | N
             if arg_value is None:
                 return True
             if "=" in arg:
-                return arg.split("=")[1] == arg_value
+                return arg.split("=", 1)[1] == arg_value
     return False
 
 

--- a/skbuild/constants.py
+++ b/skbuild/constants.py
@@ -87,7 +87,7 @@ def _default_skbuild_plat_name() -> str:
     # it returns the macOS version on which Python was built which may be
     # significantly older than the user's current machine.
     release = os.environ.get("MACOSX_DEPLOYMENT_TARGET", "") or release
-    major_macos, minor_macos = release.split(".")[:2]
+    major_macos, minor_macos = [*release.split("."), "0"][:2]
 
     # On macOS 11+, only the major version matters.
     if int(major_macos) >= 11:
@@ -100,7 +100,7 @@ def _default_skbuild_plat_name() -> str:
 
     archflags = os.environ.get("ARCHFLAGS")
     if archflags is not None:
-        machine = ";".join(set(archflags.split()) & supported_macos_architectures)
+        machine = ";".join(sorted(set(archflags.split()) & supported_macos_architectures))
 
     machine = os.environ.get("CMAKE_OSX_ARCHITECTURES", machine)
 

--- a/skbuild/platform_specifics/abstract.py
+++ b/skbuild/platform_specifics/abstract.py
@@ -64,7 +64,7 @@ class CMakePlatform:
                 "  if(NOT MSVC)\n"
                 '    message(FATAL_ERROR "MSVC is required to pass this check.")\n'
                 "  elseif(MSVC_VERSION LESS FORCE_MIN OR MSVC_VERSION GREATER FORCE_MAX)\n"
-                '    message(FATAL_ERROR "MSVC ${MSVC_VERSION} does pass this check.")\n'
+                '    message(FATAL_ERROR "MSVC ${MSVC_VERSION} does not pass this check.")\n'
                 "  endif()\n"
                 "endif()\n"
             )

--- a/skbuild/platform_specifics/windows.py
+++ b/skbuild/platform_specifics/windows.py
@@ -60,7 +60,7 @@ class WindowsPlatform(abstract.CMakePlatform):
             """
             Building windows wheels requires Microsoft Visual Studio.
             Get it from:
-n
+
              https://visualstudio.microsoft.com/vs/
             """
         ).strip()
@@ -233,9 +233,9 @@ def _get_msvc_compiler_env(vs_version: int, vs_toolset: str | None = None) -> Ca
     # Set vcvars_ver argument based on toolset
     vcvars_ver = ""
     if vs_toolset is not None:
-        match = re.findall(r"^v(\d\d)(\d+)$", vs_toolset)[0]
+        match = re.match(r"^v(\d\d)(\d+)$", vs_toolset)
         if match:
-            match_str = ".".join(match)
+            match_str = ".".join(match.groups())
             vcvars_ver = f"-vcvars_ver={match_str}"
 
     try:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes a batch of correctness bugs surfaced by a code review (refs #1189). Each is small and independent:

- **windows**: removed a stray `n` (a botched `\n`) from the Visual Studio install help text shown on missing-generator errors.
- **abstract**: fixed the inverted MSVC version-check message — it fires when the version is *out of range*, so it now reads "does **not** pass this check."
- **windows**: `re.findall(r"...", vs_toolset)[0]` raised an uncaught `IndexError` on a malformed toolset and the following `if match:` guard was always true. Switched to `re.match(...)` with a proper `None` check so a bad toolset degrades to an empty `vcvars_ver`.
- **cmaker**: `has_cmake_cache_arg` split cache args on every `=`, truncating values that contain `=`. Now splits on the first `=` only.
- **constants** (macOS plat name):
  - sorted the `ARCHFLAGS` architecture set so the generated plat name is deterministic;
  - tolerate a bare-major `MACOSX_DEPLOYMENT_TARGET` (e.g. `11`) instead of crashing on tuple unpack.

Lint (ruff/mypy) and `tests/test_constants.py` + `tests/test_platform.py` pass locally.