### PR TITLE
feat!: drop Python 3.8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,16 +49,13 @@ jobs:
     - name: Setup nox
       uses: wntrblm/nox@2026.07.11
       with:
-        python-versions: "3.8,3.9,3.10,3.11,3.12,3.13,3.14"
+        python-versions: "3.9,3.10,3.11,3.12,3.13,3.14"
 
     # We check all Python's on Linux, because it's fast.
     # We check minimum Python and maximum Python on all OS's.
 
-    - name: Test on 🐍 3.8
-      run: nox -s tests-3.8 -- --cov --cov-report=xml --cov-report=term --durations=20
     - name: Test on 🐍 3.9
-      if: runner.os == 'Linux'
-      run: nox -s tests-3.9 -- --cov --cov-report=xml --cov-report=term --cov-append --durations=20
+      run: nox -s tests-3.9 -- --cov --cov-report=xml --cov-report=term --durations=20
     - name: Test on 🐍 3.10
       if: runner.os == 'Linux'
       run: nox -s tests-3.10 -- --cov --cov-report=xml --cov-report=term --cov-append --durations=20

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to agents when working with code in this repository.
 
 ## What this is
 
-scikit-build (classic) is glue between setuptools and CMake: it lets `setup.py` projects build C/C++/Fortran/Cython extensions with CMake. It is in maintenance mode; new development happens in its successor, scikit-build-core. Supports Python 3.8+ and PyPy.
+scikit-build (classic) is glue between setuptools and CMake: it lets `setup.py` projects build C/C++/Fortran/Cython extensions with CMake. It is in maintenance mode; new development happens in its successor, scikit-build-core. Supports Python 3.9+ and PyPy.
 
 ## Commands
 
@@ -31,7 +31,7 @@ The whole package implements one entry point: `skbuild.setup()` (in `skbuild/set
 3. `skbuild/cmaker.py` (`CMaker`) runs CMake configure/build/install into `_skbuild/<platform>-<pyversion>/` (layout defined in `skbuild/constants.py`: `cmake-build/`, `cmake-install/`, `setuptools/`). It injects the shipped CMake modules in `skbuild/resources/cmake/` (`FindPythonExtensions.cmake`, `UseCython.cmake`, `FindF2PY.cmake`, …) onto `CMAKE_MODULE_PATH`.
 4. The CMake-installed files are merged into the setuptools package layout, then control passes to setuptools using the overridden command classes in `skbuild/command/` (subclasses of `build`, `build_py`, `build_ext`, `bdist_wheel`, `sdist`, `install`, etc., plus the mixin in `skbuild/command/__init__.py`) so setuptools accounts for CMake-generated files.
 
-Errors are reported via `SKBuildError` (`skbuild/exceptions.py`). `skbuild/_compat/` holds version shims (e.g. `tomllib`); `typing-modules` in ruff is pointed at `skbuild._compat.typing`.
+Errors are reported via `SKBuildError` (`skbuild/exceptions.py`).
 
 ## Tests
 
@@ -41,4 +41,4 @@ Errors are reported via `SKBuildError` (`skbuild/exceptions.py`). `skbuild/_comp
 
 - Type checking is strict mypy for `skbuild/` (untyped defs allowed in `tests/`); run via pre-commit.
 - Ruff enforces `from __future__ import annotations` in every file; line length 120.
-- CI must pass on Python 3.8 — no 3.9+ only constructs outside `_compat`.
+- CI must pass on Python 3.9 — no 3.10+ only constructs.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -111,7 +111,7 @@ Before you submit a pull request, check that it meets these guidelines:
    your new functionality into a function with a docstring, and add the
    feature to the list in ``README.md``.
 
-3. The pull request should work for Python 3.8+ and PyPy.  Make sure that
+3. The pull request should work for Python 3.9+ and PyPy.  Make sure that
    the tests pass for all supported Python versions in CI on your PR.
 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,12 +9,12 @@ jobs:
 
     strategy:
       matrix:
-        Python37:
+        Python39:
           python.arch: 'x86'
-          python.version: '3.8'
-        Python37-x64:
+          python.version: '3.9'
+        Python39-x64:
           python.arch: 'x64'
-          python.version: '3.8'
+          python.version: '3.9'
       maxParallel: 2
 
     steps:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -119,7 +119,7 @@ Make a fold name my_project as your project root folder, place the following in 
         author='The scikit-build team',
         license="MIT",
         packages=['hello'],
-        python_requires=">=3.8",
+        python_requires=">=3.9",
     )
 
 Your project now uses scikit-build instead of setuptools.

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,7 +14,7 @@ nox.options.default_venv_backend = "uv|virtualenv"
 PYPROJECT = nox.project.load_toml("pyproject.toml")
 PYTHON_VERSIONS = nox.project.python_versions(PYPROJECT)
 
