### PR TITLE
docs: review and update for the scikit-build-core backend

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -89,7 +89,7 @@ Ready to contribute? Here's how to set up ``scikit-build`` for local development
    If you would like to check all Python versions and you don't happen to have them
    all installed locally, you can use the manylinux docker image instead:
 
-   $ docker run --rm -itv $PWD:/src -w /src quay.io/pypa/manylinux_2_24_x86_64:latest pipx run nox
+   $ docker run --rm -itv $PWD:/src -w /src quay.io/pypa/manylinux_2_28_x86_64:latest pipx run nox
 
 6. Commit your changes and push your branch to GitHub::
 
@@ -107,9 +107,7 @@ Before you submit a pull request, check that it meets these guidelines:
 
 1. The pull request should include tests.
 
-2. If the pull request adds functionality, the docs should be updated. Put
-   your new functionality into a function with a docstring, and add the
-   feature to the list in ``README.md``.
+2. If the pull request adds functionality, the docs should be updated.
 
 3. The pull request should work for Python 3.9+ and PyPy.  Make sure that
    the tests pass for all supported Python versions in CI on your PR.
@@ -124,7 +122,7 @@ To run a subset of tests::
 
 You can build and serve the docs::
 
-    $ nox -s docs -- serve
+    $ nox -s docs -- --serve
 
 You can build an SDist and a wheel in the ``dist`` folder::
 

--- a/docs/generators.rst
+++ b/docs/generators.rst
@@ -47,7 +47,7 @@ for each operating system.
     +------------------+---------------------------+-------------------------+-----------------------------------+
     |                  | Linux                     | MacOSX                  | Windows                           |
     +==================+===========================+=========================+===================================+
-    | **C runtime**    | `GNU C Library (glibc)`_  | `libSystem library`_    | `Microsoft C run-time library`_   |
+    | **C runtime**    | `GNU C Library (glibc)`_  | libSystem               | `Microsoft C run-time library`_   |
     +------------------+---------------------------+-------------------------+-----------------------------------+
     | **Compiler**     | `GNU compiler (gcc)`_     | `clang`_                | Microsoft C/C++ Compiler (cl.exe) |
     +------------------+---------------------------+-------------------------+-----------------------------------+
@@ -58,7 +58,6 @@ for each operating system.
 .. _GNU C Library (glibc): https://en.wikipedia.org/wiki/GNU_C_Library
 .. _Package manager: https://en.wikipedia.org/wiki/Package_manager
 .. _Microsoft C run-time library: https://en.wikipedia.org/wiki/Microsoft_Windows_library_files#Runtime_libraries
-.. _libSystem library: https://www.safaribooksonline.com/library/view/mac-os-x/0596003560/ch05s02.html
 .. _XCode: https://en.wikipedia.org/wiki/Xcode#Version_comparison_table
 .. _Microsoft Windows SDK: https://en.wikipedia.org/wiki/Microsoft_Windows_SDK
 .. _Microsoft Visual Studio: https://en.wikipedia.org/wiki/Microsoft_Visual_Studio

--- a/docs/hacking.rst
+++ b/docs/hacking.rst
@@ -7,8 +7,8 @@ Where the build backend lives
 
 .. versionchanged:: 1.0
 
-    The ``skbuild.cmaker`` module and the rest of the classic build backend
-    were removed.
+    The classic build backend was removed; a few internal modules survive as
+    deprecated shims.
 
 The build backend is provided by the setuptools plugin of `scikit-build-core
 <https://scikit-build-core.readthedocs.io>`_; ``skbuild`` is a thin wrapper
@@ -16,6 +16,13 @@ around it that re-exports ``setup()`` and ships the scikit-build CMake
 modules. If you want to hack on how projects are configured and built, look
 at the `scikit-build-core repository
 <https://github.com/scikit-build/scikit-build-core>`_.
