### PR TITLE
chore: remove dead code and fix docs in CMake modules

### DIFF
--- a/skbuild/resources/cmake/FindF2PY.cmake
+++ b/skbuild/resources/cmake/FindF2PY.cmake
@@ -68,7 +68,7 @@
 
 find_program(F2PY_EXECUTABLE NAMES f2py f2py${PYTHON_VERSION_MAJOR} )
 
-# XXX This is required to support NumPy < v0.15.0. See note in module documentation above.
+# XXX This is required to support NumPy < v1.15.0. See note in module documentation above.
 if(NOT F2PY_EXECUTABLE)
   find_package(NumPy)
   set(F2PY_EXECUTABLE "${PYTHON_EXECUTABLE}" "-m" "numpy.f2py")

--- a/skbuild/resources/cmake/FindNumPy.cmake
+++ b/skbuild/resources/cmake/FindNumPy.cmake
@@ -8,7 +8,7 @@
 # ``NumPy_FOUND``
 #   True if NumPy was found.
 # ``NumPy_INCLUDE_DIRS``
-#   The include directories needed to use NumpPy.
+#   The include directories needed to use NumPy.
 # ``NumPy_VERSION``
 #   The version of NumPy found.
 # ``NumPy_CONV_TEMPLATE_EXECUTABLE``
@@ -22,9 +22,9 @@
 #
 # .. note::
 #
-#     To support NumPy < v0.15.0 where ``from-template`` and ``conv-template`` are not declared as entry points,
+#     To support NumPy < v1.15.0 where ``from-template`` and ``conv-template`` are not declared as entry points,
 #     the module emulates the behavior of standalone executables by setting the corresponding variables with the
-#     path the the python interpreter and the path to the associated script. For example:
+#     path to the python interpreter and the path to the associated script. For example:
 #     ::
 #
 #         set(NumPy_CONV_TEMPLATE_EXECUTABLE /path/to/python /path/to/site-packages/numpy/distutils/conv_template.py CACHE STRING "Command executing conv-template program" FORCE)
@@ -33,14 +33,6 @@
 #
 
 if(NOT NumPy_FOUND)
-  set(_find_extra_args)
-  if(NumPy_FIND_REQUIRED)
-    list(APPEND _find_extra_args REQUIRED)
-  endif()
-  if(NumPy_FIND_QUIET)
-    list(APPEND _find_extra_args QUIET)
-  endif()
-
   find_program(NumPy_CONV_TEMPLATE_EXECUTABLE NAMES conv-template)
   find_program(NumPy_FROM_TEMPLATE_EXECUTABLE NAMES from-template)
 
@@ -58,7 +50,7 @@ if(NOT NumPy_FOUND)
       ERROR_QUIET
       )
 
