### PR TITLE
test: tolerate CMake 4 install path normalization

### DIFF
--- a/tests/test_cmaker.py
+++ b/tests/test_cmaker.py
@@ -123,16 +123,18 @@ def test_make(configure_with_cmake_source_dir, capfd):
             messages += [
                 "/SRC",
                 f"/BUILD/{to_unix_path(CMAKE_BUILD_DIR())}",
-                f"/BUILD/{to_unix_path(CMAKE_INSTALL_DIR())}/./foo.txt",
+                f"/BUILD/{to_unix_path(CMAKE_INSTALL_DIR())}/foo.txt",
             ]
         else:
             messages += [
                 "/SRC",
                 f"/SRC/{to_unix_path(CMAKE_BUILD_DIR())}",
-                f"/SRC/{to_unix_path(CMAKE_INSTALL_DIR())}/./foo.txt",
+                f"/SRC/{to_unix_path(CMAKE_INSTALL_DIR())}/foo.txt",
             ]
 
+        # CMake >= 4 normalizes the redundant "/./" out of install messages.
         out, _ = capfd.readouterr()
+        out = out.replace("/./", "/")
         for message in messages:
             assert message in out
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

CMake 4 normalizes the redundant `/./` out of `-- Installing:` messages, so `test_make` failed on the newer runner images (macos-15-intel, windows-latest, PyPy macos/windows) that ship CMake 4.x, while jobs on CMake 3.x kept passing. This surfaced in #1204 only because that dependabot PR runs on those images; it is unrelated to the action bumps.

The test now strips `/./` from the captured output before matching, so it passes on both CMake 3 and 4.