### PR TITLE
chore: use dependency groups and add pre-commit ci config

### DIFF
--- a/.distro/python-scikit-build.spec
+++ b/.distro/python-scikit-build.spec
@@ -55,7 +55,7 @@ Provides:       bundled(cmake(UsePythonExtensions))
 
 
 %generate_buildrequires
-%pyproject_buildrequires -x test
+%pyproject_buildrequires -g test
 
 
 %build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,8 @@
+ci:
+  autoupdate_commit_msg: "chore(deps): update pre-commit hooks"
+  autofix_commit_msg: "style: pre-commit fixes"
+  autoupdate_schedule: monthly
+
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: "3e8a8703264a2f4a69428a0aa4dcb512790b2c8c"  # frozen: v6.0.0

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -25,7 +25,7 @@ sphinx:
 
 python:
   install:
-  - method: pip
-    path: .
-    extra_requirements:
+  - method: uv
+    command: sync
+    groups:
     - docs

--- a/noxfile.py
+++ b/noxfile.py
@@ -38,14 +38,16 @@ def tests(session: nox.Session) -> None:
     env["SKBUILD_CORE_REQ"] = SKBUILD_CORE_REQ
 
     numpy = [] if "pypy" in session.python or sys.platform == "cygwin" else ["numpy"]
-    install_spec = "-e.[test,cov,doctest]" if "--cov" in posargs else ".[test,doctest]"
     if "--cov" in posargs:
+        install_spec = ["-e.", "--group=cov", "--group=doctest"]
         posargs.append("--cov-config=pyproject.toml")
+    else:
+        install_spec = [".", "--group=test", "--group=doctest"]
 
     # Latest versions may break things, so grab them for testing!
     session.install("-U", "setuptools", "wheel", "virtualenv")
     session.install(SKBUILD_CORE_REQ)
-    session.install(install_spec, *numpy)
+    session.install(*install_spec, *numpy)
     session.run("pytest", *posargs, env=env)
 
 
@@ -71,7 +73,7 @@ def docs(session):
     args = parser.parse_args(session.posargs)
 
     session.install(SKBUILD_CORE_REQ)
-    session.install("-e.[docs]")
+    session.install("-e.", "--group=docs")
 
     session.chdir("docs")
     shutil.rmtree("_build", ignore_errors=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,34 @@ dependencies = [
     'scikit-build-core[setuptools]>=1.0',
 ]
 
-[project.optional-dependencies]
+[project.entry-points."cmake.module"]
+skbuild = "skbuild.resources.cmake"
+
+[project.urls]
+"Bug Tracker" = "https://github.com/scikit-build/scikit-build/issues"
+Changelog = "https://scikit-build.readthedocs.io/en/latest/history.html"
+Discussions = "https://github.com/orgs/scikit-build/discussions"
+Documentation = "https://scikit-build.readthedocs.io/"
+Examples = "https://github.com/scikit-build/scikit-build-sample-projects"
+Homepage = "https://github.com/scikit-build/scikit-build"
+
+[dependency-groups]
+test = [
+    'build>=0.7',
+    'cython>=0.25.1',
+    'pip',
+    'pytest-mock>=1.10.4',
+    'pytest>=6.0.0',
+    'requests',
+    'virtualenv',
+]
+doctest = [
+    { include-group = "test" },
+    "ubelt>=0.8.2",
+    "xdoctest>=0.10.0",
+]
 cov = [
+    { include-group = "test" },
     "coverage[toml]>=4.2",
     "pytest-cov>=2.7.1",
 ]
@@ -45,30 +71,11 @@ docs = [
     "sphinx>=7.0",
     "sphinxcontrib-moderncmakedomain>=3.19",
 ]
-doctest = [
-    "ubelt>=0.8.2",
-    "xdoctest>=0.10.0",
-]
-test = [
-    'build>=0.7',
-    'cython>=0.25.1',
-    'pip',
-    'pytest-mock>=1.10.4',
-    'pytest>=6.0.0',
-    'requests',
-    'virtualenv',
+dev = [
+    { include-group = "cov" },
+    { include-group = "doctest" },
 ]
 
-[project.entry-points."cmake.module"]
-skbuild = "skbuild.resources.cmake"
-
-[project.urls]
-"Bug Tracker" = "https://github.com/scikit-build/scikit-build/issues"
-Changelog = "https://scikit-build.readthedocs.io/en/latest/history.html"
-Discussions = "https://github.com/orgs/scikit-build/discussions"
-Documentation = "https://scikit-build.readthedocs.io/"
-Examples = "https://github.com/scikit-build/scikit-build-sample-projects"
-Homepage = "https://github.com/scikit-build/scikit-build"
 
 [tool.hatch]
 build.targets.wheel.packages = ["skbuild"]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Moves the `test`, `doctest`, `cov`, and `docs` extras to `[dependency-groups]`, so they no longer ship in the wheel metadata. `doctest` and `cov` now `include-group = "test"` rather than the noxfile listing all three by hand. Adds a `dev` group covering both.

Read the Docs cannot install a dependency group through its `pip` method, so `.readthedocs.yml` switches to `method: uv` / `command: sync`. Note `uv.lock` is gitignored here, so that sync resolves fresh on each docs build.

Also picks up scikit-build-core's pre-commit.ci block, which this repo was missing — monthly hook autoupdates with conventional-commit messages.