### PR TITLE
ci: add windows-latest job for Visual Studio 2026

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, macos-15-intel, windows-2022]
+        runs-on: [ubuntu-latest, macos-15-intel, windows-2022, windows-latest]
 
     name: Tests on ${{ matrix.runs-on }}
     steps:
@@ -47,6 +47,14 @@ jobs:
         echo "SKBUILD_TEST_FIND_VS2017_INSTALLATION_EXPECTED=0" >> $GITHUB_ENV
         echo "SKBUILD_TEST_FIND_VS2019_INSTALLATION_EXPECTED=0" >> $GITHUB_ENV
         echo "SKBUILD_TEST_FIND_VS2022_INSTALLATION_EXPECTED=1" >> $GITHUB_ENV
+
+    - name: Set environment for available GHA MSVCs
+      if: matrix.runs-on == 'windows-latest'
+      shell: bash
+      run: |
+        echo "SKBUILD_TEST_FIND_VS2017_INSTALLATION_EXPECTED=0" >> $GITHUB_ENV
+        echo "SKBUILD_TEST_FIND_VS2019_INSTALLATION_EXPECTED=0" >> $GITHUB_ENV
+        echo "SKBUILD_TEST_FIND_VS2026_INSTALLATION_EXPECTED=1" >> $GITHUB_ENV
 
     - name: Set environment for Fortran compiler on MacOS
       if: runner.os == 'macOS'


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds a `windows-latest` runner to the test matrix to exercise Visual Studio 2026 (support for which already landed in `skbuild/platform_specifics/windows.py`).

- New matrix entry: `windows-latest` alongside the existing `windows-2022`.
- Dedicated VS-expectation step for it: asserts VS 2026 is installed (`SKBUILD_TEST_FIND_VS2026_INSTALLATION_EXPECTED=1`) and that VS 2017/2019 are absent. VS 2022 is left unset (the image does not ship it), so `test_platform_windows_find_visual_studio[2022]` skips there.

The shared Python-version steps already run min (3.8) and max (3.14) Python on every OS, so the new runner picks those up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)