### PR TITLE
perf: resolve Visual Studio generator environments lazily

### DIFF
--- a/skbuild/platform_specifics/abstract.py
+++ b/skbuild/platform_specifics/abstract.py
@@ -279,7 +279,7 @@ class CMakeGenerator:
         """
         self._generator_name = name
         self.args = list(args or [])
-        self.env = dict(list(os.environ.items()) + list(env.items() if env else []))
+        self._env: Mapping[str, str] = env or {}
         self._generator_toolset = toolset
         self._generator_architecture = arch
         description_arch = name if arch is None else f"{name} {arch}"
@@ -287,6 +287,15 @@ class CMakeGenerator:
             self._description = description_arch
         else:
             self._description = f"{description_arch} {toolset}"
+
+    @property
+    def env(self) -> dict[str, str]:
+        """Environment associated with the generator, layered on top of ``os.environ``.
+
+        Resolved lazily so that constructing a generator that is never selected
+        does not pay the cost of probing the environment.
+        """
+        return {**os.environ, **self._env}
 
     @property
     def name(self) -> str:

--- a/skbuild/platform_specifics/windows.py
+++ b/skbuild/platform_specifics/windows.py
@@ -200,7 +200,9 @@ def find_visual_studio(vs_version: int) -> str:
 
 # To avoid multiple slow calls to ``subprocess.run()`` (either directly or
 # indirectly through ``query_vcvarsall``), results of previous calls are cached.
-__get_msvc_compiler_env_cache: dict[str, CachedEnv] = {}
+# Failures (an empty mapping) are cached too, so a missing or broken Visual
+# Studio edition is probed at most once.
+__get_msvc_compiler_env_cache: dict[str, CachedEnv | dict[str, str]] = {}
 
 
 def _get_msvc_compiler_env(vs_version: int, vs_toolset: str | None = None) -> CachedEnv | dict[str, str]:
@@ -228,6 +230,7 @@ def _get_msvc_compiler_env(vs_version: int, vs_toolset: str | None = None) -> Ca
     vc_dir = find_visual_studio(vs_version)
     vcvarsall = os.path.join(vc_dir, "vcvarsall.bat")
     if not os.path.exists(vcvarsall):
+        __get_msvc_compiler_env_cache[cache_key] = {}
         return {}
 
     # Set vcvars_ver argument based on toolset
@@ -262,6 +265,7 @@ def _get_msvc_compiler_env(vs_version: int, vs_toolset: str | None = None) -> Ca
     except subprocess.CalledProcessError as exc:
         print(exc.output.decode("utf-16le", errors="replace"), file=sys.stderr, flush=True)
 
+    __get_msvc_compiler_env_cache[cache_key] = {}
     return {}
 
 
@@ -286,8 +290,20 @@ class CMakeVisualStudioCommandLineGenerator(CMakeGenerator):
 
         The platform (32-bit or 64-bit or ARM) is automatically selected.
         """
-        arch = _compute_arch()
-        vc_env = _get_msvc_compiler_env(VS_YEAR_TO_VERSION[year], toolset)
-        env = {str(key.upper()): str(value) for key, value in vc_env.items()}
-        super().__init__(name, env, arch=arch, args=args)
+        self._vs_version = VS_YEAR_TO_VERSION[year]
+        self._vs_toolset = toolset
+        super().__init__(name, arch=_compute_arch(), args=args)
         self._description = f"{self.name} ({CMakeVisualStudioIDEGenerator(year, toolset).description})"
+
+    @property
+    def env(self) -> dict[str, str]:
+        """Visual Studio environment, resolved lazily on first use.
+
+        ``WindowsPlatform`` builds one generator per supported toolset, so
+        resolving the environment here (rather than in ``__init__``) avoids
+        running ``vswhere.exe`` / ``vcvarsall.bat`` for editions that are never
+        selected. Results are cached in :data:`__get_msvc_compiler_env_cache`.
+        """
+        vc_env = _get_msvc_compiler_env(self._vs_version, self._vs_toolset)
+        msvc_env = {str(key.upper()): str(value) for key, value in vc_env.items()}
+        return {**os.environ, **msvc_env}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Addresses the eager Visual Studio environment probing flagged in code review (refs #1189, item 10).

### Problem
`WindowsPlatform.__init__` builds one command-line generator per supported toolset (VS 2017–2026 × Ninja + NMake, ~10 generators). Each generator ran `vswhere.exe` and `vcvarsall.bat` **in its constructor**, so merely constructing the platform — before `get_best_generator` decides which to try — probed the environment for editions that may never be used. Failures (`return {}`) were also never cached, so editions that are missing/broken re-ran those subprocesses on every generator sharing the version.

### Change
- `CMakeGenerator.env` is now a property that layers the generator-specific environment over `os.environ` on access, rather than materializing it in `__init__`.
- `CMakeVisualStudioCommandLineGenerator` overrides `env` to call `_get_msvc_compiler_env` lazily — only when the environment is actually needed (during generator testing and for the selected build).
- `_get_msvc_compiler_env` now caches its empty-mapping failure results, so a missing/broken VS edition is probed at most once.

### Behavior notes
- The base environment is now captured at `.env` access time instead of construction time. `.env` is read-only everywhere in the tree (only passed to `subprocess.run(env=...)` and returned), so this is safe — verified with a repo-wide search.
- No public API change; `generator.env` still returns the same merged mapping.

### Verification
- `ruff` clean; lazy construction + negative-caching confirmed with a probe-counter harness (constructing a generator triggers 0 `vswhere` calls; two `.env` accesses trigger exactly 1).
- `tests/test_platform.py` + `tests/test_command_line.py` pass locally (the Windows-only `test_cached_generator` reads `generator.env` and is exercised by CI on Windows runners).

Independent of #1191/#1192 (touches different lines); can merge in any order.