+
+The public Python API is ``skbuild.setup`` and
+``skbuild.exceptions.SKBuildError``. Anything else is deprecated:
+``skbuild.cmaker``, ``skbuild.constants``, ``skbuild.utils`` and
+``skbuild.setuptools_wrap`` are compatibility shims that warn on import and
+keep only the handful of helpers downstream ``setup.py`` files use (see
+below).
 
 .. _internal_api:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -43,18 +43,19 @@ Compiler Toolchain
 
 The same compiler toolchain used to build the CPython interpreter should also
 be available. Refer to the
-`CPython Developer's Guide <https://docs.python.org/devguide/setup.html#build-dependencies>`_
+`CPython Developer's Guide <https://devguide.python.org/getting-started/setup-building/#install-dependencies>`_
 for details about the compiler toolchain for your operating system.
 
 For example, on *Ubuntu Linux*, install with::
 
     $ sudo apt-get install build-essential
 
-On *Mac OSX*, install `XCode <https://developer.apple.com/xcode/>`_ to build
-packages for the system Python.
+On *macOS*, install `Xcode <https://developer.apple.com/xcode/>`_ or the
+command line tools (``xcode-select --install``).
 
-On Windows, install `the version of Visual Studio used to create the target
-version of CPython <https://docs.python.org/devguide/setup.html#windows>`_
+On *Windows*, install `Visual Studio
+<https://visualstudio.microsoft.com/visual-cpp-build-tools/>`_ with the C++
+workload.
 
 .. _installation_cmake:
 
@@ -62,9 +63,8 @@ CMake
 ^^^^^
 
 The easiest way to get `CMake <https://www.cmake.org/>`_ is :ref:`to add it to
-the pyproject.toml file <basic_usage_example>`.  With pip 10 or later, this
-will cause the CMake Python package to be downloaded and installed when your
-project is built.
+the pyproject.toml file <basic_usage_example>`. The CMake Python package is
+then downloaded and installed when your project is built.
 
 To manually install the *cmake* package from PyPI::
 

--- a/docs/make_a_release.rst
+++ b/docs/make_a_release.rst
@@ -15,6 +15,11 @@ Prerequisites
 
 * You have a `GPG signing key <https://help.github.com/articles/generating-a-new-gpg-key/>`_.
 
+* You can push to the repository and create GitHub releases. No PyPI
+  credentials are needed: publishing the GitHub release triggers a GitHub
+  Actions workflow that builds the package and uploads it to `PyPI`_ using
+  trusted publishing.
+
 -------------------------
 Documentation conventions
 -------------------------
@@ -27,35 +32,6 @@ Commands to evaluate starts with a dollar sign. For example::
   Hello
 
 means that ``echo "Hello"`` should be copied and evaluated in the terminal.
-
-----------------------
-Setting up environment
-----------------------
-
-1. First, `register for an account on PyPI <https://pypi.org>`_.
-
-
-2. If not already the case, ask to be added as a ``Package Index Maintainer``.
-
-
-3. Create a ``~/.pypirc`` file with your login credentials::
-
-    [distutils]
-    index-servers =
-      pypi
-      pypitest
-
-    [pypi]
-    username=<your-username>
-    password=<your-password>
-
-    [pypitest]
-    repository=https://test.pypi.org/legacy/
-    username=<your-username>
-    password=<your-password>
-
-  where ``<your-username>`` and ``<your-password>`` correspond to your PyPI account.
-
 
 ---------------------
 `PyPI`_: Step-by-step
@@ -131,6 +107,9 @@ Setting up environment
 
     For examples of releases, see https://github.com/scikit-build/scikit-build/releases
 
+  Publishing the release triggers the ``CD`` GitHub Actions workflow, which
+  builds the SDist and wheel and uploads them to `PyPI`_.
+
 
 9. Add a ``Next Release`` section back in ``CHANGES.md``, commit and push local changes.
 
