### PR TITLE
docs: recommend the scikit-build-core setuptools backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,56 @@
 
 The scikit-build package is fundamentally just glue between the `setuptools` Python module and [CMake](https://cmake.org).
 
-The next generation of scikit-build, [scikit-build-core](https://scikit-build-core.readthedocs.io), provides a simple, reliable build backend for CMake that does not use setuptools and provides a lot of new features. Since scikit-build 1.0, scikit-build (classic) is a thin wrapper around scikit-build-core's setuptools plugin. If you do not require setuptools, you should consider using scikit-build-core directly instead.
+The next generation of scikit-build, [scikit-build-core](https://scikit-build-core.readthedocs.io), provides a simple, reliable build backend for CMake that does not use setuptools and provides a lot of new features. Since scikit-build 1.0, scikit-build (classic) is a thin wrapper around scikit-build-core's setuptools plugin. If you do not require setuptools, you should consider using scikit-build-core directly instead. This package only adds the legacy CMake helper modules (which have modern equivalents) and the compatibility `setup()` wrapper.
 
 To get started, see [this example](https://scikit-build.readthedocs.io/en/latest/usage.html#example-of-setup-py-cmakelists-txt-and-pyproject-toml). For more examples, see [scikit-build-sample-projects](https://github.com/scikit-build/scikit-build-sample-projects).
+
+## Quick upgrade instructions for 1.0
+
+Code should build (using standards-based tools, like `pip`/`uv`/`build`/`cibuildwheel`) as long as you are not using our internals. `setup.py` commands may not work (a few do, like `setup.py build_ext --inplace`, which works better than before). You can now use `tool.scikit-build`, as described by scikit-build-core.
+
+If you keep `from skbuild import setup` in `setup.py`, require scikit-build and use scikit-build-core's setuptools backend for auto-cmake/ninja and config-settings support:
+
+```toml
+[build-system]
+requires = ["scikit-build>=1"]
+build-backend = "scikit_build_core.setuptools.build_meta"
+```
+
+If you want to use scikit-build-core directly but keep setuptools:
+
+```toml
+[build-system]
+requires = ["scikit-build-core[setuptools]>=1"]
+build-backend = "scikit_build_core.setuptools.build_meta"
+```
+
+And either use setup with at least a `cmake_source_dir` argument:
+
+```python
+from setuptools import setup
+
+setup(cmake_source_dir=".")
+```
+
+or the following in your pyproject.toml:
+
+```toml
+[tool.scikit-build]
+cmake.source-dir = "."
+```
+
+Either one of those will cause scikit-build-core's setuptools plugin to activate. The defaults for the native plugin are different from the `skbuild.setup()` wrapper (`scikit_build_core.setuptools.wrapper.setup()`); for example `SKBUILD_CONFIGURE_OPTIONS`/`SKBUILD_BUILD_OPTIONS` are not adapted without the wrapper.
+
+And if you want to use the native, non-setuptools backend:
+
+```toml
+[build-system]
+requires = ["scikit-build-core>=1"]
+build-backend = "scikit_build_core.build"
+```
+
+You'll need to use a `project` table and `tool.scikit-build`; `setup.py`, `MANIFEST.in`, and `setup.cfg` have no effect without setuptools. The native backend is recommended unless you specifically need a setuptools or hatchling plugin, e.g. to combine with other plugins.
 
 <!-- END-INTRO -->
 

--- a/docs/cmake-modules.rst
+++ b/docs/cmake-modules.rst
@@ -4,7 +4,7 @@ CMake modules
 
 To facilitate the writing of ``CMakeLists.txt`` used to build
 CPython C/C++/Cython extensions, **scikit-build** provides the following
-CMake modules:
+historical CMake modules:
 
 .. toctree::
    :maxdepth: 1
@@ -26,3 +26,10 @@ They can be included using ``find_package``:
 
 
 For more details, see the respective documentation of each modules.
+
+New code should not use these. The recommended replacements:
+
+* ``Cython`` -> cython-cmake (on PyPI)
+* ``NumPy`` -> FindPython with NumPy component (CMake built-in)
+* ``PythonExtensions`` -> FindPython (CMake built-in)
+* ``F2PY`` -> f2py-cmake (on PyPI)

--- a/docs/generators.rst
+++ b/docs/generators.rst
@@ -2,6 +2,8 @@
 C Runtime, Compiler and Build System Generator
 ==============================================
 
+.. _Ninja:
+
 Build system generator
 ----------------------
 
@@ -23,15 +25,16 @@ CMake selects its default generator for the current platform, and the
     CMAKE_GENERATOR="Unix Makefiles" pip install .
 
 ``Ninja`` is the recommended generator. It is automatically parallel and is
-available on all platforms; listing the `ninja python package
-<https://pypi.org/project/ninja/>`_ in the ``build-system.requires`` table of
-your ``pyproject.toml`` (see :ref:`basic_usage_example`) ensures it is
-available during the build. On Windows, MSVC 2017 and newer ship with Ninja
-already, so ``ninja`` can be limited to non-Windows systems in
-``build-system.requires``.
+available on all platforms. The recommended
+``scikit_build_core.setuptools.build_meta`` backend (see
+:ref:`basic_usage_example`) adds the `ninja python package
+<https://pypi.org/project/ninja/>`_ to the build requirements automatically
+when no suitable build tool is already available.
 
 For more details about CMake generators, see the `CMake documentation
 <https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html>`_.
+
+.. _Visual Studio IDE:
 
 Compiler
 --------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -50,9 +50,12 @@ projects keep working unchanged:
   ``TRUE`` (still truthy).
 - The standard setuptools commands: ``build``, ``bdist_wheel``, ``sdist``,
   ``install`` and ``build_ext --inplace``.
-- The recommended ``build-system`` table in ``pyproject.toml`` is unchanged:
+- The classic ``build-system`` table:
   ``requires = ["setuptools", "scikit-build", "cmake", "ninja"]`` with
-  ``build-backend = "setuptools.build_meta"``.
+  ``build-backend = "setuptools.build_meta"``. The recommended backend is now
+  ``scikit_build_core.setuptools.build_meta``, which adds ``cmake`` and
+  ``ninja`` only when needed and supports config-settings; see
+  :ref:`basic_usage_example`.
 
 The following changes are breaking:
 
@@ -62,12 +65,10 @@ The following changes are breaking:
   ``--skip-cmake``, ``--install-target``, as well as the
   ``setup.py <setuptools args> -- <cmake args> -- <build tool args>``
   triple-section syntax. Use the ``CMAKE_ARGS`` and ``CMAKE_GENERATOR``
-  environment variables, the ``cmake_args`` keyword of ``setup()``,
+  environment variables, the ``cmake_args`` keyword of ``setup()``, or
   scikit-build-core's ``[tool.scikit-build]`` settings in ``pyproject.toml``
-  (or the equivalent ``SKBUILD_*`` environment variables), or the options of
-  the new ``build_cmake`` setuptools command (``--source-dir``,
-  ``--cmake-args``, ``--parallel`` and ``--debug``) instead. See the
-  `scikit-build-core configuration documentation
+  (or the equivalent ``SKBUILD_*`` environment variables or config-settings)
+  instead. See the `scikit-build-core configuration documentation
   <https://scikit-build-core.readthedocs.io/en/latest/configuration/index.html>`__.
 
 - ``cmake_with_sdist=True`` now raises an error. ``cmake_languages`` and
@@ -119,8 +120,8 @@ Example of setup.py, CMakeLists.txt and pyproject.toml
 ------------------------------------------------------
 The full example code is `Here <https://github.com/scikit-build/scikit-build-sample-projects/tree/master/projects/hello-cpp>`_
 
-Make a fold name my_project as your project root folder, place the following in your project's
-``setup.py`` file::
+Make a folder named ``my_project`` as your project root folder, and place the
+following in your project's ``setup.py`` file::
 
     from skbuild import setup  # This line replaces 'from setuptools import setup'
     setup(
@@ -148,20 +149,22 @@ a C++ extension named ``_hello`` is built::
     python_extension_module(_hello)
     install(TARGETS _hello LIBRARY DESTINATION hello)
 
-Then, add a ``pyproject.toml`` to list the build system requirements::
+Then, add a ``pyproject.toml`` declaring the build backend::
 
     [build-system]
-    requires = [
-        "setuptools>=42",
-        "scikit-build>=0.13",
-        "cmake>=3.18",
-        "ninja",
-    ]
-    build-backend = "setuptools.build_meta"
+    requires = ["scikit-build>=1"]
+    build-backend = "scikit_build_core.setuptools.build_meta"
+
+The ``scikit_build_core.setuptools.build_meta`` backend adds ``cmake`` (and
+``ninja``) to the build requirements only when a suitable version is not
+already available, and supports config-settings (see
+:ref:`usage-setuptools_options`). If you don't want those, you can use the
+standard setuptools backend here; then list ``cmake`` (and ``ninja``) in
+``requires`` yourself.
 
 Make a hello folder inside my_project folder and place `_hello.cxx <https://github.com/scikit-build/scikit-build-sample-projects/blob/8fdbc8a0dd78656ea0b431e005b49f3e19786444/projects/hello-cpp/hello/_hello.cxx>`_ and `__init__.py <https://github.com/scikit-build/scikit-build-sample-projects/blob/8fdbc8a0dd78656ea0b431e005b49f3e19786444/projects/hello-cpp/hello/__init__.py>`_ inside hello folder.
 
-Now every thing is ready, go to my_project's parent folder and type following command to install your extension::
+Now everything is ready; go to my_project's parent folder and type the following command to install your extension::
 
     pip install my_project/.
 
@@ -178,10 +181,6 @@ Try your new extension::
     >>> hello.hello("scikit-build")
     Hello, scikit-build!
     >>>
-
-You can add lower limits to ``cmake`` or ``scikit-build`` as needed. Ninja
-should be limited to non-Windows systems, as MSVC 2017+ ships with Ninja
-already.
 
 ..  note::
 
@@ -286,16 +285,17 @@ Command line options
     ``setup.py <setuptools args> -- <cmake args> -- <build tool args>``
     syntax were removed. See :ref:`migration_guide`.
 
-Only the standard `setuptools command line options
-<https://setuptools.readthedocs.io/en/latest/setuptools.html#command-reference>`_
-are supported. CMake options can be passed using the ``CMAKE_ARGS``
-environment variable, the ``cmake_args`` keyword of ``setup()``, or
-scikit-build-core's ``[tool.scikit-build]`` settings in ``pyproject.toml``.
+Build with a standard frontend like ``pip``, ``build`` or ``uv``. When using
+the ``scikit_build_core.setuptools.build_meta`` backend (see
+:ref:`basic_usage_example`), any scikit-build-core setting can be passed as a
+config-setting::
 
-In addition, the ``build_cmake`` command accepts the ``--source-dir``,
-``--cmake-args``, ``--parallel`` and ``--debug`` options. For example::
+    pip install . -C cmake.build-type=Debug
+    python -m build -C cmake.args="-DSOME_FEATURE:BOOL=OFF"
 
-    python setup.py build_cmake --cmake-args="-DSOME_FEATURE:BOOL=OFF" --parallel 3
+CMake options can also be passed using the ``CMAKE_ARGS`` environment
+variable, the ``cmake_args`` keyword of ``setup()``, or scikit-build-core's
+``[tool.scikit-build]`` settings in ``pyproject.toml``.
 
 
 ==============
@@ -319,106 +319,17 @@ and a python wheel, it is possible to test for the variable ``SKBUILD``:
     The ``SKBUILD`` variable is now set to ``2`` instead of ``TRUE``. Both
     values are truthy in CMake.
 
-Adding cmake as building requirement only if not installed or too low a version
--------------------------------------------------------------------------------
-
-.. versionchanged:: 1.0
-
-    This previously required writing an in-tree build backend by hand.
-
-Use scikit-build-core's PEP 517 backend instead of ``setuptools.build_meta``;
-it adds ``cmake`` (and ``ninja``) to the build requirements only when a
-suitable version is not already available::
-
-    [build-system]
-    requires = ["setuptools", "scikit-build"]
-    build-backend = "scikit_build_core.setuptools.build_meta"
-
-This backend also supports config-settings, e.g. ``pip install .
--C cmake.build-type=Debug``.
-
 .. _usage_enabling_parallel_build:
 
-Enabling parallel build
------------------------
+Parallel builds
+---------------
 
-.. _Ninja:
+The build runs through ``cmake --build``; with the ``Ninja`` generator it is
+parallel by default. Set the `CMAKE_BUILD_PARALLEL_LEVEL
+<https://cmake.org/cmake/help/latest/envvar/CMAKE_BUILD_PARALLEL_LEVEL.html>`_
+environment variable to control the number of parallel jobs::
 
-Ninja
-^^^^^
-
-If the ``Ninja`` generator is used, the associated build tool (called ``ninja``)
-will automatically parallelize the build based on the number of available CPUs.
-
-To limit the number of parallel jobs, set the ``CMAKE_BUILD_PARALLEL_LEVEL``
-environment variable, or pass the ``--parallel`` option to the ``build_cmake``
-command.
-
-For example, to  limit the number of parallel jobs to ``3``, the following could be done::
-
-    python setup.py build_cmake --parallel 3
-
-For complex projects where more granularity is required, it is also possible to limit
-the number of simultaneous link jobs, or compile jobs, or both, by configuring
-the project with these options:
-
-* `CMAKE_JOB_POOL_COMPILE <https://cmake.org/cmake/help/latest/variable/CMAKE_JOB_POOL_COMPILE.html>`_
-* `CMAKE_JOB_POOL_LINK <https://cmake.org/cmake/help/latest/variable/CMAKE_JOB_POOL_LINK.html>`_
-* `CMAKE_JOB_POOLS <https://cmake.org/cmake/help/latest/variable/CMAKE_JOB_POOLS.html>`_
-
-For example, to have at most ``5`` compile jobs and ``2`` link jobs, the following could be done::
-
-    export CMAKE_ARGS="-DCMAKE_JOB_POOL_COMPILE:STRING=compile \
-      -DCMAKE_JOB_POOL_LINK:STRING=link \
-      -DCMAKE_JOB_POOLS:STRING=compile=5;link=2"
-    python setup.py bdist_wheel
-
-Unix Makefiles
-^^^^^^^^^^^^^^
-
-If the ``Unix Makefiles`` generator is used, the associated build tool (called ``make``)
-will **NOT** automatically parallelize the build, the user has to explicitly set
-the number of jobs.
-
-For example, to limit the number of parallel jobs to ``3``, the following could be done::
-
-    CMAKE_BUILD_PARALLEL_LEVEL=3 python setup.py bdist_wheel
-
-
-.. _Visual Studio IDE:
-
-Visual Studio IDE
-^^^^^^^^^^^^^^^^^
-
-If a ``Visual Studio`` generator is used, there are two types of parallelism:
-
-* target level parallelism
-* object level parallelism
-
-.. warning::
-
-    Since finding the right combination of parallelism can be challenging, whenever
-    possible we recommend to use the ``Ninja`` generator.
-
-
-To adjust the object level parallelism, the compiler flag ``/MP[processMax]`` could
-be specified. To learn more, read `/MP (Build with Multiple Processes)
-<https://docs.microsoft.com/en-us/cpp/build/reference/mp-build-with-multiple-processes>`_.
-
-For example::
-
-    set CXXFLAGS=/MP4
-    python setup.py bdist_wheel
-
-The target level parallelism defines the number of simultaneous ``MSBuild.exe``
-processes. It can be set with the ``CMAKE_BUILD_PARALLEL_LEVEL`` environment
-variable. To learn more, read `Building Multiple Projects in Parallel with MSBuild
-<https://msdn.microsoft.com/en-us/library/bb651793.aspx>`_.
-
-For example::
-
-    set CMAKE_BUILD_PARALLEL_LEVEL=4
-    python setup.py bdist_wheel
+    CMAKE_BUILD_PARALLEL_LEVEL=3 pip install .
 
 
 .. _support_isolated_build:
@@ -477,11 +388,10 @@ Scikit-build support environment variables to configure some options. These are:
   This selects the CMake generator to use. See :doc:`/generators`.
 
 ``SKBUILD_CONFIGURE_OPTIONS``
-  Extra arguments appended when configuring CMake, like ``CMAKE_ARGS``.
+  Extra arguments appended when configuring CMake, like ``CMAKE_ARGS``. (Deprecated)
 
 ``SKBUILD_BUILD_OPTIONS``
-  Extra arguments forwarded to ``cmake --build``. Use a leading ``--`` to
-  pass native build-tool options, e.g. ``SKBUILD_BUILD_OPTIONS="-- -l4"``.
+  Extra arguments forwarded to ``cmake --build``. (Deprecated)
 
 Both ``SKBUILD_*_OPTIONS`` variables are split following shell quoting rules
 and only honored when building through ``skbuild.setup()``.


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Follow-up docs work for the 1.0 backend swap:

- README: add quick upgrade instructions for 1.0 (keep the wrapper, use core's setuptools plugin directly, or move to the native backend).
- usage: recommend `scikit_build_core.setuptools.build_meta` in the basic example and command-line section; mark `SKBUILD_*_OPTIONS` deprecated; condense the parallel-build section to `CMAKE_BUILD_PARALLEL_LEVEL`.
- generators: note the backend adds ninja automatically; take over the `Ninja` and `Visual Studio IDE` labels removed from usage.
- cmake-modules: point the legacy modules at their modern replacements (cython-cmake, f2py-cmake, FindPython).

Docs build cleanly with `-W`.