### PR TITLE
fix: python_modules_header include-dir output variable; drop debug print

### DIFF
--- a/skbuild/resources/cmake/FindPythonExtensions.cmake
+++ b/skbuild/resources/cmake/FindPythonExtensions.cmake
@@ -343,7 +343,6 @@ function(_set_python_extension_symbol_visibility _target)
   else()
     set(_modinit_prefix "init")
   endif()
-  message("_modinit_prefix:${_modinit_prefix}")
   if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
     set_target_properties(${_target} PROPERTIES LINK_FLAGS
         "/EXPORT:${_modinit_prefix}${_target}"
@@ -602,7 +601,7 @@ function(python_modules_header _name)
   if(_args_INCLUDE_DIR_OUTPUT_VAR)
     set(_include_dir_var ${_args_INCLUDE_DIR_OUTPUT_VAR})
   endif()
-  set(${_include_dirs_var} ${CMAKE_CURRENT_BINARY_DIR} PARENT_SCOPE)
+  set(${_include_dir_var} ${CMAKE_CURRENT_BINARY_DIR} PARENT_SCOPE)
 endfunction()
 
 include(UsePythonExtensions)


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The `<Name>_INCLUDE_DIRS` output of `python_modules_header` was never set: the final `set(... PARENT_SCOPE)` referenced `_include_dirs_var`, but the computed variable is `_include_dir_var`. The module's own usage example relies on this output, so it silently produced nothing.

Also drops a leftover `message("_modinit_prefix:...")` debug line that printed for every extension module built.
