### PR TITLE
fix: repair add_f2py_target argument handling and F2PY version regex

### DIFF
--- a/skbuild/resources/cmake/FindF2PY.cmake
+++ b/skbuild/resources/cmake/FindF2PY.cmake
@@ -105,7 +105,7 @@ if(F2PY_EXECUTABLE)
   execute_process(COMMAND "${F2PY_EXECUTABLE}" -v
                   OUTPUT_VARIABLE F2PY_VERSION_STRING
                   OUTPUT_STRIP_TRAILING_WHITESPACE)
-  if("${F2PY_VERSION_STRING}" MATCHES "^([0-9]+)(.([0-9+]))?(.([0-9+]))?$")
+  if("${F2PY_VERSION_STRING}" MATCHES "^([0-9]+)(\\.([0-9]+))?(\\.([0-9]+))?$")
     set(F2PY_VERSION_MAJOR ${CMAKE_MATCH_1})
     set(F2PY_VERSION_MINOR "${CMAKE_MATCH_3}")
     set(F2PY_VERSION_PATCH "${CMAKE_MATCH_5}")

--- a/skbuild/resources/cmake/UseF2PY.cmake
+++ b/skbuild/resources/cmake/UseF2PY.cmake
@@ -88,7 +88,7 @@ function(add_f2py_target _name)
     # if extension provided, _name is the source file
     if(_name_ext)
       set(_source_file ${_name})
-      string(REGEX REPLACE "\\.[^.]*$" "" _name ${_source})
+      string(REGEX REPLACE "\\.[^.]*$" "" _name ${_source_file})
 
     # otherwise, assume the source file is ${_name}.pyf
     else()
@@ -141,6 +141,6 @@ function(add_f2py_target _name)
                      DEPENDS ${_source_file}
                              ${_args_DEPENDS}
                      WORKING_DIRECTORY ${generated_file_dir}
-                     COMMENT ${source_comment})
+                     COMMENT "${comment}")
 
 endfunction()

--- a/tests/samples/hello-fortran/bonjour/CMakeLists.txt
+++ b/tests/samples/hello-fortran/bonjour/CMakeLists.txt
@@ -1,9 +1,6 @@
 set(_module_name _bonjour)
 
-add_f2py_target(_bonjour
-  "${CMAKE_CURRENT_SOURCE_DIR}/_bonjour.pyf"
-  OUTPUT_VAR _pyf_target_output
-  )
+add_f2py_target(_bonjour.pyf OUTPUT_VAR _pyf_target_output)
 
 add_library(${_module_name} MODULE ${_module_name}.f90)
 target_include_directories(${_module_name} PRIVATE ${F2PY_INCLUDE_DIRS})


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Three bugs in the shipped F2PY CMake helpers are fixed:

- The documented one-argument form of `add_f2py_target` was a hard CMake error: `UseF2PY.cmake` stripped the extension from an undefined `_source` variable, so `string(REGEX REPLACE ...)` got too few arguments.
- The generated custom command's `COMMENT` referenced an undefined `source_comment`; it now uses the `comment` string built just above it.
- The F2PY version regex in `FindF2PY.cmake` used `[0-9+]` (a single-character class) with unescaped dots, so multi-digit components like `1.26.4` never matched. It now uses `[0-9]+` with escaped dots.

The `bonjour` sample now calls `add_f2py_target(_bonjour.pyf ...)`, exercising the one-arg form so the regression is covered.
