### PR TITLE
fix(skbuild): guard against missing `_version.py`

### DIFF
--- a/skbuild/__init__.py
+++ b/skbuild/__init__.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 from scikit_build_core.setuptools.wrapper import setup
 
-from ._version import version as __version__
+try:
+    from ._version import version as __version__
+except ImportError:  # pragma: no cover
+    __version__ = "0.0.0.dev0"
 
 __author__ = "The scikit-build team"
 __email__ = "scikit-build@googlegroups.com"


### PR DESCRIPTION
When `hatch-vcs` cannot determine a version (e.g., in fork repositories without git tags), `_version.py` is not generated, causing a `ModuleNotFoundError` at import time. Add a `try`/`except` fallback so the package remains importable for development and documentation builds.

Close: #1227