@@ -149,15 +128,10 @@ Setting up environment
     For examples of announcements, see https://github.com/orgs/scikit-build/discussions/categories/announcements
 
 
-.. _virtualenvwrapper: https://virtualenvwrapper.readthedocs.io/
-.. _virtualenv: http://virtualenv.readthedocs.io
-.. _venv: https://docs.python.org/3/library/venv.html
-
 .. _Azure Pipelines: https://dev.azure.com/scikit-build/scikit-build/_build
 .. _GitHub Actions: https://github.com/scikit-build/scikit-build/actions
 
 .. _PyPI: https://pypi.org/project/scikit-build
-.. _TestPyPI: https://test.pypi.org/project/scikit-build
 
 .. _scikit-build discussions board: https://github.com/orgs/scikit-build/discussions/categories/announcements
 
@@ -167,7 +141,7 @@ Setting up environment
 
 .. warning::
 
-   Publishing on conda requires to have corresponding the corresponding Github release.
+   Publishing on conda requires the corresponding GitHub release.
 
 After a GitHub release is created in the `scikit-build <https://github.com/scikit-build/scikit-build>`_ project
 and after the conda-forge `Autoticking Bot <https://justcalamari.github.io/jekyll/update/2018/06/11/introduction.html>`_

--- a/docs/skbuild.rst
+++ b/docs/skbuild.rst
@@ -16,3 +16,31 @@ skbuild.exceptions module
    :members:
    :undoc-members:
    :show-inheritance:
+
+Deprecated shims
+----------------
+
+These modules exist only for compatibility with scikit-build <1.0 and warn
+with ``DeprecationWarning`` on import.
+
+skbuild.cmaker module
+^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: skbuild.cmaker
+   :members:
+
+skbuild.constants module
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: skbuild.constants
+   :members:
+
+skbuild.setuptools_wrap module
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: skbuild.setuptools_wrap
+
+skbuild.utils module
+^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: skbuild.utils

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -5,12 +5,18 @@
 Why should I use scikit-build ?
 ===============================
 
-Scikit-build is a replacement for `distutils.core.Extension <https://docs.python.org/3/distutils/apiref.html?highlight=extension#distutils.core.Extension>`_
-with the following advantages:
+Scikit-build is a replacement for `setuptools.Extension
+<https://setuptools.pypa.io/en/latest/userguide/ext_modules.html>`_ that
+builds extension modules with CMake, providing:
 
-- provide better support for :doc:`additional compilers and build systems </generators>`
+- better support for :doc:`additional compilers and build systems </generators>`
 - first-class :ref:`cross-compilation <cross_compilation>` support
 - location of dependencies and their associated build requirements
+
+Scikit-build is a lightweight wrapper around the setuptools plugin of
+`scikit-build-core <https://scikit-build-core.readthedocs.io>`_. Use it when
+you have an existing ``setup.py``-based project or need setuptools features;
+for new projects, use scikit-build-core directly.
 
 .. _migration_guide:
 
@@ -69,9 +75,14 @@ The following changes are breaking:
   the minimum CMake version is configured with the ``cmake.version`` setting
   in the ``[tool.scikit-build]`` table of ``pyproject.toml``.
 
-- The Python modules ``skbuild.cmaker``, ``skbuild.constants``,
-  ``skbuild.command.*``, ``skbuild.platform_specifics``, ``skbuild.utils``
-  and ``skbuild.setuptools_wrap`` no longer exist.
+- The internal Python API is gone; only ``skbuild.setup`` and
+  ``skbuild.exceptions.SKBuildError`` remain public.
+  ``skbuild.command.*`` and ``skbuild.platform_specifics`` were removed.
+  ``skbuild.cmaker``, ``skbuild.constants``, ``skbuild.utils`` and
+  ``skbuild.setuptools_wrap`` remain importable as deprecated shims that
+  warn on import: ``skbuild.cmaker`` keeps only ``get_cmake_version()``,
+  ``skbuild.constants`` keeps only ``CMAKE_INSTALL_DIR()`` and
+  ``skbuild_plat_name()``, and the last two expose nothing.
   ``skbuild.exceptions.SKBuildError`` is now an alias of setuptools'
   ``SetupError``, so it is no longer a ``RuntimeError``; its
   ``SKBuildInvalidFileInstallationError`` and