-PYTHON_ALL_VERSIONS = [*PYTHON_VERSIONS, "pypy3.8", "pypy3.9", "pypy3.10", "pypy3.11"]
+PYTHON_ALL_VERSIONS = [*PYTHON_VERSIONS, "pypy3.9", "pypy3.10", "pypy3.11"]
 
 SKBUILD_CORE_REQ = os.environ.get("SKBUILD_CORE_REQ", "scikit-build-core[setuptools]>=1.0")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "scikit-build"
 dynamic = ["version", "readme"]
 description = "Improved build system generator for Python C/C++/Fortran/Cython extensions"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "The scikit-build team" },
 ]
@@ -19,7 +19,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -109,7 +108,7 @@ replacement = '[@\1](https://github.com/\1)'
 [tool.mypy]
 files = ["skbuild", "tests"]
 exclude = ["tests/samples"]
-python_version = "3.8"
+python_version = "3.9"
 warn_unused_configs = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 strict = true
@@ -129,7 +128,7 @@ ignore_missing_imports = true
 
 
 [tool.pylint]
-py-version = "3.8"
+py-version = "3.9"
 jobs = "0"
 reports.output-format = "colorized"
 similarities.ignore-imports = "yes"
@@ -221,7 +220,6 @@ extend-select = [
   "EXE",         # flake8-executable
   "NPY",         # NumPy specific rules
 ]
-typing-modules = ["skbuild._compat.typing"]
 ignore = ["PLR2004", "PLR09", "SIM117"]
 flake8-unused-arguments.ignore-variadic-names = true
 isort.known-third-party = ["distutils"]

--- a/tests/pytest_helpers.py
+++ b/tests/pytest_helpers.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 import tarfile
 from importlib import metadata
 from zipfile import ZipFile
@@ -36,7 +35,7 @@ def check_sdist_content(sdist_archive, expected_distribution_name, expected_cont
         f"{egg_info_dir}/SOURCES.txt",
     }
 
-    if sdist_zip and sys.version_info > (3, 7, 1):
+    if sdist_zip:
         # Add directory entries in ZIP files created by distutils.
         # See https://github.com/python/cpython/pull/9419
         for entry in expected_content:

--- a/tests/samples/issue-668-symbol-visibility/setup.py
+++ b/tests/samples/issue-668-symbol-visibility/setup.py
@@ -9,5 +9,5 @@ setup(
     author="The scikit-build team",
     license="MIT",
     packages=["hello"],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
 )

--- a/tests/samples/issue-707-nested-packages/setup.py
+++ b/tests/samples/issue-707-nested-packages/setup.py
@@ -9,5 +9,5 @@ setup(
     author="The scikit-build team",
     license="MIT",
     packages=["hello_nested", "hello_nested.goodbye_nested"],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
 )


### PR DESCRIPTION
Used my drop Python skill (https://github.com/henryiii/skills/blob/main/drop-python/SKILL.md).

:robot: _AI text below_ :robot:

Drops Python 3.8; the minimum is now 3.9 (including PyPy). Updates classifiers, mypy/pylint targets, CI (3.9 now runs on all OSs as the minimum), Azure, nox, and docs.

Also removes leftovers from the #1185 `_compat` removal: the stale ruff `typing-modules` setting and the matching AGENTS.md text, plus an always-true `sys.version_info > (3, 7, 1)` check in a test helper.

Verified locally with `nox -s tests-3.9` on the hello-cpp tests.