### PR TITLE
chore: prepare for 1.0.0rc1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,9 @@
 
 This is the list of changes to scikit-build between each release. For full details, see the commit logs at <https://github.com/scikit-build/scikit-build>
 
-## Next Release
+<!-- START-BRIEF-CHANGELOG -->
+
+## Scikit-build 1.0.0
 
 The classic scikit-build backend has been replaced by [scikit-build-core](https://github.com/scikit-build/scikit-build-core)'s setuptools plugin. `skbuild.setup()` is now a thin wrapper around `scikit_build_core.setuptools.wrapper.setup()`, and scikit-build depends on `scikit-build-core[setuptools]`. Most packages — those that only use `from skbuild import setup` with the documented `cmake_*` keyword arguments — will continue to build unchanged. New projects are still encouraged to use scikit-build-core directly.
 
@@ -23,8 +25,41 @@ Breaking changes:
 - Editable installs (`pip install -e .`) require `editable.mode = "inplace"` in the `[tool.scikit-build]` table of `pyproject.toml`.
 - CMake generator probing (including Visual Studio discovery) was removed; CMake's own default generator selection applies, and `CMAKE_GENERATOR` overrides it.
 - Dependencies changed to `scikit-build-core[setuptools]`; `distro`, `wheel`, and `tomli` were dropped.
+- Python 3.8 and 3.9 support was dropped; Python 3.10+ is required.
 
-<!-- START-BRIEF-CHANGELOG -->
+### Features
+
+- Use scikit-build-core's setuptools plugin as the backend in {pr}`1185`
+- Drop Python 3.8 support in {pr}`1207`
+- Drop Python 3.9 support in {pr}`1210`
+
+### Bug fixes
+
+- Repair `add_f2py_target` argument handling and the F2PY version regex in {pr}`1216`
+- Fix the `python_modules_header` include-dir output variable and drop a debug print in {pr}`1217`
+
+### Documentation
+
+- Review and update for the scikit-build-core backend in {pr}`1212`
+- Recommend the scikit-build-core setuptools backend in {pr}`1213`
+- Switch to furo, matching scikit-build-core, in {pr}`1208`
+- Convert changelog and README to Markdown with MyST in {pr}`1198`
+
+### Testing
+
+- Trim the suite now that the backend lives in scikit-build-core in {pr}`1211`
+- Tolerate CMake 4 install path normalization in {pr}`1205`
+- Split the test matrix per Python version in {pr}`1209`
+- Test on Python 3.15 in {pr}`1215`
+
+### Miscellaneous
+
+- Remove dead code and fix docs in the CMake modules in {pr}`1218`
+- Pin GitHub Actions to commit SHAs and harden workflows in {pr}`1219` and {pr}`1221`
+- Drop ref-names from `.git_archival.txt` in {pr}`1220`
+- Packit maintenance in {pr}`1201`
+- Bump the actions group in {pr}`1200` and {pr}`1204`
+- Pre-commit autoupdate in {pr}`1199`, {pr}`1203`, and {pr}`1206`
 
 ## Scikit-build 0.19.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,7 @@ Breaking changes:
 
 ### Miscellaneous
 
+- Mark as Production/Stable and prepare the release in {pr}`1222`
 - Remove dead code and fix docs in the CMake modules in {pr}`1218`
 - Pin GitHub Actions to commit SHAs and harden workflows in {pr}`1219` and {pr}`1221`
 - Drop ref-names from `.git_archival.txt` in {pr}`1220`

--- a/docs/make_a_release.rst
+++ b/docs/make_a_release.rst
@@ -11,9 +11,7 @@ A core developer should use the following steps to create a release ``X.Y.Z`` of
 Prerequisites
 -------------
 
-* All CI tests are passing on `GitHub Actions`_ and `Azure Pipelines`_.
-
-* You have a `GPG signing key <https://help.github.com/articles/generating-a-new-gpg-key/>`_.
+* All CI tests are passing on `GitHub Actions`_.
 
 * You can push to the repository and create GitHub releases. No PyPI
   credentials are needed: publishing the GitHub release triggers a GitHub
@@ -37,7 +35,7 @@ means that ``echo "Hello"`` should be copied and evaluated in the terminal.
 `PyPI`_: Step-by-step
 ---------------------
 
-1. Make sure that all CI tests are passing on `GitHub Actions`_ and `Azure Pipelines`_.
+1. Make sure that all CI tests are passing on `GitHub Actions`_.
 
 
 2. Download the latest sources (or use an existing git checkout)
@@ -62,14 +60,17 @@ means that ``echo "Hello"`` should be copied and evaluated in the terminal.
 
     $ release=X.Y.Z
 
-  .. warning::
+  .. note::
 
-      To ensure the packages are uploaded on `PyPI`_, tags must match this regular
-      expression: ``^[0-9]+(\.[0-9]+)*(\.post[0-9]+)?$``.
+      Tags are bare :pep:`440` versions with no ``v`` prefix: ``1.0.0``,
+      ``1.0.0rc1``, ``1.0.0.post1``. The version is derived from the tag by
+      hatch-vcs.
 
 
 5. In ``CHANGES.md`` replace ``Next Release`` section header with
-   ``Scikit-build X.Y.Z`` and commit the changes.
+   ``Scikit-build X.Y.Z`` and commit the changes. Keep the
+   ``START-BRIEF-CHANGELOG`` marker above the newest release section so the
+   release notes appear in the PyPI readme.
 
   .. code::
 
@@ -81,12 +82,7 @@ means that ``echo "Hello"`` should be copied and evaluated in the terminal.
 
   .. code::
 
-    $ git tag --sign -m "Scikit-build $release" $release main
-
-  .. warning::
-
-      We recommend using a `GPG signing key <https://help.github.com/articles/generating-a-new-gpg-key/>`_
-      to sign the tag.
+    $ git tag -a -m "Scikit-build $release" $release main
 
 
 7. Publish both the release tag and the main branch
@@ -101,7 +97,8 @@ means that ``echo "Hello"`` should be copied and evaluated in the terminal.
    Paste the release's section from ``CHANGES.md`` as the body. The ``{pr}`` and
    ``{user}`` roles should be converted to simple ``#<number>`` and ``@<user>``
    form. Be sure to use the tag you just pushed as the tag version, and
-   ``Scikit-build X.Y.Z`` should be the name.
+   ``Scikit-build X.Y.Z`` should be the name. For a release candidate, check
+   the "Set as a pre-release" box so it does not become the latest release.
 
   .. note::
 
@@ -128,7 +125,6 @@ means that ``echo "Hello"`` should be copied and evaluated in the terminal.
     For examples of announcements, see https://github.com/orgs/scikit-build/discussions/categories/announcements
 
 
-.. _Azure Pipelines: https://dev.azure.com/scikit-build/scikit-build/_build
 .. _GitHub Actions: https://github.com/scikit-build/scikit-build/actions
 
 .. _PyPI: https://pypi.org/project/scikit-build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ keywords = [
     "scikit-build",
 ]
 classifiers = [
-    "Development Status :: 2 - Pre-Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Release prep for 1.0.0rc1:

- Rename the changelog's "Next Release" section to "Scikit-build 1.0.0", add entries for everything merged since 0.19.1, and move the `START-BRIEF-CHANGELOG` marker above it so the notes appear in the PyPI readme.
- Bump the Development Status classifier from Pre-Alpha to Production/Stable.
- Refresh `make_a_release.rst`: drop the stale Azure Pipelines and GPG references, correct the tag-format warning (the old regex rejected rc tags; nothing in `cd.yml` enforces it), and note marking rc releases as pre-release.

Verified locally: built the sdist/wheel, `twine check` passes, and the assembled PyPI readme contains the 1.0.0 section with resolved PR links.