### PR TITLE
ci: pin actions to SHAs and harden workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,13 +10,3 @@ updates:
           - "*"
     cooldown:
       default-days: 7
-  - package-ecosystem: "pre-commit"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    groups:
-      pre-commit:
-        patterns:
-          - "*"
-    cooldown:
-      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,22 @@
 version: 2
 updates:
-  # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
-      actions:
+      github-actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      pre-commit:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,18 +6,28 @@ on:
     types:
     - published
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
 jobs:
   dist:
+    name: Distribution
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Build SDist and wheel
       run: pipx run build
 
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         path: dist/*
 
@@ -26,17 +36,18 @@ jobs:
 
 
   publish:
+    name: Publish to PyPI
     needs: [dist]
     environment: pypi
     permissions:
-      id-token: write
+      id-token: write # Required for PyPI trusted publishing
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: artifact
         path: dist
 
-    - uses: pypa/gh-action-pypi-publish@release/v1
+    - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: "3"
 
@@ -19,9 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v7
-    - uses: pre-commit/action@v3.0.1
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
   tests:
     runs-on: ${{ matrix.runs-on }}
@@ -39,11 +44,12 @@ jobs:
 
     name: Tests on 🐍 ${{ matrix.python }} • ${{ matrix.runs-on }}
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
+        persist-credentials: false
 
-    - uses: astral-sh/setup-uv@v8.3.2
+    - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
     - name: Set environment for Fortran compiler on MacOS
       if: runner.os == 'macOS'
@@ -52,12 +58,14 @@ jobs:
         echo "FC=gfortran" >> $GITHUB_ENV
 
     - name: Setup nox
-      uses: wntrblm/nox@2026.07.11
+      uses: wntrblm/nox@3284968a16fa5bd7fc0cc64a69a531404ccb4756 # 2026.07.11
       with:
         python-versions: "${{ matrix.python }}"
 
     - name: Test on 🐍 ${{ matrix.python }}
+      shell: bash
       env:
+        PYTHON: ${{ matrix.python }}
         # Get a numpy nightly for the nox env until it publishes 3.15 wheels
         # (the pep518 wheelhouse handles this itself in conftest.py).
         UV_EXTRA_INDEX_URL: ${{ matrix.python == '3.15' && 'https://pypi.anaconda.org/scientific-python-nightly-wheels/simple' || '' }}
@@ -65,10 +73,10 @@ jobs:
         # The nightly index also carries scikit-build-core dev builds; without
         # this uv's first-index-wins rule blocks the released version on PyPI.
         UV_INDEX_STRATEGY: ${{ matrix.python == '3.15' && 'unsafe-best-match' || 'first-index' }}
-      run: nox -s tests-${{ matrix.python }} -- --cov --cov-report=xml --cov-report=term --durations=20
+      run: nox -s "tests-$PYTHON" -- --cov --cov-report=xml --cov-report=term --durations=20
 
     - name: Upload coverage report
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         name: ${{ matrix.runs-on }}-${{ matrix.python }}
         verbose: true
@@ -80,11 +88,12 @@ jobs:
     timeout-minutes: 120
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
+        persist-credentials: false
 
-    - uses: cygwin/cygwin-install-action@v6
+    - uses: cygwin/cygwin-install-action@3f0a3f9f988f7e96b8c18098ae05eaec175f5b52 # v6.1
       with:
         platform: x86_64
         packages: cmake ninja git make gcc-g++ gcc-fortran python312 python312-devel python312-pip
@@ -109,27 +118,29 @@ jobs:
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
+        persist-credentials: false
 
-    - uses: yezz123/setup-uv@v4
+    - uses: yezz123/setup-uv@ab6be5a42627f19dc36e57b548592a5e52cece4a # v4.1
 
     - name: Setup nox
-      uses: wntrblm/nox@2026.07.11
+      uses: wntrblm/nox@3284968a16fa5bd7fc0cc64a69a531404ccb4756 # 2026.07.11
 
-    - uses: actions/setup-python@v7
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: pypy3.11-v7.3.22
 
     - name: Test on 🐍 PyPy
-      run: >
-        nox -s tests-pypy3.11 --
-        --cov --cov-report=xml --cov-report=term --durations=20
-        ${{ matrix.runs-on == 'windows-latest' && '-k "not pep518"' || '' }}
+      shell: bash
+      run: |
+        deselect=()
+        if [[ "$RUNNER_OS" == "Windows" ]]; then deselect=(-k "not pep518"); fi
+        nox -s tests-pypy3.11 -- --cov --cov-report=xml --cov-report=term --durations=20 "${deselect[@]}"
 
     - name: Upload coverage report
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         name: ${{ runner.os }}-pypy3.11
         verbose: true
@@ -145,23 +156,25 @@ jobs:
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
+        persist-credentials: false
 
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         repository: scikit-build/scikit-build-sample-projects
         # Pinned so sample-projects changes can't break this repo's CI; bump deliberately.
         ref: 0ad0bd760a3f2df4d7e21a3c89d5e49353304c32
         path: scikit-build-sample-projects
+        persist-credentials: false
 
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.13"
 
     - name: Setup nox
-      uses: wntrblm/nox@2026.04.10
+      uses: wntrblm/nox@3284968a16fa5bd7fc0cc64a69a531404ccb4756 # 2026.07.11
 
     - name: Build sample projects
       run: nox -s sample_projects
@@ -172,14 +185,15 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Build SDist and wheel
       run: pipx run build
 
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         path: dist/*
 
@@ -188,12 +202,13 @@ jobs:
 
 
   pass:
+    name: Pass
     if: always()
     timeout-minutes: 1
     needs: [lint, tests, tests-pypy, sample-projects, dist]
     runs-on: ubuntu-slim
     steps:
      - name: Decide whether the needed jobs succeeded or failed
-       uses: re-actors/alls-green@release/v1
+       uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
        with:
          jobs: ${{ toJSON(needs) }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: "v6.0.0"
+  rev: "3e8a8703264a2f4a69428a0aa4dcb512790b2c8c"  # frozen: v6.0.0
   hooks:
   - id: check-added-large-files
   - id: check-case-conflict
@@ -16,20 +16,20 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/sirosen/texthooks
-  rev: "0.7.1"
+  rev: "869eecde9a62460e123fa60b83858fac426163e8"  # frozen: 0.7.1
   hooks:
   - id: fix-ligatures
   - id: fix-smartquotes
 
 - repo: https://github.com/adamchainz/blacken-docs
-  rev: 1.20.0
+  rev: fda77690955e9b63c6687d8806bafd56a526e45f  # frozen: 1.20.0
   hooks:
   - id: "blacken-docs"
     additional_dependencies:
     - black==26.*
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.22
+  rev: 2700fd5671c633760d912769c041bfcde2b9a01b  # frozen: v0.15.22
   hooks:
   - id: ruff-check
     args: ["--fix"]
@@ -37,21 +37,21 @@ repos:
     exclude: ^docs/conf\.py$
 
 - repo: https://github.com/codespell-project/codespell
-  rev: "v2.4.3"
+  rev: "57b21406f092110c18776e39b0bda50d37c945c8"  # frozen: v2.4.3
   hooks:
   - id: codespell
     exclude: "(.png|.svg|^_version.py)$"
     args: ["-L", "ba,endwhile,unparseable"]
 
 - repo: https://github.com/pre-commit/pygrep-hooks
-  rev: "v1.10.0"
+  rev: "3a6eb0fadf60b3cccfd80bad9dbb6fae7e47b316"  # frozen: v1.10.0
   hooks:
   - id: rst-backticks
   - id: rst-directive-colons
   - id: rst-inline-touching-normal
 
 - repo: https://github.com/henryiii/check-sdist
-  rev: "v1.5.0"
+  rev: "377c4f639d3c5fd025ee882a22ae243e12bef469"  # frozen: v1.5.0
   hooks:
    - id: check-sdist
      args: [--inject-junk]
@@ -60,8 +60,15 @@ repos:
      - hatch-vcs
      - hatchling
 
+- repo: https://github.com/zizmorcore/zizmor-pre-commit
+  rev: 64a97fb7fa63188393d3215c6e312f5f9c6d0f78  # frozen: v1.27.0
+  hooks:
+  - id: zizmor
+    files: "^\\.github"
+    args: [--persona=pedantic]
+
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: "v2.3.0"
+  rev: "41e691678310dfd3833f7ab4e180ddb014310356"  # frozen: v2.3.0
   hooks:
   - id: mypy
     files: ^(skbuild|tests)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,10 @@ pattern = '\{user\}`(\S+)`'
 replacement = '[@\1](https://github.com/\1)'
 
 
+[tool.uv]
+exclude-newer = "7 days"
+
+
 [tool.mypy]
 files = ["skbuild", "tests"]
 exclude = ["tests/samples"]


### PR DESCRIPTION
Followup to #1219.

:robot: _AI text below_ :robot:

Supply-chain hardening pass over CI:

- Pin every GitHub Action to a commit SHA (releases newer than 7 days excluded). Includes fixing the nox action pin, which an automated updater tried to move from CalVer `2026.07.11` to the ancient `v0.19.1`.
- Add zizmor to pre-commit and fix all its `--persona=pedantic` findings: minimal `permissions` blocks, `persist-credentials: false` on checkouts, `matrix` template expansions moved into env vars / shell conditionals, concurrency and job names in `cd.yml`.
- Pin pre-commit hooks to SHAs (`prek auto-update --freeze --cooldown-days 7`).
- Dependabot: monthly grouped updates with a 7-day cooldown; add the `pre-commit` ecosystem.
- Add `[tool.uv] exclude-newer = "7 days"`.

The test steps that now use `$PYTHON` / `$RUNNER_OS` get `shell: bash` so they behave the same on Windows.