### PR TITLE
feat!: drop Python 3.9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       # Minimum and maximum Python on all OS's, a couple of middle versions on Linux.
       matrix:
         runs-on: [ubuntu-latest, macos-15-intel, windows-2022, windows-latest]
-        python: ["3.9", "3.14"]
+        python: ["3.10", "3.14"]
         include:
         - { runs-on: ubuntu-latest, python: "3.11" }
         - { runs-on: ubuntu-latest, python: "3.13" }
@@ -66,7 +66,7 @@ jobs:
 
 
   cygwin:
-    name: Tests on 🐍 3.9 • cygwin
+    name: Tests on 🐍 3.12 • cygwin
     runs-on: windows-latest
     timeout-minutes: 120
 
@@ -78,16 +78,16 @@ jobs:
     - uses: cygwin/cygwin-install-action@v6
       with:
         platform: x86_64
-        packages: cmake ninja git make gcc-g++ gcc-fortran python39 python39-devel python39-pip
+        packages: cmake ninja git make gcc-g++ gcc-fortran python312 python312-devel python312-pip
 
     - name: Install nox
-      run: python3.9 -m pip install nox
+      run: python3.12 -m pip install nox
 
     - name: Run tests
       env:
         TMP: /tmp
         TEMP: /tmp
-      run: python3.9 -m nox -s tests-3.9 -- --durations=20
+      run: python3.12 -m nox -s tests-3.12 -- --durations=20
 
 
   tests-pypy:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to agents when working with code in this repository.
 
 ## What this is
 
-scikit-build (classic) is glue between setuptools and CMake: it lets `setup.py` projects build C/C++/Fortran/Cython extensions with CMake. It is in maintenance mode; new development happens in its successor, scikit-build-core. Supports Python 3.9+ and PyPy.
+scikit-build (classic) is glue between setuptools and CMake: it lets `setup.py` projects build C/C++/Fortran/Cython extensions with CMake. It is in maintenance mode; new development happens in its successor, scikit-build-core. Supports Python 3.10+ and PyPy.
 
 ## Commands
 
@@ -41,4 +41,4 @@ Errors are reported via `SKBuildError` (`skbuild/exceptions.py`).
 
 - Type checking is strict mypy for `skbuild/` (untyped defs allowed in `tests/`); run via pre-commit.
 - Ruff enforces `from __future__ import annotations` in every file; line length 120.
-- CI must pass on Python 3.9 — no 3.10+ only constructs.
+- CI must pass on Python 3.10 — no 3.11+ only constructs.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -111,7 +111,7 @@ Before you submit a pull request, check that it meets these guidelines:
    your new functionality into a function with a docstring, and add the
    feature to the list in ``README.md``.
 
-3. The pull request should work for Python 3.9+ and PyPy.  Make sure that
+3. The pull request should work for Python 3.10+ and PyPy.  Make sure that
    the tests pass for all supported Python versions in CI on your PR.
 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,12 +9,12 @@ jobs:
 
     strategy:
       matrix:
-        Python39:
+        Python310:
           python.arch: 'x86'
-          python.version: '3.9'
-        Python39-x64:
+          python.version: '3.10'
+        Python310-x64:
           python.arch: 'x64'
-          python.version: '3.9'
+          python.version: '3.10'
       maxParallel: 2
 
     steps:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -119,7 +119,7 @@ Make a fold name my_project as your project root folder, place the following in 
         author='The scikit-build team',
         license="MIT",
         packages=['hello'],
-        python_requires=">=3.9",
+        python_requires=">=3.10",
     )
 
 Your project now uses scikit-build instead of setuptools.

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,7 +14,7 @@ nox.options.default_venv_backend = "uv|virtualenv"
 PYPROJECT = nox.project.load_toml("pyproject.toml")
 PYTHON_VERSIONS = nox.project.python_versions(PYPROJECT)
 
-PYTHON_ALL_VERSIONS = [*PYTHON_VERSIONS, "pypy3.9", "pypy3.10", "pypy3.11"]
+PYTHON_ALL_VERSIONS = [*PYTHON_VERSIONS, "pypy3.10", "pypy3.11"]
 
 SKBUILD_CORE_REQ = os.environ.get("SKBUILD_CORE_REQ", "scikit-build-core[setuptools]>=1.0")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "scikit-build"
 dynamic = ["version", "readme"]
 description = "Improved build system generator for Python C/C++/Fortran/Cython extensions"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "The scikit-build team" },
 ]
@@ -19,7 +19,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -109,7 +108,7 @@ replacement = '[@\1](https://github.com/\1)'
 [tool.mypy]
 files = ["skbuild", "tests"]
 exclude = ["tests/samples"]
-python_version = "3.9"
+python_version = "3.10"
 warn_unused_configs = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 strict = true
@@ -129,7 +128,7 @@ ignore_missing_imports = true
 
 
 [tool.pylint]
-py-version = "3.9"
+py-version = "3.10"
 jobs = "0"
 reports.output-format = "colorized"
 similarities.ignore-imports = "yes"

--- a/tests/samples/issue-668-symbol-visibility/setup.py
+++ b/tests/samples/issue-668-symbol-visibility/setup.py
@@ -9,5 +9,5 @@ setup(
     author="The scikit-build team",
     license="MIT",
     packages=["hello"],
-    python_requires=">=3.9",
+    python_requires=">=3.10",
 )

--- a/tests/samples/issue-707-nested-packages/setup.py
+++ b/tests/samples/issue-707-nested-packages/setup.py
@@ -9,5 +9,5 @@ setup(
     author="The scikit-build team",
     license="MIT",
     packages=["hello_nested", "hello_nested.goodbye_nested"],
-    python_requires=">=3.9",
+    python_requires=">=3.10",
 )


### PR DESCRIPTION
To keep projects that follow EoL from having old versions broken, going 3.10+ here.

:robot: _AI text below_ :robot:

Raise the minimum Python to 3.10. Removes the 3.9 classifier, bumps mypy/pylint targets, updates CI matrices and docs, and drops pypy3.9 from nox. The Cygwin CI job moves to Python 3.12, since Cygwin no longer packages 3.10 or 3.11.