@@ -187,79 +198,21 @@ Setup options
 setuptools options
 ^^^^^^^^^^^^^^^^^^
 
-The section below documents some of the options accepted by the ``setup()``
-function. These currently must be passed in your ``setup.py``, not in
-``setup.cfg``, as scikit-build intercepts them and inspects them. This
-restriction may be relaxed in the future. Setuptools options not listed here can
-be placed in ``setup.cfg`` as normal.
+.. versionchanged:: 1.0
 
-- ``packages``: Explicitly list of all packages to include in the distribution. Setuptools will not recursively
-  scan the source tree looking for any directory with an ``__init__.py`` file. To automatically generate the list
-  of packages, see `Using find_package()`_.
+    scikit-build no longer intercepts or rewrites setuptools options.
 
-- ``package_dir``: A mapping of package to directory names
-
-- ``include_package_data``: If set to ``True``, this tells setuptools to automatically include any data files it finds
-  inside your package directories that are specified by your ``MANIFEST.in`` file. For more information, see the setuptools
-  documentation section on `Including Data Files`_. scikit-build matches
-  `the setuptools behavior <https://setuptools.pypa.io/en/latest/history.html#id255>`__ of defaulting this parameter to
-  ``True`` if a pyproject.toml file exists and contains either the ``project`` or ``tool.setuptools`` table.
-
-- ``package_data``: A dictionary mapping package names to lists of glob patterns. For a complete description and examples,
-  see the setuptools documentation section on `Including Data Files`_.
-  You do not need to use this option if you are using include_package_data, unless you need to add e.g. files that are generated
-  by your setup script and build process. (And are therefore not in source control or are files that you don't want to include
-  in your source distribution.)
-
-- ``exclude_package_data``: Dictionary mapping package names to lists of glob patterns that should be excluded from
-  the package directories. You can use this to trim back any excess files included by include_package_data.
-  For a complete description and examples, see the setuptools documentation section on `Including Data Files`_.
-
-- ``py_modules``: List all modules rather than listing packages. More details in the `Listing individual modules`_
-  section of the distutils documentation.
-
-- ``data_files``: Sequence of ``(directory, files)`` pairs. Each ``(directory, files)`` pair in the sequence specifies
-  the installation directory and the files to install there. More details in the `Installing Additional Files`_
-  section of the setuptools documentation.
-
-- ``entry_points``: A dictionary mapping entry point group names to strings or lists of strings defining the entry points.
-  Entry points are used to support dynamic discovery of services or plugins provided by a project.
-  See `Dynamic Discovery of Services and Plugins`_ for details and examples of the format of this argument. In addition,
-  this keyword is used to support `Automatic Script Creation`_. Note that if using ``pyproject.toml`` for configuration,
-  the requirement to put ``entry_points`` in ``setup.py`` also requires that the ``project`` section include ``entry_points``
-  in the ``dynamic`` section.
-
-- ``scripts``: List of python script relative paths. If the first line of the script starts with ``#!`` and contains the
-  word ``python``, the Distutils will adjust the first line to refer to the current interpreter location.
-  More details in the `Installing Scripts <https://docs.python.org/3/distutils/setupscript.html#installing-scripts>`_ section
-  of the distutils documentation.
-
-.. versionadded:: 0.8.0
-
-- ``zip_safe``: A boolean indicating if the Python packages may be run directly from a zip file. If not already
-  set, scikit-build sets this option to ``False``. See `Setting the zip_safe flag`_
-  section of the setuptools documentation.
-
-.. note::
-
-    As specified in the `Wheel documentation`_, the ``universal`` and ``python-tag`` options
-    have no effect.
-
-.. _Using find_package(): https://setuptools.readthedocs.io/en/latest/setuptools.html#using-find-packages
-.. _Including Data Files: https://setuptools.readthedocs.io/en/latest/setuptools.html#including-data-files
-.. _Installing Additional Files: https://docs.python.org/3/distutils/setupscript.html#installing-additional-files
-.. _Listing individual modules: https://docs.python.org/3/distutils/setupscript.html#listing-individual-modules
-.. _Dynamic Discovery of Services and Plugins: https://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins
-.. _Automatic Script Creation: https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation
-.. _Setting the zip_safe flag: https://setuptools.readthedocs.io/en/latest/setuptools.html#setting-the-zip-safe-flag
-.. _Wheel documentation: https://wheel.readthedocs.io/en/stable/
+Standard setuptools options are handled by setuptools itself and can be
+declared in ``setup.py``, ``setup.cfg``, or the ``[project]`` table of
+``pyproject.toml`` as usual. See the `setuptools documentation
+<https://setuptools.pypa.io/en/latest/userguide/>`_.
 
 scikit-build options
 ^^^^^^^^^^^^^^^^^^^^
 
 Scikit-build augments the ``setup()`` function with the following options:
 
