### PR TITLE
ci: test on Python 3.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,8 @@ jobs:
 
     - name: Test on 🐍 ${{ matrix.python }}
       env:
-        # Get numpy nightlies until it publishes 3.15 wheels; PIP_* covers pip's
-        # isolated build envs (pep518 tests), UV_* the nox env install.
-        PIP_EXTRA_INDEX_URL: ${{ matrix.python == '3.15' && 'https://pypi.anaconda.org/scientific-python-nightly-wheels/simple' || '' }}
-        PIP_PRE: ${{ matrix.python == '3.15' && '1' || '0' }}
+        # Get a numpy nightly for the nox env until it publishes 3.15 wheels
+        # (the pep518 wheelhouse handles this itself in conftest.py).
         UV_EXTRA_INDEX_URL: ${{ matrix.python == '3.15' && 'https://pypi.anaconda.org/scientific-python-nightly-wheels/simple' || '' }}
         UV_PRERELEASE: ${{ matrix.python == '3.15' && 'allow' || 'if-necessary-or-explicit' }}
         # The nightly index also carries scikit-build-core dev builds; without

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,14 @@ jobs:
     timeout-minutes: 40
     strategy:
       fail-fast: false
-      # Minimum and maximum Python on all OS's, a couple of middle versions on Linux.
+      # Minimum and maximum stable Python on all OS's, other versions on Linux.
       matrix:
         runs-on: [ubuntu-latest, macos-15-intel, windows-2022, windows-latest]
         python: ["3.10", "3.14"]
         include:
         - { runs-on: ubuntu-latest, python: "3.11" }
         - { runs-on: ubuntu-latest, python: "3.13" }
+        - { runs-on: ubuntu-latest, python: "3.15" }
 
     name: Tests on 🐍 ${{ matrix.python }} • ${{ matrix.runs-on }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
         PIP_PRE: ${{ matrix.python == '3.15' && '1' || '0' }}
         UV_EXTRA_INDEX_URL: ${{ matrix.python == '3.15' && 'https://pypi.anaconda.org/scientific-python-nightly-wheels/simple' || '' }}
         UV_PRERELEASE: ${{ matrix.python == '3.15' && 'allow' || 'if-necessary-or-explicit' }}
+        # The nightly index also carries scikit-build-core dev builds; without
+        # this uv's first-index-wins rule blocks the released version on PyPI.
+        UV_INDEX_STRATEGY: ${{ matrix.python == '3.15' && 'unsafe-best-match' || 'first-index' }}
       run: nox -s tests-${{ matrix.python }} -- --cov --cov-report=xml --cov-report=term --durations=20
 
     - name: Upload coverage report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,13 @@ jobs:
         python-versions: "${{ matrix.python }}"
 
     - name: Test on 🐍 ${{ matrix.python }}
+      env:
+        # Get numpy nightlies until it publishes 3.15 wheels; PIP_* covers pip's
+        # isolated build envs (pep518 tests), UV_* the nox env install.
+        PIP_EXTRA_INDEX_URL: ${{ matrix.python == '3.15' && 'https://pypi.anaconda.org/scientific-python-nightly-wheels/simple' || '' }}
+        PIP_PRE: ${{ matrix.python == '3.15' && '1' || '0' }}
+        UV_EXTRA_INDEX_URL: ${{ matrix.python == '3.15' && 'https://pypi.anaconda.org/scientific-python-nightly-wheels/simple' || '' }}
+        UV_PRERELEASE: ${{ matrix.python == '3.15' && 'allow' || 'if-necessary-or-explicit' }}
       run: nox -s tests-${{ matrix.python }} -- --cov --cov-report=xml --cov-report=term --durations=20
 
     - name: Upload coverage report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Typing :: Typed",
 ]
 dependencies = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,27 @@ def pep518_wheelhouse(tmp_path_factory: pytest.TempPathFactory) -> Path:
         ],
         check=True,
     )
+
+    # No numpy release supports 3.15 yet; take the nightly wheel.
+    if sys.version_info >= (3, 15) and sys.platform != "cygwin":
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "download",
+                "-q",
+                "--pre",
+                "--no-deps",
+                "--index-url",
+                "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple",
+                "-d",
+                str(wheelhouse),
+                "numpy",
+            ],
+            check=True,
+        )
+
     return wheelhouse
 
 
@@ -169,6 +190,9 @@ class VEnv:
 def pep518(pep518_wheelhouse, monkeypatch):
     monkeypatch.setenv("PIP_FIND_LINKS", str(pep518_wheelhouse))
     monkeypatch.setenv("PIP_NO_INDEX", "true")
+    if sys.version_info >= (3, 15):
+        # The wheelhouse numpy is a nightly (dev version)
+        monkeypatch.setenv("PIP_PRE", "true")
     return pep518_wheelhouse
 
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds the 3.15 trove classifier (which also creates the `tests-3.15` nox session via `nox.project.python_versions`) and a Linux 3.15 CI job. 3.14 stays the all-OS maximum since 3.15 is still in beta.

Since the suite runs with `filterwarnings = error`, new 3.15 warnings may show up as failures on this job.