### PR TITLE
ci: fetch full history for readthedocs builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,6 +13,11 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.13"
+  jobs:
+    post_checkout:
+      # RTD does a shallow clone, hiding the release tag from setuptools-scm and
+      # producing a bogus 0.1.devN version. Fetch full history + tags.
+      - git fetch --unshallow --tags || true
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Read the Docs was showing the version as `0.1dev50`. RTD does a shallow clone with no tags, so setuptools-scm falls back to a dev version. Adding a `post_checkout` job to unshallow and fetch tags fixes it — the same fix used in scikit-build-core.