-- ``cmake_args``: List of `CMake options <https://cmake.org/cmake/help/v3.6/manual/cmake.1.html#options>`_.
+- ``cmake_args``: List of `CMake options <https://cmake.org/cmake/help/latest/manual/cmake.1.html#options>`_.
 
 For example::
 
@@ -307,6 +260,14 @@ For example::
       [...]
     )
 
+These options are described in more detail in the `scikit-build-core
+setuptools plugin documentation
+<https://scikit-build-core.readthedocs.io/en/latest/plugins/setuptools.html>`__.
+All other scikit-build-core settings can be set in the ``[tool.scikit-build]``
+table of ``pyproject.toml``; see the `scikit-build-core configuration
+documentation
+<https://scikit-build-core.readthedocs.io/en/latest/configuration/index.html>`__.
+
 .. versionchanged:: 1.0
 
     The ``cmake_with_sdist`` option now raises an error if set to ``True``,
@@ -336,11 +297,6 @@ In addition, the ``build_cmake`` command accepts the ``--source-dir``,
 
     python setup.py build_cmake --cmake-args="-DSOME_FEATURE:BOOL=OFF" --parallel 3
 
-.. note::
-
-    As specified in the `Wheel documentation`_, the ``--universal`` and ``--python-tag`` options
-    have no effect.
-
 
 ==============
 Advanced Usage
@@ -366,48 +322,20 @@ and a python wheel, it is possible to test for the variable ``SKBUILD``:
 Adding cmake as building requirement only if not installed or too low a version
 -------------------------------------------------------------------------------
 
-If systematically installing cmake wheel is not desired, it is possible to set it using an ``in-tree backend``.
-For this purpose place the following configuration in your ``pyproject.toml``::
+.. versionchanged:: 1.0
+
+    This previously required writing an in-tree build backend by hand.
+
+Use scikit-build-core's PEP 517 backend instead of ``setuptools.build_meta``;
+it adds ``cmake`` (and ``ninja``) to the build requirements only when a
+suitable version is not already available::
 
     [build-system]
-    requires = [
-      "setuptools>=42",
-      "packaging",
-      "scikit-build",
-      "ninja; platform_system!='Windows'"
-    ]
-    build-backend = "backend"
-    backend-path = ["_custom_build"]
+    requires = ["setuptools", "scikit-build"]
+    build-backend = "scikit_build_core.setuptools.build_meta"
 