-    # XXX This is required to support NumPy < v0.15.0. See note in module documentation above.
+    # XXX This is required to support NumPy < v1.15.0. See note in module documentation above.
     if(NOT NumPy_CONV_TEMPLATE_EXECUTABLE)
       execute_process(COMMAND "${PYTHON_EXECUTABLE}"
         -c "from numpy.distutils import conv_template; print(conv_template.__file__)"
@@ -69,7 +61,7 @@ if(NOT NumPy_FOUND)
       set(NumPy_CONV_TEMPLATE_EXECUTABLE "${PYTHON_EXECUTABLE}" "${_numpy_conv_template_file}" CACHE STRING "Command executing conv-template program" FORCE)
     endif()
 
-    # XXX This is required to support NumPy < v0.15.0. See note in module documentation above.
+    # XXX This is required to support NumPy < v1.15.0. See note in module documentation above.
     if(NOT NumPy_FROM_TEMPLATE_EXECUTABLE)
       execute_process(COMMAND "${PYTHON_EXECUTABLE}"
         -c "from numpy.distutils import from_template; print(from_template.__file__)"

--- a/skbuild/resources/cmake/FindPythonExtensions.cmake
+++ b/skbuild/resources/cmake/FindPythonExtensions.cmake
@@ -72,7 +72,7 @@
 #
 # ``MODULE_SUFFIX <ModuleSuffix>``
 #   Suffix appended to the python extension module file.
-#   The default suffix is retrieved using ``sysconfig.get_config_var("SO")"``,
+#   The default suffix is retrieved using ``sysconfig.get_config_var("EXT_SUFFIX")``,
 #   if not available, the default is then ``.so`` on unix and ``.pyd`` on
 #   windows.
 #   Setting the variable ``PYTHON_EXTENSION_MODULE_SUFFIX`` in the caller
@@ -104,17 +104,16 @@
 #                         [HEADER_OUTPUT_VAR <HeaderOutputVar>]
 #                         [INCLUDE_DIR_OUTPUT_VAR <IncludeDirOutputVar>])
 #
-# without the extension is used as the logical name.  If only ``<Name>`` is
-#
 # If only ``<Name>`` is provided, and it ends in the ".h" extension, then it
 # is assumed to be the ``<HeaderFilename>``.  The filename of the header file
+# without the extension is used as the logical name.  If only ``<Name>`` is
 # provided, and it does not end in the ".h" extension, then the
-# ``<HeaderFilename>`` is assumed to ``<Name>.h``.
+# ``<HeaderFilename>`` is assumed to be ``<Name>.h``.
 #
 # The exact contents of the generated header file depend on the logical
 # ``<Name>``.  It should be set to a value that corresponds to the target
 # application, or for the case of multiple applications, some identifier that
-# conveyes its purpose.  It is featured in the generated multiple inclusion
+# conveys its purpose.  It is featured in the generated multiple inclusion
 # guard as well as the names of the generated initialization routines.
 #
 # The generated header file includes forward declarations for all listed
@@ -133,7 +132,7 @@
 #   preprocessing macro ``EXCLUDE_LOAD_ALL_FUNCTION`` is defined.
 #
 # ``void Py_Initialize_Wrapper();``
-#   Wrapper arpund ``Py_Initialize()`` that initializes all listed python
+#   Wrapper around ``Py_Initialize()`` that initializes all listed python
 #   extension modules.  This function is excluded during preprocessing if the
 #   preprocessing macro ``EXCLUDE_PY_INIT_WRAPPER`` is defined.  If this
 #   function is generated, then ``Py_Initialize()`` is redefined to a macro

--- a/skbuild/resources/cmake/UseF2PY.cmake
+++ b/skbuild/resources/cmake/UseF2PY.cmake
@@ -96,17 +96,13 @@ function(add_f2py_target _name)
     endif()
   endif()
 
-  set(_embed_main FALSE)
-
   if("C" IN_LIST languages)
     set(_output_syntax "C")
   else()
     message(FATAL_ERROR "C must be enabled to use F2PY")
   endif()
 
-  set(extension "c")
-
-  set(generated_file "${CMAKE_CURRENT_BINARY_DIR}/${_name}module.${extension}")
+  set(generated_file "${CMAKE_CURRENT_BINARY_DIR}/${_name}module.c")
   set(generated_wrappers
     "${CMAKE_CURRENT_BINARY_DIR}/${_name}-f2pywrappers.f"
     "${CMAKE_CURRENT_BINARY_DIR}/${_name}-f2pywrappers2.f90"

--- a/skbuild/resources/cmake/UsePythonExtensions.cmake
+++ b/skbuild/resources/cmake/UsePythonExtensions.cmake
@@ -105,7 +105,7 @@ function(add_python_library _name)
   # Generate targets for all *.src files
   set(_processed )
   foreach(_source IN LISTS _sources)
-    if(${_source} MATCHES ".pyf.src$" OR ${_source} MATCHES "\\.f\\.src$")
+    if(${_source} MATCHES "\\.pyf\\.src$" OR ${_source} MATCHES "\\.f\\.src$")
       if(NOT NumPy_FOUND)
         message(
           FATAL_ERROR

--- a/skbuild/resources/cmake/targetLinkLibrariesWithDynamicLookup.cmake
+++ b/skbuild/resources/cmake/targetLinkLibrariesWithDynamicLookup.cmake
@@ -515,10 +515,6 @@ function(_check_dynamic_lookup
 
   if(NOT DEFINED ${cache_var})
 
-    if(CMAKE_CROSSCOMPILING AND NOT CMAKE_CROSSCOMPILING_EMULATOR)
-      set(skip_test TRUE)
-    endif()
-
     _test_weak_link_project(${target_type}
                             ${lib_type}
                             has_dynamic_lookup


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Dead-code removal and documentation fixes in the CMake helper modules, no behavior changes.

Removed dead code:
- `_find_extra_args` block in `FindNumPy.cmake` (never used; also referenced the wrong variable name `NumPy_FIND_QUIET`).
- `skip_test` assignment in `targetLinkLibrariesWithDynamicLookup.cmake` (never read; cross-compile handling lives in `_test_weak_link_project`).
- `_embed_main` and the `extension` variable in `UseF2PY.cmake` (unused; inlined the `c` suffix).

Doc fixes:
- Typos: "NumpPy" to "NumPy", "path the the" to "path to the", "conveyes" to "conveys", "arpund" to "around".
- Corrected `NumPy < v0.15.0` to `v1.15.0` across `FindNumPy.cmake` and `FindF2PY.cmake`.
- `MODULE_SUFFIX` doc now names the `EXT_SUFFIX` config var the code actually uses.
- Unscrambled the `python_modules_header` header paragraph in `FindPythonExtensions.cmake`.
- Escaped the dots in the `.pyf.src` regex in `UsePythonExtensions.cmake` to match its sibling.