-then you can implement a thin wrapper around ``build_meta`` in the ``_custom_build/backend.py`` file::
-
-    import re
-    import subprocess
-
-    from setuptools import build_meta as _orig
-
-    prepare_metadata_for_build_wheel = _orig.prepare_metadata_for_build_wheel
-    build_wheel = _orig.build_wheel
-    build_sdist = _orig.build_sdist
-    get_requires_for_build_sdist = _orig.get_requires_for_build_sdist
-
-    def get_requires_for_build_wheel(config_settings=None):
-        from packaging import version
-        packages = []
-        try:
-            output = subprocess.run(
-                ["cmake", "--version"], check=True, capture_output=True, text=True
-            ).stdout
-            cmake_version = re.match(r"cmake version (\S+)", output).group(1)
-            if version.parse(cmake_version) < version.parse("3.15"):
-                packages.append('cmake')
-        except (OSError, subprocess.CalledProcessError, AttributeError):
-            packages.append('cmake')
-
-        return _orig.get_requires_for_build_wheel(config_settings) + packages
-
-Also see `scikit-build-core <https://scikit-build-core.readthedocs.io>`_ where
-this is a built-in feature.
+This backend also supports config-settings, e.g. ``pip install .
+-C cmake.build-type=Debug``.
 
 .. _usage_enabling_parallel_build:
 
@@ -431,10 +359,8 @@ For example, to  limit the number of parallel jobs to ``3``, the following could
     python setup.py build_cmake --parallel 3
 
 For complex projects where more granularity is required, it is also possible to limit
-the number of simultaneous link jobs, or compile jobs, or both.
-
-Indeed, starting with CMake 3.11, it is possible to configure the project with these
-options:
+the number of simultaneous link jobs, or compile jobs, or both, by configuring
+the project with these options:
 
 * `CMAKE_JOB_POOL_COMPILE <https://cmake.org/cmake/help/latest/variable/CMAKE_JOB_POOL_COMPILE.html>`_
 * `CMAKE_JOB_POOL_LINK <https://cmake.org/cmake/help/latest/variable/CMAKE_JOB_POOL_LINK.html>`_
@@ -500,22 +426,10 @@ For example::
 Support for isolated build
 --------------------------
 
-.. versionadded:: 0.8.0
-
-As specified in `PEP 518`_, dependencies required at install time can be specified using a
-``pyproject.toml`` file. Starting with pip 10.0, pip reads the ``pyproject.toml`` file and
-installs the associated dependencies in an isolated environment. See the `pip build system interface`_
-documentation.
-
-An isolated environment will be created when using pip to install packages directly from
-source or to create an editable installation.
-
-scikit-build supports these use cases as well as the case where the isolated environment support
-is explicitly disabled using the pip option ``--no-build-isolation`` available with the ``install``,
-``download`` and ``wheel`` commands.
-
-.. _PEP 518: https://www.python.org/dev/peps/pep-0518/
-.. _pip build system interface: https://pip.pypa.io/en/stable/reference/pip/#build-system-interface
+Build frontends like ``pip`` and ``build`` install the
+``build-system.requires`` entries from ``pyproject.toml`` into an isolated
+environment before building. scikit-build supports isolated builds, as well
+as builds with isolation disabled (``pip install --no-build-isolation``).
 
 
 Editable installs
@@ -531,6 +445,10 @@ scikit-build-core's "inplace" editable mode in ``pyproject.toml``::
 
     [tool.scikit-build]
     editable.mode = "inplace"
+
+For details, including setuptools' strict editable mode, see the
+`scikit-build-core setuptools plugin documentation
+<https://scikit-build-core.readthedocs.io/en/latest/plugins/setuptools.html#editable-installs>`__.
 
 
 .. _optimized_incremental_build:
@@ -558,15 +476,19 @@ Scikit-build support environment variables to configure some options. These are:
 ``CMAKE_GENERATOR``
   This selects the CMake generator to use. See :doc:`/generators`.
 
+``SKBUILD_CONFIGURE_OPTIONS``
+  Extra arguments appended when configuring CMake, like ``CMAKE_ARGS``.
+
+``SKBUILD_BUILD_OPTIONS``
+  Extra arguments forwarded to ``cmake --build``. Use a leading ``--`` to
+  pass native build-tool options, e.g. ``SKBUILD_BUILD_OPTIONS="-- -l4"``.
+
+Both ``SKBUILD_*_OPTIONS`` variables are split following shell quoting rules
+and only honored when building through ``skbuild.setup()``.
+
 In addition, every scikit-build-core setting can be set using a corresponding
 ``SKBUILD_*`` environment variable. See the `scikit-build-core configuration
 documentation <https://scikit-build-core.readthedocs.io/en/latest/configuration/index.html>`__.
-
-.. versionchanged:: 1.0
-
-    The ``SKBUILD_CONFIGURE_OPTIONS`` and ``SKBUILD_BUILD_OPTIONS``
-    environment variables were removed; use ``CMAKE_ARGS`` and
-    ``CMAKE_BUILD_PARALLEL_LEVEL`` instead.
 
 
 .. _cross_compilation:
@@ -574,35 +496,10 @@ documentation <https://scikit-build-core.readthedocs.io/en/latest/configuration/
 Cross-compilation
 -----------------
 
-See `CMake Toolchains <https://cmake.org/cmake/help/v3.6/manual/cmake-toolchains.7.html>`_.
-
-
-Introduction to dockross
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. note:: *To be documented.* See :issue:`227`.
-
-
-Using dockcross-manylinux to generate Linux wheels
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. note:: *To be documented.* See :issue:`227`.
-
-
-Using dockcross-mingwpy to generate Windows wheels
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. note:: *To be documented.* See :issue:`227`.
-
-
-Examples for scikit-build developers
-------------------------------------
-
-.. note:: *To be documented.* See :issue:`227`.
-
-    Provide small, self-contained setup function calls for (at least) two use
-    cases:
-
-    - when a `CMakeLists.txt` file already exists
-    - when a user wants scikit-build to create a `CMakeLists.txt` file based
-      on the user specifying some input files.
+Cross-compilation works through the standard CMake mechanisms (`CMake
+toolchains
+<https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html>`_). See
+the scikit-build-core `cross-compilation guide
+<https://scikit-build-core.readthedocs.io/en/latest/guide/crosscompile.html>`_;
+tools like `cibuildwheel <https://cibuildwheel.pypa.io>`_ handle the common
+macOS and Windows cases automatically.


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Docs pass now that scikit-build wraps scikit-build-core's setuptools plugin.

Corrects two wrong claims in the 1.0 migration guide:
- `skbuild.cmaker`/`constants`/`utils`/`setuptools_wrap` are deprecated shims that warn on import, not removed (#1185's compat shims); `command.*` and `platform_specifics` are gone.
- `SKBUILD_CONFIGURE_OPTIONS` and `SKBUILD_BUILD_OPTIONS` still work through `skbuild.setup()` (core's `build_cmake` honors them in wrapper-compat mode); they are now documented in the environment-variable section instead of listed as removed.

Removes content that no longer applies: the per-option setuptools list (dead distutils links, stale interception/`zip_safe` claims), the hand-written in-tree backend for conditional cmake (`scikit_build_core.setuptools.build_meta` does this natively and adds `-C` support), the dockcross "to be documented" stubs, and the `.pypirc` password setup in the release guide (publishing uses trusted publishing via `cd.yml`).

Links into the scikit-build-core docs for the plugin options, editable installs (incl. strict mode), configuration, and cross-compilation. The internal API page now autodocs the shim modules under "Deprecated shims". Anchors referenced from CHANGES.md are kept since the changelog is spliced into the docs and sphinx runs with `-W`.

Verified with `nox -s docs` (warnings as errors) and pre-commit.